### PR TITLE
Updated bumpversion to take a search strin for package.json and elimi…

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -21,6 +21,6 @@ values =
 [bumpversion:file:code.json]
 
 [bumpversion:file:package.json]
-
-[bumpversion:file:package-lock.json]
+search = "version": "{current_version}"
+replace = "version": "{new_version}"
 


### PR DESCRIPTION
…nated package-lock.json from the file.

According to https://github.com/peritus/bumpversion/issues/149 , bumpversion does not handle multiline parsing when there are spaces as there would be in package-lock.json. We may need to consider other ways of keeping package-lock.json in sync. 