### PR TITLE
add test for empty iterable for get_capabilities

### DIFF
--- a/waterdata/tests/test_location_utils.py
+++ b/waterdata/tests/test_location_utils.py
@@ -269,6 +269,10 @@ class TestGetCapabilities(TestCase):
         expected = {'00060', '00010', '00095', '00065'}
         self.assertSetEqual(result, expected)
 
+    def test_get_empty(self):
+        result = get_capabilities([])
+        self.assertFalse(result)
+
 
 class TestGetSiteParameter(TestCase):
 


### PR DESCRIPTION
Forgot to add this as requested during the review of https://github.com/usgs/waterdataui/pull/29.