### PR TITLE
Removed the ids from the median stats circle and text label elements …

### DIFF
--- a/assets/src/scripts/components/hydrograph/index.js
+++ b/assets/src/scripts/components/hydrograph/index.js
@@ -82,7 +82,6 @@ const plotMedianPoints = function (elem, {visible, xscale, yscale, medianStatsDa
         .data(medianStatsData)
         .enter()
         .append('circle')
-            .attr('id', 'median-point')
             .attr('class', 'median-data-series')
             .attr('r', CIRCLE_RADIUS)
             .attr('cx', function(d) {
@@ -103,7 +102,6 @@ const plotMedianPoints = function (elem, {visible, xscale, yscale, medianStatsDa
                 .text(function(d) {
                     return d.label;
                 })
-                .attr('id', 'median-text')
                 .attr('x', function(d) {
                     return xscale(d.time) + 5;
                 })

--- a/assets/src/scripts/components/hydrograph/index.spec.js
+++ b/assets/src/scripts/components/hydrograph/index.spec.js
@@ -145,9 +145,9 @@ describe('Hydrograph charting module', () => {
             expect(selectAll('svg path.line').size()).toBe(1);
         });
 
-        it('should have a point for the median stat data with a label', () => {
-            expect(selectAll('svg circle#median-point').size()).toBe(1);
-            expect(selectAll('svg text#median-text').size()).toBe(0);
+        it('should have a point for the median stat data without a label', () => {
+            expect(selectAll('svg #median-points circle.median-data-series').size()).toBe(1);
+            expect(selectAll('svg #median-points text').size()).toBe(0);
         });
 
         it('should have a legend with two markers', () => {
@@ -157,7 +157,7 @@ describe('Hydrograph charting module', () => {
         it('show the labels for the median stat data showMedianStatsLabel is true', () => {
             store.dispatch(Actions.showMedianStatsLabel(true));
 
-            expect(selectAll('svg text#median-text').size()).toBe(1);
+            expect(selectAll('svg #median-points text').size()).toBe(1);
 
         });
     });

--- a/assets/src/styles/components/_hydrograph.scss
+++ b/assets/src/styles/components/_hydrograph.scss
@@ -92,9 +92,13 @@ $estimated: black;
                 }
             }
         }
+        #median-points {
+            .median-data-series {
+                cursor: pointer;
+            }
+        }
         .median-data-series {
             fill: #f96713;
-            cursor: pointer;
         }
     }
 }


### PR DESCRIPTION
…since id is supposed to be unique within a document. Modified the style so that the pointer is not visible on the legend median circle marker.