### PR TITLE
In median statistics parsing, convert values from string to float.

### DIFF
--- a/assets/src/scripts/models.js
+++ b/assets/src/scripts/models.js
@@ -145,7 +145,7 @@ export function parseMedianData(medianData, timeSeriesStartDateTime, timeSeriesE
             }
             let median = {
                 time: recordDate,
-                value: medianDatum.p50_va,
+                value: parseFloat(medianDatum.p50_va),
                 label: `${medianDatum.p50_va} ${timeSeriesUnit}`
             };
             // don't include leap days if it's not a leap year

--- a/assets/src/scripts/models.spec.js
+++ b/assets/src/scripts/models.spec.js
@@ -172,7 +172,7 @@ describe('Models module', () => {
         it('parseMedian data successfully constructs data for plotting', () => {
             let result = parseMedianData(MOCK_MEDIAN_DATA, startDate, endDate, unit);
             expect(result.length).toEqual(3);
-            expect(result[0]).toEqual({time: new Date(2017, 7, 5), value: '15', label: '15 ft3/s'});
+            expect(result[0]).toEqual({time: new Date(2017, 7, 5), value: 15, label: '15 ft3/s'});
         });
 
         it('parseMedian data handles empty data', () => {
@@ -183,7 +183,7 @@ describe('Models module', () => {
         it('parseMedian data includes leap year when appropriate', () => {
             let result = parseMedianData(MOCK_MEDIAN_DATA, leapStartDate, leapEndDate, unit);
             expect(result.length).toEqual(4);
-            expect(result[3]).toEqual({time: new Date(2016, 1, 29), value: '13', label: '13 ft3/s'});
+            expect(result[3]).toEqual({time: new Date(2016, 1, 29), value: 13, label: '13 ft3/s'});
         })
     });
 


### PR DESCRIPTION
I don't know if this was an issue before, but the extent calculation on the yAxis expects the value to be a number.