### PR TITLE
Debug test mode

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -7,14 +7,7 @@ var isparta = require('isparta');
 function isDebug(argument) {
     return argument === '--debug';
 }
-var browserifyTransform = '';
-if (!process.argv.some(isDebug)) {
-    browserifyTransform = browserifyBabalIstanbul({
-            instrumenter: isparta,
-            instrumenterConfig: { babel: { presets: ['env'] } },
-            ignore: ['**/lib/**', '**/*.spec.js']
-    });
-}
+
 
 module.exports = function (config) {
     config.set({
@@ -50,8 +43,7 @@ module.exports = function (config) {
                 bundle
                     .plugin(proxyquire.plugin)
                     .require(require.resolve('./assets/src/scripts'), {entry: true});
-            },
-            transform: browserifyTransform
+            }
         },
 
         // test results reporter to use
@@ -97,4 +89,33 @@ module.exports = function (config) {
         // how many browser should be started simultaneous
         concurrency: Infinity
     });
+
+    if (process.argv.some(isDebug)) {
+        config.set({
+            browserify: {
+                debug: true,
+                configure: function (bundle) {
+                    bundle
+                        .plugin(proxyquire.plugin)
+                        .require(require.resolve('./assets/src/scripts'), {entry: true});
+                }
+            }
+        });
+    } else {
+        config.set({
+            browserify: {
+                configure: function (bundle) {
+                    bundle
+                        .plugin(proxyquire.plugin)
+                        .require(require.resolve('./assets/src/scripts'), {entry: true});
+                },
+                transform: [browserifyBabalIstanbul({
+                    instrumenter: isparta,
+                    instrumenterConfig: {babel: {presets: ['env']}},
+                    ignore: ['**/lib/**', '**/*.spec.js']
+                })]
+            }
+        });
+    }
 };
+

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -3,6 +3,19 @@
 var proxyquire = require('proxyquireify');
 var browserifyBabalIstanbul = require('browserify-babel-istanbul');
 var isparta = require('isparta');
+
+function isDebug(argument) {
+    return argument === '--debug';
+}
+var browserifyTransform = '';
+if (!process.argv.some(isDebug)) {
+    browserifyTransform = browserifyBabalIstanbul({
+            instrumenter: isparta,
+            instrumenterConfig: { babel: { presets: ['env'] } },
+            ignore: ['**/lib/**', '**/*.spec.js']
+    });
+}
+
 module.exports = function (config) {
     config.set({
 
@@ -38,13 +51,7 @@ module.exports = function (config) {
                     .plugin(proxyquire.plugin)
                     .require(require.resolve('./assets/src/scripts'), {entry: true});
             },
-            transform: [
-                browserifyBabalIstanbul({
-                        instrumenter: isparta,
-                        instrumenterConfig: { babel: { presets: ['env'] } },
-                        ignore: ['**/lib/**', '**/*.spec.js']
-                })
-            ]
+            transform: browserifyTransform
         },
 
         // test results reporter to use

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -42,7 +42,7 @@ module.exports = function (config) {
                 browserifyBabalIstanbul({
                         instrumenter: isparta,
                         instrumenterConfig: { babel: { presets: ['env'] } },
-                        ignore: ['**/node_modules/**', '**/unitest/**']
+                        ignore: ['**/lib/**', '**/*.spec.js']
                 })
             ]
         },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "karma start",
     "test:chrome": "karma start --browsers Chrome",
     "test:firefox": "karma start --browsers Firefox",
-    "test:watch": "karma start --no-single-run --auto-watch --browsers Chrome",
+    "test:watch": "karma start --debug --no-single-run --auto-watch --browsers Chrome",
     "clean": "rm -rf assets/dist && mkdir assets/dist",
     "build": "npm run clean && run-p build:*",
     "build:css": "node-sass --include-path node_modules/leaflet/dist --include-path node_modules/uswds/src/stylesheets assets/src/styles/main.scss | uglifycss > assets/dist/main.css",


### PR DESCRIPTION
If you want to run the tests so that real line numbers are generated in the errors or if you want to use the in browser debugger than use --debug on the karma command. I have set up test:watch to run in debug mode.

Also removed the spec files and the assets/script/lib directory from the files that are part of the coverage statistics.