### PR TITLE
WDFN-71 - Handle case where all data in a series is masked.

### DIFF
--- a/assets/src/scripts/components/hydrograph/scales.js
+++ b/assets/src/scripts/components/hydrograph/scales.js
@@ -44,11 +44,13 @@ function createYScale(tsData, showSeries, ySize) {
 
     // Calculate max and min for data
     for (let key of Object.keys(tsData)) {
-        if (!showSeries[key] || tsData[key].length === 0) {
+        let points = tsData[key].filter(pt => pt.value !== null);
+
+        if (!showSeries[key] || points.length === 0) {
             continue;
         }
 
-        const thisExtent = extent(tsData[key], d => d.value);
+        const thisExtent = extent(points, d => d.value);
         if (yExtent !== undefined) {
             yExtent = [
                 Math.min(thisExtent[0], yExtent[0]),

--- a/assets/src/scripts/models.js
+++ b/assets/src/scripts/models.js
@@ -58,13 +58,16 @@ export function getTimeseries({sites, params=['00060'], startDate=null, endDate=
                             values: series.values[0].value.map(datum => {
                                 let date = new Date(datum.dateTime);
                                 let value = parseFloat(datum.value);
+                                if (value === noDataValue) {
+                                    value = null;
+                                }
                                 return {
                                     time: date,
-                                    value: value !== noDataValue ? parseFloat(datum.value) : null,
+                                    value: value,
                                     qualifiers: datum.qualifiers,
                                     approved: datum.qualifiers.indexOf('A') > -1,
                                     estimated: datum.qualifiers.indexOf('E') > -1,
-                                    label: `${formatTime(date)}\n${datum.value} ${series.variable.unit.unitCode} (Qualifiers: ${datum.qualifiers.join(', ')})`
+                                    label: `${formatTime(date)}\n${value} ${series.variable.unit.unitCode} (Qualifiers: ${datum.qualifiers.join(', ')})`
                                 };
                             })
                         };


### PR DESCRIPTION
While looking for test data for log scales, I found the earlier WDFN-71 commit broke this site, which contains 100% masked data: https://webvadevvs04.er.usgs.gov/wsgi/waterdataui/monitoring-location/05413500