### PR TITLE
Wdfn 76 - Add previous year comparison to the tool tip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
+### Added
+- Previous year value is added to the tooltip when shown.
+- Tooltip uses a focus line in addition to the focus circle to show location on the time series line.
+
+### Changed
+- Tooltip text is now fixed in the corner and the font style and color match the line style/color
+used for the time series line. 
+
 
 ## [0.1.0] - 2018-02-13
 ### Added

--- a/assets/src/scripts/components/hydrograph/index.js
+++ b/assets/src/scripts/components/hydrograph/index.js
@@ -1,7 +1,7 @@
 /**
  * Hydrograph charting module.
  */
-const { bisector, max } = require('d3-array');
+const { max } = require('d3-array');
 const { mouse, select } = require('d3-selection');
 const { line } = require('d3-shape');
 const { createSelector, createStructuredSelector } = require('reselect');
@@ -15,10 +15,7 @@ const { pointsSelector, lineSegmentsSelector, isVisibleSelector } = require('./p
 const { xScaleSelector, yScaleSelector } = require('./scales');
 const { Actions, configureStore } = require('./store');
 const { drawSimpleLegend, legendDisplaySelector, createLegendMarkers } = require('./legend');
-
-
-// Function that returns the left bounding point for a given chart point.
-const bisectDate = bisector(d => d.time).left;
+const { createTooltip } = require('./tooltip');
 
 
 
@@ -62,26 +59,6 @@ const plotDataLine = function (elem, {visible, lines, tsDataKey, xScale, yScale}
             .attr('id', `ts-${tsDataKey}`)
             .attr('d', tsLine);
     }
-};
-
-
-const getNearestTime = function (data, time) {
-    let index = bisectDate(data, time, 1);
-    let datum;
-    let d0 = data[index - 1];
-    let d1 = data[index];
-
-    if (d0 && d1) {
-        datum = time - d0.time > d1.time - time ? d1 : d0;
-    } else {
-        datum = d0 || d1;
-    }
-
-    // Return the nearest data point and its index.
-    return {
-        datum,
-        index: datum === d0 ? index - 1 : index
-    };
 };
 
 
@@ -267,13 +244,13 @@ const timeSeriesGraph = function (elem) {
                     yscale: yScaleSelector,
                     medianStatsData: pointsSelector('medianStatistics')
                 })))
-                .call(link(plotTooltips, createStructuredSelector({
+                .call(link(createTooltip, createStructuredSelector({
                     xScale: xScaleSelector('current'),
                     yScale: yScaleSelector,
-                    data: pointsSelector('current'),
-                    isCompareVisible: isVisibleSelector('compare'),
                     compareXScale: xScaleSelector('compare'),
-                    compareData: pointsSelector('compare')
+                    currentTsData: pointsSelector('current'),
+                    compareTsData: pointsSelector('compare'),
+                    isCompareVisible: isVisibleSelector('compare')
                 })));
 
     elem.append('div')
@@ -335,4 +312,4 @@ const attachToNode = function (node, {siteno} = {}) {
 };
 
 
-module.exports = {attachToNode, getNearestTime, timeSeriesGraph};
+module.exports = {attachToNode, timeSeriesGraph};

--- a/assets/src/scripts/components/hydrograph/index.js
+++ b/assets/src/scripts/components/hydrograph/index.js
@@ -85,7 +85,7 @@ const getNearestTime = function (data, time) {
 
 
 const plotTooltips = function (elem, {xScale, yScale, data}) {
-    // Create a node to hightlight the currently selected date/time.
+    // Create a node to highlight the currently selected date/time.
     let focus = elem.append('g')
         .attr('class', 'focus')
         .style('display', 'none');

--- a/assets/src/scripts/components/hydrograph/index.js
+++ b/assets/src/scripts/components/hydrograph/index.js
@@ -167,9 +167,13 @@ const plotTooltips = function (elem, {xScale, yScale, data, isCompareVisible, co
 
             tooltipText.select('.current-tooltip-text')
                 .attr('x', 15)
+                .classed('approved', datum.approved)
+                .classed('estimated', datum.estimated)
                 .text(() => datum.label);
             tooltipText.select('.compare-tooltip-text')
                 .text(() => isCompareVisible ? compare.datum.label : '')
+                .classed('approved', compare ? compare.datum.approved : false)
+                .classed('estimated', compare ? compare.datum.estimated : false)
                 .attr('x', 15)
                 .attr('y', '1em');
         });

--- a/assets/src/scripts/components/hydrograph/index.js
+++ b/assets/src/scripts/components/hydrograph/index.js
@@ -260,6 +260,12 @@ const timeSeriesGraph = function (elem) {
                     yScale: yScaleSelector,
                     tsDataKey: () => 'compare'
                 })))
+                .call(link(plotMedianPoints, createStructuredSelector({
+                    visible: isVisibleSelector('medianStatistics'),
+                    xscale: xScaleSelector('current'),
+                    yscale: yScaleSelector,
+                    medianStatsData: pointsSelector('medianStatistics')
+                })))
                 .call(link(plotTooltips, createStructuredSelector({
                     xScale: xScaleSelector('current'),
                     yScale: yScaleSelector,
@@ -267,12 +273,6 @@ const timeSeriesGraph = function (elem) {
                     isCompareVisible: isVisibleSelector('compare'),
                     compareXScale: xScaleSelector('compare'),
                     compareData: pointsSelector('compare')
-                })))
-                .call(link(plotMedianPoints, createStructuredSelector({
-                    visible: isVisibleSelector('medianStatistics'),
-                    xscale: xScaleSelector('current'),
-                    yscale: yScaleSelector,
-                    medianStatsData: pointsSelector('medianStatistics')
                 })));
 
     elem.append('div')

--- a/assets/src/scripts/components/hydrograph/index.js
+++ b/assets/src/scripts/components/hydrograph/index.js
@@ -116,7 +116,7 @@ const plotTooltips = function (elem, {xScale, yScale, data, isCompareVisible, co
     tooltipText.append('text')
         .attr('class', 'compare-tooltip-text');
 
-    let compareMax = isCompareVisible ? max(compareData.map((datum) => datum.value)) : 0
+    let compareMax = isCompareVisible ? max(compareData.map((datum) => datum.value)) : 0;
     let yMax = max([max(data.map((datum) =>  datum.value)), compareMax]);
 
     elem.append('rect')
@@ -140,8 +140,8 @@ const plotTooltips = function (elem, {xScale, yScale, data, isCompareVisible, co
         .on('mousemove', function () {
             // Get the nearest data point for the current mouse position.
             const time = xScale.invert(mouse(this)[0]);
-            const {datum, index} = getNearestTime(data, time);
-            if (!datum) {
+            const current = getNearestTime(data, time);
+            if (!current.datum) {
                 return;
             }
             let compareTime;
@@ -153,13 +153,13 @@ const plotTooltips = function (elem, {xScale, yScale, data, isCompareVisible, co
 
             tooltipLine
                 .attr('stroke', 'black')
-                .attr('x1', xScale(datum.time))
-                .attr('x2', xScale(datum.time))
+                .attr('x1', xScale(current.datum.time))
+                .attr('x2', xScale(current.datum.time))
                 .attr('y1', yScale.range()[0])
                 .attr('y2', yScale(yMax));
 
             // Move the focus node to this date/time.
-            currentFocus.attr('transform', `translate(${xScale(datum.time)}, ${yScale(datum.value)})`);
+            currentFocus.attr('transform', `translate(${xScale(current.datum.time)}, ${yScale(current.datum.value)})`);
             if (isCompareVisible) {
                 compareFocus.attr('transform',
                     `translate(${compareXScale(compare.datum.time)}, ${yScale(compare.datum.value)})`);
@@ -167,9 +167,9 @@ const plotTooltips = function (elem, {xScale, yScale, data, isCompareVisible, co
 
             tooltipText.select('.current-tooltip-text')
                 .attr('x', 15)
-                .classed('approved', datum.approved)
-                .classed('estimated', datum.estimated)
-                .text(() => datum.label);
+                .classed('approved', current.datum.approved)
+                .classed('estimated', current.datum.estimated)
+                .text(() => current.datum.label);
             tooltipText.select('.compare-tooltip-text')
                 .text(() => isCompareVisible ? compare.datum.label : '')
                 .classed('approved', compare ? compare.datum.approved : false)
@@ -287,8 +287,8 @@ const timeSeriesGraph = function (elem) {
                     return [value.value, value.time];
                 })
             ),
-            describeById: () => {return 'time-series-sr-desc'},
-            describeByText: () => {return 'current time series data in tabular format'}
+            describeById: () => 'time-series-sr-desc',
+            describeByText: () => 'current time series data in tabular format'
     })));
 
     elem.append('div')
@@ -303,8 +303,8 @@ const timeSeriesGraph = function (elem) {
                     return [value.value, value.time];
                 })
             ),
-            describeById: () => {return 'median-statistics-sr-desc'},
-            describeByText: () => {return 'median statistical data in tabular format'}
+            describeById: () => 'median-statistics-sr-desc',
+            describeByText: () => 'median statistical data in tabular format'
     })));
 };
 

--- a/assets/src/scripts/components/hydrograph/index.js
+++ b/assets/src/scripts/components/hydrograph/index.js
@@ -1,7 +1,7 @@
 /**
  * Hydrograph charting module.
  */
-const { bisector } = require('d3-array');
+const { bisector, max } = require('d3-array');
 const { mouse, select } = require('d3-selection');
 const { line } = require('d3-shape');
 const { createSelector, createStructuredSelector } = require('reselect');
@@ -89,17 +89,24 @@ const plotTooltips = function (elem, {xScale, yScale, data, isCompareVisible, co
     elem.selectAll('.focus').remove();
     elem.select('.overlay').remove();
     elem.select('.tooltip-group').remove();
-    let currentFocus = elem.append('g')
+    let focus = elem.append('g')
         .attr('class', 'focus')
         .style('display', 'none');
-    currentFocus.append('circle')
-        .attr('r', 7.5);
+    let tooltipLine = focus.append('line')
+        .attr('stroke-width', 2)
+        .attr('class', 'tooltip-focus-line');
 
-    let compareFocus = elem.append('g')
-        .attr('class', 'focus')
-        .style('display', 'none');
-    compareFocus.append('circle')
-        .attr('r', 7.5);
+    //let currentFocus = elem.append('g')
+    //    .attr('class', 'focus')
+    //    .style('display', 'none');
+    ///currentFocus.append('circle')
+     //   .attr('r', 7.5);
+
+    //let compareFocus = elem.append('g')
+    //    .attr('class', 'focus')
+    //    .style('display', 'none');
+    //compareFocus.append('circle')
+    //    .attr('r', 7.5);
 
     let tooltipText = elem.append('g')
         .attr('class', 'tooltip-group');
@@ -113,14 +120,16 @@ const plotTooltips = function (elem, {xScale, yScale, data, isCompareVisible, co
         .attr('width', '100%')
         .attr('height', '100%')
         .on('mouseover', () => {
-            currentFocus.style('display', null);
-            if (isCompareVisible) {
-                compareFocus.style('display',  null);
-            }
+            focus.style('display', null);
+            //currentFocus.style('display', null);
+            //if (isCompareVisible) {
+            //    compareFocus.style('display',  null);
+            //}
         })
         .on('mouseout', () => {
-            currentFocus.style('display', 'none');
-            compareFocus.style('display', 'none');
+            focus.style('display', 'none');
+            //currentFocus.style('display', 'none');
+            //compareFocus.style('display', 'none');
         })
         .on('mousemove', function () {
             // Get the nearest data point for the current mouse position.
@@ -136,12 +145,21 @@ const plotTooltips = function (elem, {xScale, yScale, data, isCompareVisible, co
                 compare = getNearestTime(compareData, compareTime);
             }
 
+            let yMax = max([max(data.map((datum) => { return datum.value})), max(compareData.map((datum) => { return datum.value; }))])
+
+            tooltipLine
+                .attr('stroke', 'black')
+                .attr('x1', xScale(datum.time))
+                .attr('x2', xScale(datum.time))
+                .attr('y1', yScale.range()[0])
+                .attr('y2', yScale(yMax));
+
             // Move the focus node to this date/time.
-            currentFocus.attr('transform', `translate(${xScale(datum.time)}, ${yScale(datum.value)})`);
-            if (isCompareVisible) {
-                compareFocus.attr('transform',
-                    `translate(${compareXScale(compare.datum.time)}, ${yScale(compare.datum.value)})`);
-            }
+            //currentFocus.attr('transform', `translate(${xScale(datum.time)}, ${yScale(datum.value)})`);
+            //if (isCompareVisible) {
+            //    compareFocus.attr('transform',
+            //        `translate(${compareXScale(compare.datum.time)}, ${yScale(compare.datum.value)})`);
+           // }
 
             // Draw text, anchored to the left or right, depending on
             // which side of the graph the point is on.

--- a/assets/src/scripts/components/hydrograph/index.js
+++ b/assets/src/scripts/components/hydrograph/index.js
@@ -86,15 +86,23 @@ const getNearestTime = function (data, time) {
 
 const plotTooltips = function (elem, {xScale, yScale, data, isCompareVisible, compareXScale, compareData}) {
     // Create a node to highlight the currently selected date/time.
-    elem.select('#plot-tooltip').remove();
+    elem.selectAll('.focus').remove();
     elem.select('.overlay').remove();
-    let focus = elem.append('g')
-        .attr('id', 'plot-tooltip')
+    elem.select('.tooltip-group').remove();
+    let currentFocus = elem.append('g')
         .attr('class', 'focus')
         .style('display', 'none');
-    focus.append('circle')
+    currentFocus.append('circle')
         .attr('r', 7.5);
-    let tooltipText = focus.append('g')
+
+    let compareFocus = elem.append('g')
+        .attr('class', 'focus')
+        .style('display', 'none');
+    compareFocus.append('circle')
+        .attr('r', 7.5);
+
+    let tooltipText = elem.append('g')
+        .attr('class', 'tooltip-group');
     tooltipText.append('text')
         .attr('class', 'current-tooltip-text');
     tooltipText.append('text')
@@ -104,8 +112,16 @@ const plotTooltips = function (elem, {xScale, yScale, data, isCompareVisible, co
         .attr('class', 'overlay')
         .attr('width', '100%')
         .attr('height', '100%')
-        .on('mouseover', () => focus.style('display', null))
-        .on('mouseout', () => focus.style('display', 'none'))
+        .on('mouseover', () => {
+            currentFocus.style('display', null);
+            if (isCompareVisible) {
+                compareFocus.style('display',  null);
+            }
+        })
+        .on('mouseout', () => {
+            currentFocus.style('display', 'none');
+            compareFocus.style('display', 'none');
+        })
         .on('mousemove', function () {
             // Get the nearest data point for the current mouse position.
             const time = xScale.invert(mouse(this)[0]);
@@ -121,21 +137,25 @@ const plotTooltips = function (elem, {xScale, yScale, data, isCompareVisible, co
             }
 
             // Move the focus node to this date/time.
-            focus.attr('transform', `translate(${xScale(datum.time)}, ${yScale(datum.value)})`);
+            currentFocus.attr('transform', `translate(${xScale(datum.time)}, ${yScale(datum.value)})`);
+            if (isCompareVisible) {
+                compareFocus.attr('transform',
+                    `translate(${compareXScale(compare.datum.time)}, ${yScale(compare.datum.value)})`);
+            }
 
             // Draw text, anchored to the left or right, depending on
             // which side of the graph the point is on.
             // TODO: Should we use the position of the mouse rather than the index of the date?
             const isFirstHalf = index < data.length / 2;
             tooltipText.select('.current-tooltip-text')
-                .attr('text-anchor', isFirstHalf ? 'start' : 'end')
-                .attr('x', isFirstHalf ? 15 : -15)
-                .attr('y', '-.31em')
+                //.attr('text-anchor', isFirstHalf ? 'start' : 'end')
+                //.attr('x', isFirstHalf ? 15 : -15)
+                //.attr('y', '-.31em')
                 .text(() => datum.label);
             tooltipText.select('.compare-tooltip-text')
                .text(() => isCompareVisible ? compare.datum.label : '')
-                .attr('text-anchor', isFirstHalf ? 'start' : 'end')
-                .attr('x', isFirstHalf ? 15 : -15)
+               // .attr('text-anchor', isFirstHalf ? 'start' : 'end')
+               // .attr('x', isFirstHalf ? 15 : -15)
                 .attr('y', '1em');
         });
 };

--- a/assets/src/scripts/components/hydrograph/index.js
+++ b/assets/src/scripts/components/hydrograph/index.js
@@ -149,13 +149,13 @@ const plotTooltips = function (elem, {xScale, yScale, data, isCompareVisible, co
             const isFirstHalf = index < data.length / 2;
             tooltipText.select('.current-tooltip-text')
                 //.attr('text-anchor', isFirstHalf ? 'start' : 'end')
-                //.attr('x', isFirstHalf ? 15 : -15)
+                .attr('x', 15)
                 //.attr('y', '-.31em')
                 .text(() => datum.label);
             tooltipText.select('.compare-tooltip-text')
                .text(() => isCompareVisible ? compare.datum.label : '')
                // .attr('text-anchor', isFirstHalf ? 'start' : 'end')
-               // .attr('x', isFirstHalf ? 15 : -15)
+                .attr('x', 15)
                 .attr('y', '1em');
         });
 };

--- a/assets/src/scripts/components/hydrograph/index.js
+++ b/assets/src/scripts/components/hydrograph/index.js
@@ -93,27 +93,30 @@ const plotTooltips = function (elem, {xScale, yScale, data, isCompareVisible, co
         .attr('class', 'focus')
         .style('display', 'none');
     let tooltipLine = focus.append('line')
-        .attr('stroke-width', 2)
         .attr('class', 'tooltip-focus-line');
 
-    //let currentFocus = elem.append('g')
-    //    .attr('class', 'focus')
-    //    .style('display', 'none');
-    ///currentFocus.append('circle')
-     //   .attr('r', 7.5);
+    let currentFocus = elem.append('g')
+        .attr('class', 'focus')
+        .style('display', 'none');
+    currentFocus.append('circle')
+        .attr('r', 5.5);
 
-    //let compareFocus = elem.append('g')
-    //    .attr('class', 'focus')
-    //    .style('display', 'none');
-    //compareFocus.append('circle')
-    //    .attr('r', 7.5);
+    let compareFocus = elem.append('g')
+        .attr('class', 'focus')
+        .style('display', 'none');
+    compareFocus.append('circle')
+        .attr('r', 5.5);
 
     let tooltipText = elem.append('g')
-        .attr('class', 'tooltip-group');
+        .attr('class', 'tooltip-group')
+        .style('display', 'none');
     tooltipText.append('text')
         .attr('class', 'current-tooltip-text');
     tooltipText.append('text')
         .attr('class', 'compare-tooltip-text');
+
+    let compareMax = isCompareVisible ? max(compareData.map((datum) => datum.value)) : 0
+    let yMax = max([max(data.map((datum) =>  datum.value)), compareMax]);
 
     elem.append('rect')
         .attr('class', 'overlay')
@@ -121,15 +124,17 @@ const plotTooltips = function (elem, {xScale, yScale, data, isCompareVisible, co
         .attr('height', '100%')
         .on('mouseover', () => {
             focus.style('display', null);
-            //currentFocus.style('display', null);
-            //if (isCompareVisible) {
-            //    compareFocus.style('display',  null);
-            //}
+            tooltipText.style('display', null);
+            currentFocus.style('display', null);
+            if (isCompareVisible) {
+                compareFocus.style('display',  null);
+            }
         })
         .on('mouseout', () => {
             focus.style('display', 'none');
-            //currentFocus.style('display', 'none');
-            //compareFocus.style('display', 'none');
+            tooltipText.style('display', 'none');
+            currentFocus.style('display', 'none');
+            compareFocus.style('display', 'none');
         })
         .on('mousemove', function () {
             // Get the nearest data point for the current mouse position.
@@ -145,8 +150,6 @@ const plotTooltips = function (elem, {xScale, yScale, data, isCompareVisible, co
                 compare = getNearestTime(compareData, compareTime);
             }
 
-            let yMax = max([max(data.map((datum) => { return datum.value})), max(compareData.map((datum) => { return datum.value; }))])
-
             tooltipLine
                 .attr('stroke', 'black')
                 .attr('x1', xScale(datum.time))
@@ -155,24 +158,17 @@ const plotTooltips = function (elem, {xScale, yScale, data, isCompareVisible, co
                 .attr('y2', yScale(yMax));
 
             // Move the focus node to this date/time.
-            //currentFocus.attr('transform', `translate(${xScale(datum.time)}, ${yScale(datum.value)})`);
-            //if (isCompareVisible) {
-            //    compareFocus.attr('transform',
-            //        `translate(${compareXScale(compare.datum.time)}, ${yScale(compare.datum.value)})`);
-           // }
+            currentFocus.attr('transform', `translate(${xScale(datum.time)}, ${yScale(datum.value)})`);
+            if (isCompareVisible) {
+                compareFocus.attr('transform',
+                    `translate(${compareXScale(compare.datum.time)}, ${yScale(compare.datum.value)})`);
+            }
 
-            // Draw text, anchored to the left or right, depending on
-            // which side of the graph the point is on.
-            // TODO: Should we use the position of the mouse rather than the index of the date?
-            const isFirstHalf = index < data.length / 2;
             tooltipText.select('.current-tooltip-text')
-                //.attr('text-anchor', isFirstHalf ? 'start' : 'end')
                 .attr('x', 15)
-                //.attr('y', '-.31em')
                 .text(() => datum.label);
             tooltipText.select('.compare-tooltip-text')
-               .text(() => isCompareVisible ? compare.datum.label : '')
-               // .attr('text-anchor', isFirstHalf ? 'start' : 'end')
+                .text(() => isCompareVisible ? compare.datum.label : '')
                 .attr('x', 15)
                 .attr('y', '1em');
         });

--- a/assets/src/scripts/components/hydrograph/index.js
+++ b/assets/src/scripts/components/hydrograph/index.js
@@ -146,14 +146,6 @@ const timeSeriesGraph = function (elem) {
                     yScale: yScaleSelector,
                     tsDataKey: () => 'compare'
                 })))
-                .call(link(plotMedianPoints, createStructuredSelector({
-                    visible: isVisibleSelector('medianStatistics'),
-                    xscale: xScaleSelector('current'),
-                    yscale: yScaleSelector,
-                    medianStatsData: pointsSelector('medianStatistics'),
-                    showLabel: (state) => state.showMedianStatsLabel
-
-                })))
                 .call(link(createTooltip, createStructuredSelector({
                     xScale: xScaleSelector('current'),
                     yScale: yScaleSelector,
@@ -161,6 +153,14 @@ const timeSeriesGraph = function (elem) {
                     currentTsData: pointsSelector('current'),
                     compareTsData: pointsSelector('compare'),
                     isCompareVisible: isVisibleSelector('compare')
+                })))
+                .call(link(plotMedianPoints, createStructuredSelector({
+                    visible: isVisibleSelector('medianStatistics'),
+                    xscale: xScaleSelector('current'),
+                    yscale: yScaleSelector,
+                    medianStatsData: pointsSelector('medianStatistics'),
+                    showLabel: (state) => state.showMedianStatsLabel
+
                 })));
 
     elem.append('div')

--- a/assets/src/scripts/components/hydrograph/index.spec.js
+++ b/assets/src/scripts/components/hydrograph/index.spec.js
@@ -153,46 +153,6 @@ describe('Hydrograph charting module', () => {
         });
     });
 
-    describe('Hydrograph tooltips', () => {
-        let data = [12, 13, 14, 15, 16].map(hour => {
-            return {
-                time: new Date(`2018-01-03T${hour}:00:00.000Z`),
-                label: 'label',
-                value: 0
-            };
-        });
-
-        it('return correct data points via getNearestTime' , () => {
-            // Check each date with the given offset against the hourly-spaced
-            // test data.
-            function expectOffset(offset, side) {
-                for (let [index, datum] of data.entries()) {
-                    let expected;
-                    if (side === 'left' || index === data.length - 1) {
-                        expected = {datum, index};
-                    } else {
-                        expected = {datum: data[index + 1], index: index + 1};
-                    }
-                    let time = new Date(datum.time.getTime() + offset);
-                    let returned = getNearestTime(data, time);
-
-                    expect(returned.datum.time).toBe(expected.datum.time);
-                    expect(returned.datum.index).toBe(expected.datum.index);
-                }
-            }
-
-            let hour = 3600000;  // 1 hour in milliseconds
-
-            // Check each date against an offset from itself.
-            expectOffset(0, 'left');
-            expectOffset(1, 'left');
-            expectOffset(hour / 2 - 1, 'left');
-            expectOffset(hour / 2, 'left');
-            expectOffset(hour / 2 + 1, 'right');
-            expectOffset(hour - 1, 'right');
-        });
-    });
-
     describe('Adding and removing compare time series', () => {
         /* eslint no-use-before-define: "ignore" */
         let hydrograph;

--- a/assets/src/scripts/components/hydrograph/index.spec.js
+++ b/assets/src/scripts/components/hydrograph/index.spec.js
@@ -1,7 +1,7 @@
 const { select, selectAll } = require('d3-selection');
 const { provide } = require('../../lib/redux');
 
-const { attachToNode, getNearestTime, timeSeriesGraph } = require('./index');
+const { attachToNode, timeSeriesGraph } = require('./index');
 const { Actions, configureStore } = require('./store');
 
 
@@ -155,7 +155,6 @@ describe('Hydrograph charting module', () => {
 
     describe('Adding and removing compare time series', () => {
         /* eslint no-use-before-define: "ignore" */
-        let hydrograph;
         let store;
         beforeEach(() => {
             store = configureStore({

--- a/assets/src/scripts/components/hydrograph/tooltip.js
+++ b/assets/src/scripts/components/hydrograph/tooltip.js
@@ -20,7 +20,6 @@ const createFocusLine = function(elem, {yScale, currentTsData, compareTsData=nul
     return focus;
 };
 
-
 const createFocusCircle = function(elem) {
     let focus = elem.append('g')
         .attr('class', 'focus')
@@ -87,7 +86,6 @@ const getNearestTime = function(data, time) {
     };
 };
 
-
 const createTooltip = function(elem, {xScale, yScale, compareXScale, currentTsData, compareTsData, isCompareVisible}) {
     elem.selectAll('.focus').remove();
     elem.select('.tooltip-text-group').remove();
@@ -132,16 +130,21 @@ const createTooltip = function(elem, {xScale, yScale, compareXScale, currentTsDa
             if (!currentData) {
                 return;
             }
+
+            // Update the focus line
             focusLine.select('.focus-line')
                 .attr('x1', currentTimeRange)
                 .attr('x2', currentTimeRange);
 
-            updateTooltipText(tooltipText.select('.current-tooltip-text'), currentData.datum);
+            // Update the current TS focus circle and tooltip text
             updateCircleFocus(focusCurrentCircle, {
                 xScale: xScale,
                 yScale: yScale,
                 tsDatum: currentData.datum
             });
+            updateTooltipText(tooltipText.select('.current-tooltip-text'), currentData.datum);
+
+            //Update the compare TS focus circle and tooltip text if we are showing it.
             if (isCompareVisible) {
                 const compareTime = compareXScale.invert(mouse(this)[0]);
                 const compareData = getNearestTime(compareTsData, compareTime);

--- a/assets/src/scripts/components/hydrograph/tooltip.js
+++ b/assets/src/scripts/components/hydrograph/tooltip.js
@@ -16,7 +16,7 @@ const createFocusLine = function(elem, {yScale, currentTsData, compareTsData=nul
     focus.append('line')
         .attr('class', 'focus-line')
         .attr('y1', yScale.range()[0])
-        .attr('y2', yScale(yMax));
+        .attr('y2', yMax !== 0 ? yScale(yMax) : yScale.range()[1]);
     return focus;
 };
 
@@ -46,7 +46,13 @@ const createTooltipText = function(elem, tskeys) {
 };
 
 const updateCircleFocus = function(circleFocus, {xScale, yScale, tsDatum}) {
-    circleFocus.attr('transform', `translate(${xScale(tsDatum.time)}, ${yScale(tsDatum.value)})`);
+    if (tsDatum.value) {
+        circleFocus.style('display', null)
+            .attr('transform',
+                `translate(${xScale(tsDatum.time)}, ${yScale(tsDatum.value)})`);
+    } else {
+        circleFocus.style('display', 'none');
+    }
 };
 
 const updateTooltipText = function(text, tsDatum) {
@@ -125,13 +131,13 @@ const createTooltip = function(elem, {xScale, yScale, compareXScale, currentTsDa
         .on('mousemove', function() {
             const currentTime = xScale.invert(mouse(this)[0]);
             const currentData = getNearestTime(currentTsData, currentTime);
-            const currentTimeRange = xScale(currentData.datum.time);
 
             if (!currentData) {
                 return;
             }
 
             // Update the focus line
+            const currentTimeRange = xScale(currentData.datum.time);
             focusLine.select('.focus-line')
                 .attr('x1', currentTimeRange)
                 .attr('x2', currentTimeRange);

--- a/assets/src/scripts/components/hydrograph/tooltip.js
+++ b/assets/src/scripts/components/hydrograph/tooltip.js
@@ -1,32 +1,152 @@
 
-const createFocusLine = function(elem, id) {
+const { max, bisector } = require('d3-array');
+const { mouse } = require('d3-selection');
+
+const maxValue = function (data) {
+    return max(data.map((datum) => datum.value));
+};
+
+const createFocusLine = function(elem, {yScale, currentTsData, compareTsData=null}) {
     let focus = elem.append('g')
-        .attr('id', id)
         .attr('class', 'focus')
         .style('display', 'none');
+    let compareMax = compareTsData ? maxValue(compareTsData) : 0;
+    let yMax = max([maxValue(currentTsData), compareMax]);
+
     focus.append('line')
-        .attr('class', 'focus-line');
+        .attr('class', 'focus-line')
+        .attr('y1', yScale.range()[0])
+        .attr('y2', yScale(yMax));
     return focus;
 };
 
-const createFocusCircle = function(elem, id) {
+
+const createFocusCircle = function(elem) {
     let focus = elem.append('g')
-        .attr('id', id)
         .attr('class', 'focus')
-        .style('display', 'none')
+        .style('display', 'none');
     focus.append('circle')
         .attr('r', 5.5);
     return focus;
 };
 
-const createTooltipText = function(elem, id, tskeys) {
+const createTooltipText = function(elem, tskeys) {
     let tooltipTextGroup = elem.append('g')
-        .attr('id', id)
+        .attr('class', 'tooltip-text-group')
         .style('display', 'none');
+    let y = 0;
     for (let tskey of tskeys) {
         tooltipTextGroup.append('text')
-            .attr('class', `${tskey}-tooltip-text`);
+            .attr('class', `${tskey}-tooltip-text`)
+            .attr('x', 15)
+            .attr('y', `${y}em`);
+        y += 1;
     }
     return tooltipTextGroup;
 
 };
+
+const updateCircleFocus = function(circleFocus, {xScale, yScale, tsDatum}) {
+    circleFocus.attr('transform', `translate(${xScale(tsDatum.time)}, ${yScale(tsDatum.value)})`);
+};
+
+const updateTooltipText = function(text, tsDatum) {
+    text.classed('approved', tsDatum.approved)
+        .classed('estimated', tsDatum.estimated)
+        .text(() => tsDatum.label);
+};
+
+/*
+ * Return the data point nearest to time and its index.
+ * @param {Array} data - array of Object where one of the keys is time.
+ * @param {Date} time
+ * @return {Object} - datum and index
+ */
+const getNearestTime = function(data, time) {
+    // Function that returns the left bounding point for a given chart point.
+    const bisectDate = bisector(d => d.time).left;
+
+    let index = bisectDate(data, time, 1);
+    let datum;
+    let d0 = data[index - 1];
+    let d1 = data[index];
+
+    if (d0 && d1) {
+        datum = time - d0.time > d1.time - time ? d1 : d0;
+    } else {
+        datum = d0 || d1;
+    }
+
+    // Return the nearest data point and its index.
+    return {
+        datum,
+        index: datum === d0 ? index - 1 : index
+    };
+};
+
+
+const createTooltip = function(elem, {xScale, yScale, compareXScale, currentTsData, compareTsData, isCompareVisible}) {
+    elem.selectAll('.focus').remove();
+    elem.select('.tooltip-text-group').remove();
+    elem.select('.overlay').remove();
+
+    if (!currentTsData) {
+        return;
+    }
+
+    let focusLine = createFocusLine(elem, {
+        yScale: yScale,
+        currentTsData: currentTsData,
+        compareTsData: isCompareVisible && compareTsData ? compareTsData : null
+    });
+    let focusCurrentCircle = createFocusCircle(elem);
+    let focusCompareCircle = createFocusCircle(elem);
+    let tooltipText = createTooltipText(elem, ['current', 'compare']);
+
+    elem.append('rect')
+        .attr('class', 'overlay')
+        .attr('width', '100%')
+        .attr('height', '100%')
+        .on('mouseover', () => {
+            focusLine.style('display', null);
+            focusCurrentCircle.style('display', null);
+            if (isCompareVisible) {
+                focusCompareCircle.style('display', null);
+            }
+            tooltipText.style('display', null);
+        })
+        .on('mouseout', () => {
+            focusLine.style('display', 'none');
+            focusCurrentCircle.style('display', 'none');
+            focusCompareCircle.style('display', 'none');
+            tooltipText.style('display', 'none');
+        })
+        .on('mousemove', function() {
+            const currentTime = xScale.invert(mouse(this)[0]);
+            const currentData = getNearestTime(currentTsData, currentTime);
+            const currentTimeRange = xScale(currentData.datum.time);
+
+            focusLine.select('.focus-line')
+                .attr('x1', currentTimeRange)
+                .attr('x2', currentTimeRange);
+
+            updateTooltipText(tooltipText.select('.current-tooltip-text'), currentData.datum);
+            updateCircleFocus(focusCurrentCircle, {
+                xScale: xScale,
+                yScale: yScale,
+                tsDatum: currentData.datum
+            });
+            if (isCompareVisible) {
+                const compareTime = compareXScale.invert(mouse(this)[0]);
+                const compareData = getNearestTime(compareTsData, compareTime);
+                updateTooltipText(tooltipText.select('.compare-tooltip-text'), compareData.datum);
+                updateCircleFocus(focusCompareCircle, {
+                    xScale: compareXScale,
+                    yScale: yScale,
+                    tsDatum: compareData.datum
+                });
+            }
+        });
+};
+
+module.exports = {getNearestTime, createTooltip};

--- a/assets/src/scripts/components/hydrograph/tooltip.js
+++ b/assets/src/scripts/components/hydrograph/tooltip.js
@@ -3,8 +3,30 @@ const createFocusLine = function(elem, id) {
     let focus = elem.append('g')
         .attr('id', id)
         .attr('class', 'focus')
-        .style('display', 'none')
+        .style('display', 'none');
     focus.append('line')
         .attr('class', 'focus-line');
     return focus;
+};
+
+const createFocusCircle = function(elem, id) {
+    let focus = elem.append('g')
+        .attr('id', id)
+        .attr('class', 'focus')
+        .style('display', 'none')
+    focus.append('circle')
+        .attr('r', 5.5);
+    return focus;
+};
+
+const createTooltipText = function(elem, id, tskeys) {
+    let tooltipTextGroup = elem.append('g')
+        .attr('id', id)
+        .style('display', 'none');
+    for (let tskey of tskeys) {
+        tooltipTextGroup.append('text')
+            .attr('class', `${tskey}-tooltip-text`);
+    }
+    return tooltipTextGroup;
+
 };

--- a/assets/src/scripts/components/hydrograph/tooltip.js
+++ b/assets/src/scripts/components/hydrograph/tooltip.js
@@ -42,7 +42,6 @@ const createTooltipText = function(elem, tskeys) {
         y += 1;
     }
     return tooltipTextGroup;
-
 };
 
 const updateCircleFocus = function(circleFocus, {xScale, yScale, tsDatum}) {

--- a/assets/src/scripts/components/hydrograph/tooltip.js
+++ b/assets/src/scripts/components/hydrograph/tooltip.js
@@ -64,6 +64,9 @@ const updateTooltipText = function(text, tsDatum) {
  */
 const getNearestTime = function(data, time) {
     // Function that returns the left bounding point for a given chart point.
+    if (data.length < 2) {
+        return null;
+    }
     const bisectDate = bisector(d => d.time).left;
 
     let index = bisectDate(data, time, 1);
@@ -126,6 +129,9 @@ const createTooltip = function(elem, {xScale, yScale, compareXScale, currentTsDa
             const currentData = getNearestTime(currentTsData, currentTime);
             const currentTimeRange = xScale(currentData.datum.time);
 
+            if (!currentData) {
+                return;
+            }
             focusLine.select('.focus-line')
                 .attr('x1', currentTimeRange)
                 .attr('x2', currentTimeRange);
@@ -139,6 +145,9 @@ const createTooltip = function(elem, {xScale, yScale, compareXScale, currentTsDa
             if (isCompareVisible) {
                 const compareTime = compareXScale.invert(mouse(this)[0]);
                 const compareData = getNearestTime(compareTsData, compareTime);
+                if(!compareData) {
+                    return;
+                }
                 updateTooltipText(tooltipText.select('.compare-tooltip-text'), compareData.datum);
                 updateCircleFocus(focusCompareCircle, {
                     xScale: compareXScale,

--- a/assets/src/scripts/components/hydrograph/tooltip.js
+++ b/assets/src/scripts/components/hydrograph/tooltip.js
@@ -1,0 +1,10 @@
+
+const createFocusLine = function(elem, id) {
+    let focus = elem.append('g')
+        .attr('id', id)
+        .attr('class', 'focus')
+        .style('display', 'none')
+    focus.append('line')
+        .attr('class', 'focus-line');
+    return focus;
+};

--- a/assets/src/scripts/components/hydrograph/tooltip.spec.js
+++ b/assets/src/scripts/components/hydrograph/tooltip.spec.js
@@ -93,6 +93,7 @@ describe('Hydrograph tooltip module', () => {
             expect(svg.selectAll('line').size()).toBe(1);
             expect(svg.selectAll('circle').size()).toBe(2);
             expect(svg.selectAll('text').size()).toBe(2);
+            expect(svg.selectAll('.overlay').size()).toBe(1);
         });
 
 

--- a/assets/src/scripts/components/hydrograph/tooltip.spec.js
+++ b/assets/src/scripts/components/hydrograph/tooltip.spec.js
@@ -1,0 +1,100 @@
+const { scaleLinear, scaleTime } = require('d3-scale');
+const { select } = require('d3-selection');
+
+const { getNearestTime, createTooltip } = require('./tooltip');
+
+describe('Hydrograph tooltip module', () => {
+
+    let data = [12, 13, 14, 15, 16].map(hour => {
+        return {
+            time: new Date(`2018-01-03T${hour}:00:00.000Z`),
+            label: 'label',
+            value: hour
+        };
+    });
+
+    describe('getNearestTime', () => {
+        it('Return null if the length of the data array is less than two', function() {
+            expect(getNearestTime([], data[0].time)).toBeNull();
+            expect(getNearestTime([data[1]], data[0].time)).toBeNull();
+        });
+
+        it('return correct data points via getNearestTime' , () => {
+            // Check each date with the given offset against the hourly-spaced
+            // test data.
+            function expectOffset(offset, side) {
+                for (let [index, datum] of data.entries()) {
+                    let expected;
+                    if (side === 'left' || index === data.length - 1) {
+                        expected = {datum, index};
+                    } else {
+                        expected = {datum: data[index + 1], index: index + 1};
+                    }
+                    let time = new Date(datum.time.getTime() + offset);
+                    let returned = getNearestTime(data, time);
+
+                    expect(returned.datum.time).toBe(expected.datum.time);
+                    expect(returned.datum.index).toBe(expected.datum.index);
+                }
+            }
+
+            let hour = 3600000;  // 1 hour in milliseconds
+
+            // Check each date against an offset from itself.
+            expectOffset(0, 'left');
+            expectOffset(1, 'left');
+            expectOffset(hour / 2 - 1, 'left');
+            expectOffset(hour / 2, 'left');
+            expectOffset(hour / 2 + 1, 'right');
+            expectOffset(hour - 1, 'right');
+        });
+    });
+
+    describe('createTooltip', () => {
+        let svg;
+        let xScale, yScale, compareXScale, currentTsData, compareTsData, isCompareVisible;
+        beforeEach(() => {
+            svg = select('body')
+                .append('svg');
+
+            xScale = scaleTime()
+                .range([0, 100])
+                .domain([data[0].time, data[4].time]);
+            yScale = scaleLinear()
+                .range([0, 100])
+                .domain([12, 16]);
+            let lastYearStart = new Date(data[0].time);
+            let lastYearEnd = new Date(data[4].time);
+            compareXScale = scaleTime()
+                .range([0, 100])
+                .domain([
+                    lastYearStart.setFullYear(data[0].time.getFullYear() - 1),
+                    lastYearEnd.setFullYear(data[4].time.getFullYear() - 1)
+                ]
+            );
+            currentTsData = data;
+            compareTsData = [12, 13, 14, 15, 16].map(hour => {
+                return {
+                    time: new Date(`2017-01-03T${hour}:00:00.000Z`),
+                    label: 'label',
+                    value: hour + 1
+                };
+            });
+            isCompareVisible = false;
+
+            createTooltip(svg, {xScale, yScale, compareXScale, currentTsData, compareTsData, isCompareVisible});
+        });
+
+        afterEach(() => {
+            svg.remove();
+        });
+
+        it('Add tooltip elements', () => {
+            expect(svg.selectAll('line').size()).toBe(1);
+            expect(svg.selectAll('circle').size()).toBe(2);
+            expect(svg.selectAll('text').size()).toBe(2);
+        });
+
+
+    });
+});

--- a/assets/src/scripts/utils.js
+++ b/assets/src/scripts/utils.js
@@ -1,3 +1,4 @@
+
 /**
  * Determine the unicode variant of an HTML decimal entity
  *
@@ -58,3 +59,4 @@ export function deltaDays(date1, date2) {
 
     return Math.round(delta_ms/one_day_ms);
 }
+

--- a/assets/src/styles/components/_hydrograph.scss
+++ b/assets/src/styles/components/_hydrograph.scss
@@ -1,3 +1,6 @@
+$approved: darkgreen;
+$estimated: black;
+
 .hydrograph-container {
     display: inline-block;
     position: relative;
@@ -28,13 +31,20 @@
             line {
                 opacity: .5;
                 stroke-color: #436BAF;
-                stroke-width: 2
+                stroke-width: 1;
+                stroke-dasharray: 5, 5
             }
 
         }
         .tooltip-group {
             .current-tooltip-text {
                 font-weight: bold;
+            }
+            .approved {
+                fill: $approved;
+            }
+            .estimated {
+                fill: $estimated;
             }
             .compare-tooltip-text {
                 font-weight: normal
@@ -45,9 +55,10 @@
             stroke-width: 3px;
             stroke: $usgs-blue;
             &.approved {
-                stroke: darkgreen;
+                stroke: $approved;
             }
             &.estimated {
+                stroke: $estimated;
                 stroke-dasharray: 1, 3;
             }
         }

--- a/assets/src/styles/components/_hydrograph.scss
+++ b/assets/src/styles/components/_hydrograph.scss
@@ -25,6 +25,12 @@
                 fill: #436BAF;
                 opacity: .6;
             }
+            .current-tooltip-text {
+                font-weight: bold;
+            }
+            .compare-tooltip-text {
+                font-weight: normal;
+            }
         }
         .line {
             fill: none;

--- a/assets/src/styles/components/_hydrograph.scss
+++ b/assets/src/styles/components/_hydrograph.scss
@@ -25,6 +25,11 @@
                 fill: #436BAF;
                 opacity: .6;
             }
+            line {
+                opacity: .5;
+                stroke-color: #436BAF;
+                stroke-width: 2
+            }
 
         }
         .tooltip-group {

--- a/assets/src/styles/components/_hydrograph.scss
+++ b/assets/src/styles/components/_hydrograph.scss
@@ -25,11 +25,14 @@
                 fill: #436BAF;
                 opacity: .6;
             }
+
+        }
+        .tooltip-group {
             .current-tooltip-text {
                 font-weight: bold;
             }
             .compare-tooltip-text {
-                font-weight: normal;
+                font-weight: normal
             }
         }
         .line {

--- a/assets/src/styles/components/_hydrograph.scss
+++ b/assets/src/styles/components/_hydrograph.scss
@@ -30,13 +30,13 @@ $estimated: black;
             }
             line {
                 opacity: .5;
-                stroke-color: #436BAF;
+                stroke: #436BAF;
                 stroke-width: 1;
                 stroke-dasharray: 5, 5
             }
 
         }
-        .tooltip-group {
+        .tooltip-text-group {
             .current-tooltip-text {
                 font-weight: bold;
             }


### PR DESCRIPTION
Tooltip text is now draw in the upper left corner of the graph. Added a dashed focus line to the tooltip. Refactored the tooltip code into its own module.