### PR TITLE
Wdfn 125 - Render precip as a cumulative graph rather than as instantaneous

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 ### Changed
-- Precipitation timeseries is now shown as accumulated precipiation over the 7 days.
+- Precipitation timeseries is now shown as accumulated precipitation over the 7 days.
 
 ## [0.3.0] - 2018-03-09
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
+### Changed
+- Precipitation timeseries is now shown as accumulated precipiation over the 7 days.
 
 ## [0.3.0] - 2018-03-09
 ### Added

--- a/assets/src/scripts/components/hydrograph/drawingData.js
+++ b/assets/src/scripts/components/hydrograph/drawingData.js
@@ -1,0 +1,328 @@
+import {
+    allTimeSeriesSelector, currentVariableSelector, currentVariableTimeSeriesSelector, timeSeriesSelector,
+    variablesSelector
+} from './timeseries';
+
+const memoize = require('fast-memoize');
+const { createSelector } = require('reselect');
+
+export const MASK_DESC = {
+    ice: 'Ice Affected',
+    fld: 'Flood',
+    bkw: 'Backwater',
+    zfl: 'Zeroflow',
+    dry: 'Dry',
+    ssn: 'Seasonal',
+    pr: 'Partial Record',
+    rat: 'Rating Development',
+    eqp: 'Equipment Malfunction',
+    mnt: 'Maintenance',
+    dis: 'Discontinued',
+    tst: 'Test',
+    pmp: 'Pump',
+    '***': 'Unavailable'
+};
+
+export const HASH_ID = {
+    current: 'hash-45',
+    compare: 'hash-135'
+};
+
+// Lines will be split if the difference exceeds 72 minutes.
+export const MAX_LINE_POINT_GAP = 60 * 1000 * 72;
+
+
+/*
+ * @param {Array} points - Array of point objects
+ */
+const transformToCumulative = function(points) {
+    let accumulatedValue = 0;
+    return points.map((point) => {
+        let result = {...point};
+        if (point.value !== null) {
+            accumulatedValue += point.value;
+            result.value = accumulatedValue;
+        } else {
+            accumulatedValue = 0;
+        }
+        return result;
+    });
+};
+
+export const allPointsSelector = createSelector(
+    allTimeSeriesSelector,
+    state => state.series.variables,
+    (timeSeries, variables) => {
+        let allPoints = {};
+        Object.keys(timeSeries).forEach((tsId) => {
+            const ts = timeSeries[tsId];
+            const variableId = ts.variable;
+            const parmCd = variables[variableId].variableCode.value;
+            if (ts.tsKey !== 'median' && parmCd === '00045') {
+                allPoints[tsId] = transformToCumulative(ts.points);
+            } else {
+                allPoints[tsId] = ts.points;
+            }
+        });
+        return allPoints;
+    }
+);
+
+/*
+ * @param {Object} state
+ * @param {String} tsKey
+ * @returns {Object} of keys are tsId, values are Array of points
+ * in tsKey
+ */
+export const pointsByTsKeySelector = memoize(tsKey => createSelector(
+    allPointsSelector,
+    state => state.series.timeSeries,
+    (points, timeSeries) => {
+        let result = {};
+        Object.keys(points).forEach((tsId) => {
+            if (timeSeries[tsId].tsKey === tsKey) {
+                result[tsId] = points[tsId];
+            }
+        });
+        return result;
+    }));
+
+/*
+* @return Array of Array of points
+ */
+export const currentVariablePointsSelector = memoize(tsKey => createSelector(
+    pointsByTsKeySelector(tsKey),
+    currentVariableTimeSeriesSelector(tsKey),
+    (points, timeSeries) => {
+        return timeSeries ? Object.keys(timeSeries).map((tsId) => points[tsId]) : [];
+    }
+));
+/**
+ * Returns a selector that, for a given tsKey:
+ * Returns an array of time points for all visible time series.
+ * @param  {Object} state     Redux store
+ * @param  {String} tsKey     Timeseries key
+ * @return {Array}            Array of array of points.
+ */
+    //TODO: Candidate for removal
+export const pointsSelector = memoize((tsKey) => createSelector(
+    pointsByTsKeySelector(tsKey),
+    (points) => {
+        return Object.values(points);
+    }
+));
+
+
+/**
+ * Factory function that returns a selector for a given tsKey, that:
+ * Returns a single array of all points.
+ * @param  {Object} state       Redux state
+ * @return {Array}              Array of points.
+ */
+export const flatPointsSelector = memoize(tsKey => createSelector(
+    pointsSelector(tsKey),
+    tsPointsList => tsPointsList.reduce((finalPoints, points) => {
+        Array.prototype.push.apply(finalPoints, points);
+        return finalPoints;
+    }, [])
+));
+
+
+export const classesForPoint = point => {
+    return {
+        approved: point.qualifiers.indexOf('A') > -1,
+        estimated: point.qualifiers.indexOf('E') > -1
+    };
+};
+
+
+
+/**
+ * Returns an array of points for each visible timeseries.
+ * @param  {Object} state     Redux store
+ * @return {Array}            Array of point arrays.
+ */
+export const visiblePointsSelector = createSelector(
+    currentVariablePointsSelector('current'),
+    currentVariablePointsSelector('compare'),
+    currentVariablePointsSelector('median'),
+    (state) => state.showSeries,
+    (current, compare, median, showSeries) => {
+        const pointArray = [];
+        if (showSeries['current']) {
+            Array.prototype.push.apply(pointArray, current);
+
+        }
+        if (showSeries['compare']) {
+            Array.prototype.push.apply(pointArray, compare);
+        }
+        if (showSeries['median']) {
+            Array.prototype.push.apply(pointArray, median);
+        }
+        return pointArray;
+    }
+);
+
+
+/**
+ * Factory function creates a function that, for a given tsKey:
+ * Returns all point data as an array of [value, time, qualifiers].
+ * @param {Object} state - Redux store
+ * @param {String} tsKey - timeseries key
+ * @param {Array of Array} for each point returns [value, time, qualifiers] or empty array.
+ */
+    //TODO: This needs to be changes to use point selector since it should be showing the data being displayed
+export const pointsTableDataSelector = memoize(tsKey => createSelector(
+    allTimeSeriesSelector,
+    (timeSeries) => {
+        return Object.keys(timeSeries).reduce((dataByTsID, tsID) => {
+            const series = timeSeries[tsID];
+            if (series.tsKey !== tsKey) {
+                return dataByTsID;
+            }
+
+            dataByTsID[tsID] = series.points.map((value) => {
+                return [
+                    value.value || '',
+                    value.dateTime || '',
+                    value.qualifiers && value.qualifiers.length > 0 ? value.qualifiers.join(', ') : ''
+                ];
+            });
+
+            return dataByTsID;
+        }, {});
+    }
+));
+
+const getLineClasses = function(pt) {
+    let dataMask = null;
+    if (pt.value === null) {
+        let qualifiers = new Set(pt.qualifiers.map(q => q.toLowerCase()));
+
+        // current business rules specify that a particular data point
+        // will only have at most one masking qualifier
+        let maskIntersection = Object.keys(MASK_DESC).filter(x => qualifiers.has(x));
+        dataMask = maskIntersection[0];
+    }
+    return {
+        ...classesForPoint(pt),
+        dataMask
+    };
+};
+
+
+/**
+ * Factory function creates a function that:
+ * Returns all points in a timeseries grouped into line segments, for each time series.
+ * @param  {Object} state     Redux store
+ * @param  {String} tsKey Timeseries key
+ * @return {Array}            Array of array of points.
+ */
+export const lineSegmentsSelector = memoize(tsKey => createSelector(
+    pointsByTsKeySelector(tsKey),
+    (tsPoints) => {
+        let seriesLines = {};
+        Object.keys(tsPoints).forEach((tsId) => {
+            const points = tsPoints[tsId];
+            let lines = [];
+
+            // Accumulate data into line groups, splitting on the estimated and
+            // approval status.
+            let lastClasses = {};
+
+            for (let pt of points) {
+                // Classes to put on the line with this point.
+                let lineClasses = getLineClasses(pt);
+
+                // If this is a non-masked data point, split lines if the gap
+                // from the period point exceeds MAX_LINE_POINT_GAP.
+                let splitOnGap = false;
+                if (!lineClasses.dataMask && lines.length > 0) {
+                    const lastPoints = lines[lines.length - 1].points;
+                    const lastPtDateTime = lastPoints[lastPoints.length - 1].dateTime;
+                    if (pt.dateTime - lastPtDateTime > MAX_LINE_POINT_GAP) {
+                        splitOnGap = true;
+                    }
+                }
+
+                // If this point doesn't have the same classes as the last point,
+                // create a new line for it.
+                if (lastClasses.approved !== lineClasses.approved ||
+                    lastClasses.estimated !== lineClasses.estimated ||
+                    lastClasses.dataMask !== lineClasses.dataMask ||
+                    splitOnGap) {
+                    lines.push({
+                        classes: lineClasses,
+                        points: []
+                    });
+                }
+
+                // Add this point to the current line.
+                lines[lines.length - 1].points.push(pt);
+
+                // Cache the classes for the next loop iteration.
+                lastClasses = lineClasses;
+            }
+            seriesLines[tsId] = lines;
+        });
+        return seriesLines;
+    }
+));
+
+
+/**
+ * Factory function creates a function that, for a given tsKey:
+ * @return {Object}     Mapping of parameter to code list of line segments arrays.
+ */
+export const lineSegmentsByParmCdSelector = memoize(tsKey => createSelector(
+    lineSegmentsSelector(tsKey),
+    timeSeriesSelector(tsKey),
+    variablesSelector,
+    (lineSegmentsBySeriesID, timeSeriesMap, variables) => {
+        return Object.keys(lineSegmentsBySeriesID).reduce((byVarID, sID) => {
+            const series = timeSeriesMap[sID];
+            const parmCd = variables[series.variable].variableCode.value;
+            byVarID[parmCd] = byVarID[parmCd] || [];
+            byVarID[parmCd].push(lineSegmentsBySeriesID[sID]);
+            return byVarID;
+        }, {});
+    }
+));
+
+
+/**
+ * Factory function creates a function that, for a given tsKey:
+ * Returns mapping of time series IDs to series for the current variable.
+ * @return {Object}
+ */
+const currentVariableTimeseriesSelector = memoize(tsKey => createSelector(
+    timeSeriesSelector(tsKey),
+    currentVariableSelector,
+    (seriesMap, variable) => {
+        return Object.keys(seriesMap).filter(
+                sID => seriesMap[sID].variable === variable.oid).reduce((curMap, sID) => {
+            curMap[sID] = seriesMap[sID];
+            return curMap;
+        }, {});
+    }
+));
+
+
+/**
+ * Factory function creates a function that, for a given tsKey:
+ * Returns mapping of series ID to line segments for the currently selected variable.
+ * @return {Object}
+ */
+export const currentVariableLineSegmentsSelector = memoize(tsKey => createSelector(
+    currentVariableTimeseriesSelector(tsKey),
+    lineSegmentsSelector(tsKey),
+    (seriesMap, linesMap) => {
+        const result = Object.keys(seriesMap).reduce((visMap, sID) => {
+                visMap[sID] = linesMap[sID];
+                return visMap;
+            }, {});
+        return result;
+
+    }
+));
+

--- a/assets/src/scripts/components/hydrograph/drawingData.js
+++ b/assets/src/scripts/components/hydrograph/drawingData.js
@@ -31,6 +31,8 @@ export const MAX_LINE_POINT_GAP = 60 * 1000 * 72;
 
 /*
  * @param {Array} points - Array of point objects
+ * @return {Array} - Returns the array of points accumulated. If a null value is found,
+ * the accumulator is set back to zero.
  */
 const transformToCumulative = function(points) {
     let accumulatedValue = 0;
@@ -46,10 +48,10 @@ const transformToCumulative = function(points) {
     });
 };
 
-/*
+/* Factory function that returns a function that returns an object where the properties are ts IDs and the values
+ * are array of point objects that can be used to render a time series graph.
  * @param {Object} state
- * @return {Object} where the keys are ts ids and the values are an object that can be used to render a
- * timeseries graph.
+ * @return {Object} where the keys are ts ids and the values are an Array of point Objects.
  */
 export const allPointsSelector = createSelector(
     allTimeSeriesSelector,
@@ -70,11 +72,10 @@ export const allPointsSelector = createSelector(
     }
 );
 
-/*
+/* Factory function that for a given tsKey returns an object with keys that are the tsID and values an array of point objects
  * @param {Object} state
  * @param {String} tsKey
- * @returns {Object} of keys are tsId, values are Array of points
- * in tsKey
+ * @return {Object} of keys are tsId, values are Array of point Objects
  */
 export const pointsByTsKeySelector = memoize(tsKey => createSelector(
     allPointsSelector,
@@ -89,8 +90,10 @@ export const pointsByTsKeySelector = memoize(tsKey => createSelector(
         return result;
     }));
 
-/*
-* @return Array of Array of points
+/* Returns a selector that returns all time series points for the current variable and in the selected series, tsKey.
+ * @param {Object} state
+ * @param {String} tsKey
+ * @return Array of Array of points
  */
 export const currentVariablePointsSelector = memoize(tsKey => createSelector(
     pointsByTsKeySelector(tsKey),
@@ -99,6 +102,8 @@ export const currentVariablePointsSelector = memoize(tsKey => createSelector(
         return timeSeries ? Object.keys(timeSeries).map((tsId) => points[tsId]) : [];
     }
 ));
+
+
 /**
  * Returns a selector that, for a given tsKey:
  * Returns an array of time points for all time series.
@@ -129,6 +134,11 @@ export const flatPointsSelector = memoize(tsKey => createSelector(
 ));
 
 
+/*
+ * Returns an object which identifies which classes to use for the point
+ * @param {Object} point
+ * @return {Object}
+ */
 export const classesForPoint = point => {
     return {
         approved: point.qualifiers.indexOf('A') > -1,
@@ -139,7 +149,8 @@ export const classesForPoint = point => {
 
 
 /**
- * Returns an array of points for each visible timeseries.
+ * Factory function create a function that
+ * returns an array of points for each visible timeseries.
  * @param  {Object} state     Redux store
  * @return {Array}            Array of point arrays.
  */
@@ -170,7 +181,7 @@ export const visiblePointsSelector = createSelector(
  * Returns all point data as an array of [value, time, qualifiers].
  * @param {Object} state - Redux store
  * @param {String} tsKey - timeseries key
- * @param {Object of Array} for each point returns [value, time, qualifiers] or empty array.
+ * @param {Object} - keys are ts id, values are an array of points where each point is an Array as follows:  [value, time, qualifiers].
  */
 export const pointsTableDataSelector = memoize(tsKey => createSelector(
     pointsByTsKeySelector(tsKey),
@@ -210,7 +221,7 @@ const getLineClasses = function(pt) {
  * Returns all points in a timeseries grouped into line segments, for each time series.
  * @param  {Object} state     Redux store
  * @param  {String} tsKey Timeseries key
- * @return {Object}  Keys are ts Ids, values are  of array of points.
+ * @return {Object}  Keys are ts Ids, values are  of array of line segments.
  */
 export const lineSegmentsSelector = memoize(tsKey => createSelector(
     pointsByTsKeySelector(tsKey),
@@ -266,7 +277,7 @@ export const lineSegmentsSelector = memoize(tsKey => createSelector(
 
 /**
  * Factory function creates a function that, for a given tsKey:
- * @return {Object}     Mapping of parameter to code list of line segments arrays.
+ * @return {Object} - Mapping of parameter code Array of line segments.
  */
 export const lineSegmentsByParmCdSelector = memoize(tsKey => createSelector(
     lineSegmentsSelector(tsKey),
@@ -293,11 +304,10 @@ export const currentVariableLineSegmentsSelector = memoize(tsKey => createSelect
     currentVariableTimeSeriesSelector(tsKey),
     lineSegmentsSelector(tsKey),
     (seriesMap, linesMap) => {
-        const result = Object.keys(seriesMap).reduce((visMap, sID) => {
+        return Object.keys(seriesMap).reduce((visMap, sID) => {
                 visMap[sID] = linesMap[sID];
                 return visMap;
             }, {});
-        return result;
 
     }
 ));

--- a/assets/src/scripts/components/hydrograph/drawingData.js
+++ b/assets/src/scripts/components/hydrograph/drawingData.js
@@ -29,6 +29,8 @@ export const HASH_ID = {
 // Lines will be split if the difference exceeds 72 minutes.
 export const MAX_LINE_POINT_GAP = 60 * 1000 * 72;
 
+const PARM_CODES_TO_ACCUMULATE = ['00045'];
+
 
 /*
  * @param {Array} points - Array of point objects
@@ -63,7 +65,7 @@ export const allPointsSelector = createSelector(
             const ts = timeSeries[tsId];
             const variableId = ts.variable;
             const parmCd = variables[variableId].variableCode.value;
-            if (ts.tsKey !== 'median' && parmCd === '00045') {
+            if (ts.tsKey !== 'median' && PARM_CODES_TO_ACCUMULATE.includes(parmCd)) {
                 allPoints[tsId] = transformToCumulative(ts.points);
             } else {
                 allPoints[tsId] = ts.points;

--- a/assets/src/scripts/components/hydrograph/drawingData.js
+++ b/assets/src/scripts/components/hydrograph/drawingData.js
@@ -1,7 +1,8 @@
-const {allTimeSeriesSelector, currentVariableTimeSeriesSelector, timeSeriesSelector, variablesSelector } = require('./timeseries');
-
 const memoize = require('fast-memoize');
 const { createSelector } = require('reselect');
+
+const {allTimeSeriesSelector, currentVariableTimeSeriesSelector, timeSeriesSelector, variablesSelector } = require('./timeseries');
+
 
 export const MASK_DESC = {
     ice: 'Ice Affected',

--- a/assets/src/scripts/components/hydrograph/drawingData.spec.js
+++ b/assets/src/scripts/components/hydrograph/drawingData.spec.js
@@ -1,4 +1,80 @@
+const { lineSegmentsSelector, pointsSelector, pointsTableDataSelector, MAX_LINE_POINT_GAP } = require('./drawingData');
 
+const TEST_DATA = {
+    series: {
+        timeSeries: {
+            '00060': {
+                tsKey: 'current',
+                startTime: new Date('2018-03-06T15:45:00.000Z'),
+                endTime: new Date('2018-03-13t13:45:00.000Z'),
+                variable: '45807197',
+                points: [{
+                    value: 10,
+                    qualifiers: ['P'],
+                    approved: false,
+                    estimated: false
+                }, {
+                    value: null,
+                    qualifiers: ['P', 'ICE'],
+                    approved: false,
+                    estimated: false
+                }, {
+                    value: null,
+                    qualifiers: ['P', 'FLD'],
+                    approved: false,
+                    estimated: false
+                }]
+            },
+            '00010': {
+                tsKey: 'compare',
+                startTime: new Date('2017-03-06T15:45:00.000Z'),
+                endTime: new Date('2017-03-13t13:45:00.000Z'),
+                variable: '45807196',
+                points: [{
+                    value: 1,
+                    qualifiers: ['P'],
+                    approved: false,
+                    estimated: false
+                }, {
+                    value: 2,
+                    qualifiers: ['P'],
+                    approved: false,
+                    estimated: false
+                }, {
+                    value: 3,
+                    qualifiers: ['P'],
+                    approved: false,
+                    estimated: false
+                }]}
+        },
+        timeSeriesCollections: {
+            'coll1': {
+                variable: 45807197,
+                timeSeries: ['00060']
+            }
+        },
+        requests: {
+            current: {
+                timeSeriesCollections: ['coll1']
+            }
+        },
+        variables: {
+            '45807197': {
+                variableCode: {value: '00060'},
+                variableName: 'Streamflow',
+                variableDescription: 'Discharge, cubic feet per second',
+                oid: '45807197'
+            },
+            '45807196': {
+                variableCode: {value: '00010'},
+                variableName: 'Gage Height',
+                variableDescription: 'Gage Height in feet',
+                oid: '45807196'
+            }
+        }
+    },
+    currentVariableID: '45807197'
+};
 describe('drawingData module', () => {
 
     describe('line segment selector', () => {
@@ -10,6 +86,7 @@ describe('drawingData module', () => {
                     timeSeries: {
                         ...TEST_DATA.series.timeSeries,
                         '00060': {
+                            ...TEST_DATA.series.timeSeries['00060'],
                             points: [{
                                 value: 10,
                                 qualifiers: []
@@ -72,6 +149,7 @@ describe('drawingData module', () => {
                     timeSeries: {
                         ...TEST_DATA.series.timeSeries,
                         '00060': {
+                            ...TEST_DATA.series.timeSeries['00060'],
                             points: [{
                                 value: 10,
                                 qualifiers: ['P']
@@ -138,6 +216,7 @@ describe('drawingData module', () => {
                     timeSeries: {
                         ...TEST_DATA.series.timeSeries,
                         '00060': {
+                            ...TEST_DATA.series.timeSeries['00060'],
                             points: [{
                                 value: 10,
                                 qualifiers: ['P']
@@ -220,6 +299,7 @@ describe('drawingData module', () => {
                     timeSeries: {
                         ...TEST_DATA.series.timeSeries,
                         '00060': {
+                            ...TEST_DATA.series.timeSeries['00060'],
                             points: dates.map(d => {
                                 return {
                                     value: 10,
@@ -291,6 +371,7 @@ describe('drawingData module', () => {
                     timeSeries: {
                         ...TEST_DATA.series.timeSeries,
                         '00060': {
+                            ...TEST_DATA.series.timeSeries['00060'],
                             points: dates.map(d => {
                                 return {
                                     value: null,

--- a/assets/src/scripts/components/hydrograph/drawingData.spec.js
+++ b/assets/src/scripts/components/hydrograph/drawingData.spec.js
@@ -130,6 +130,47 @@ describe('drawingData module', () => {
         it('Return the empty object if there are no timeseries', () =>  {
             expect(allPointsSelector({series: {}})).toEqual({});
         });
+
+        it('Resets the accumulator for precip if null value is encountered', () => {
+            const newTestData = {
+                ...TEST_DATA,
+                series: {
+                    ...TEST_DATA.series,
+                    timeSeries: {
+                        ...TEST_DATA.series.timeSeries,
+                        '00045': {
+                            tsKey: 'current',
+                            startTime: new Date('2017-03-06T15:45:00.000Z'),
+                            endTime: new Date('2017-03-13t13:45:00.000Z'),
+                            variable: '45807140',
+                            points: [{
+                                value: 1,
+                                qualifiers: ['P'],
+                                approved: false,
+                                estimated: false
+                            }, {
+                                value: 2,
+                                qualifiers: ['P'],
+                                approved: false,
+                                estimated: false
+                            }, {
+                                value: null,
+                                qualifiers: ['P'],
+                                approved: false,
+                                estimated: false
+                            }, {
+                                value: 4,
+                                qualifiers: ['P'],
+                                approved: false,
+                                estimated: false
+                            }]
+                        }
+                    }
+                }
+            };
+
+            expect(allPointsSelector(newTestData)['00045'].map((point) => point.value)).toEqual([1, 3, null, 4]);
+        });
     });
 
     describe('pointsByTsKeySelector', () => {

--- a/assets/src/scripts/components/hydrograph/index.js
+++ b/assets/src/scripts/components/hydrograph/index.js
@@ -15,7 +15,7 @@ const { drawSimpleLegend, legendMarkerRowsSelector } = require('./legend');
 const { plotSeriesSelectTable, availableTimeseriesSelector } = require('./parameters');
 const { xScaleSelector, yScaleSelector, timeSeriesScalesByParmCdSelector } = require('./scales');
 const { Actions } = require('../../store');
-const { currentVariableLineSegmentsSelector, currentVariableSelector, currentVariableTimeseries, pointsSelector,
+const { currentVariableLineSegmentsSelector, currentVariableSelector, pointsByTsKeySelector,
     methodsSelector, pointsTableDataSelector, isVisibleSelector, titleSelector,
     descriptionSelector, lineSegmentsByParmCdSelector, currentVariableTimeSeriesSelector, MASK_DESC, HASH_ID } = require('./timeseries');
 const { createTooltipFocus, createTooltipText } = require('./tooltip');
@@ -298,15 +298,15 @@ const timeSeriesGraph = function (elem) {
                     xScale: xScaleSelector('current'),
                     yScale: yScaleSelector,
                     compareXScale: xScaleSelector('compare'),
-                    currentTsData: pointsSelector('current'),
-                    compareTsData: pointsSelector('compare'),
+                    currentTsData: pointsByTsKeySelector('current'),
+                    compareTsData: pointsByTsKeySelector('compare'),
                     isCompareVisible: isVisibleSelector('compare')
                 })))
                 .call(link(plotAllMedianPoints, createStructuredSelector({
                     visible: isVisibleSelector('median'),
                     xscale: xScaleSelector('current'),
                     yscale: yScaleSelector,
-                    seriesMap: currentVariableTimeseries('median'),
+                    seriesMap: currentVariableTimeSeriesSelector('median'),
                     variable: currentVariableSelector,
                     showLabel: (state) => state.showMedianStatsLabel
                 })));

--- a/assets/src/scripts/components/hydrograph/index.js
+++ b/assets/src/scripts/components/hydrograph/index.js
@@ -170,12 +170,12 @@ const timeSeriesLegend = function(elem) {
 /**
  * Plots the median points for a single median time series.
  * @param  {Object} elem
- * @param  {Function} options.xscale
- * @param  {Function} options.yscale
- * @param  {Number} options.modulo
- * @param  {Array} options.points
- * @param  {Boolean} options.showLabel
- * @param  {Object} options.variable
+ * @param  {Function} xscale
+ * @param  {Function} yscale
+ * @param  {Number} modulo
+ * @param  {Array} points
+ * @param  {Boolean} showLabel
+ * @param  {Object} variable
  */
 const plotMedianPoints = function (elem, {xscale, yscale, modulo, points, showLabel, variable}) {
     elem.selectAll('medianPoint')
@@ -215,12 +215,12 @@ const plotMedianPoints = function (elem, {xscale, yscale, modulo, points, showLa
 /**
  * Plots the median points for all median time series for the current variable.
  * @param  {Object} elem
- * @param  {Boolean} options.visible
- * @param  {Function} options.xscale
- * @param  {Function} options.yscale
- * @param  {Array} options.pointsList
- * @param  {Boolean} options.showLabel
- * @param  {Object} options.variable
+ * @param  {Boolean} visible
+ * @param  {Function} xscale
+ * @param  {Function} yscale
+ * @param  {Array} pointsList
+ * @param  {Boolean} showLabel
+ * @param  {Object} variable
  */
 const plotAllMedianPoints = function (elem, {visible, xscale, yscale, seriesMap, showLabel, variable}) {
     elem.select('#median-points').remove();

--- a/assets/src/scripts/components/hydrograph/index.js
+++ b/assets/src/scripts/components/hydrograph/index.js
@@ -16,9 +16,10 @@ const { drawSimpleLegend, legendMarkerRowsSelector } = require('./legend');
 const { plotSeriesSelectTable, availableTimeseriesSelector } = require('./parameters');
 const { xScaleSelector, yScaleSelector, timeSeriesScalesByParmCdSelector } = require('./scales');
 const { Actions } = require('../../store');
-const { currentVariableLineSegmentsSelector, currentVariableSelector, pointsSelector,
-    methodsSelector, pointsTableDataSelector, isVisibleSelector, titleSelector,
-    descriptionSelector, lineSegmentsByParmCdSelector, currentVariableTimeSeriesSelector, MASK_DESC, HASH_ID } = require('./timeseries');
+const { pointsSelector, pointsTableDataSelector, lineSegmentsByParmCdSelector, currentVariableLineSegmentsSelector,
+    MASK_DESC, HASH_ID } = require('./drawingData');
+const { currentVariableSelector, methodsSelector, isVisibleSelector, titleSelector,
+    descriptionSelector,  currentVariableTimeSeriesSelector } = require('./timeseries');
 const { createTooltipFocus, createTooltipText } = require('./tooltip');
 
 

--- a/assets/src/scripts/components/hydrograph/index.js
+++ b/assets/src/scripts/components/hydrograph/index.js
@@ -101,7 +101,7 @@ const plotDataLine = function (elem, {visible, lines, tsKey, xScale, yScale}) {
 };
 
 
-const plotDataLines = function (elem, {visible, tsLinesMap, tsKey, xScale, yScale, parmCd}) {
+const plotDataLines = function (elem, {visible, tsLinesMap, tsKey, xScale, yScale}) {
     const elemId = `ts-${tsKey}-group`;
 
     elem.selectAll(`#${elemId}`).remove();
@@ -111,7 +111,7 @@ const plotDataLines = function (elem, {visible, tsLinesMap, tsKey, xScale, yScal
         .classed('tsKey', true);
 
     for (const lines of Object.values(tsLinesMap)) {
-        plotDataLine(tsLineGroup, {visible, lines, tsKey, xScale, yScale, parmCd});
+        plotDataLine(tsLineGroup, {visible, lines, tsKey, xScale, yScale});
     }
 };
 

--- a/assets/src/scripts/components/hydrograph/index.js
+++ b/assets/src/scripts/components/hydrograph/index.js
@@ -15,7 +15,7 @@ const { drawSimpleLegend, legendMarkerRowsSelector } = require('./legend');
 const { plotSeriesSelectTable, availableTimeseriesSelector } = require('./parameters');
 const { xScaleSelector, yScaleSelector, timeSeriesScalesByParmCdSelector } = require('./scales');
 const { Actions } = require('../../store');
-const { currentVariableLineSegmentsSelector, currentVariableSelector, pointsByTsKeySelector,
+const { currentVariableLineSegmentsSelector, currentVariableSelector, pointsSelector,
     methodsSelector, pointsTableDataSelector, isVisibleSelector, titleSelector,
     descriptionSelector, lineSegmentsByParmCdSelector, currentVariableTimeSeriesSelector, MASK_DESC, HASH_ID } = require('./timeseries');
 const { createTooltipFocus, createTooltipText } = require('./tooltip');
@@ -298,8 +298,8 @@ const timeSeriesGraph = function (elem) {
                     xScale: xScaleSelector('current'),
                     yScale: yScaleSelector,
                     compareXScale: xScaleSelector('compare'),
-                    currentTsData: pointsByTsKeySelector('current'),
-                    compareTsData: pointsByTsKeySelector('compare'),
+                    currentTsData: pointsSelector('current'),
+                    compareTsData: pointsSelector('compare'),
                     isCompareVisible: isVisibleSelector('compare')
                 })))
                 .call(link(plotAllMedianPoints, createStructuredSelector({

--- a/assets/src/scripts/components/hydrograph/index.js
+++ b/assets/src/scripts/components/hydrograph/index.js
@@ -99,7 +99,7 @@ const plotDataLine = function (elem, {visible, lines, tsKey, xScale, yScale}) {
 };
 
 
-const plotDataLines = function (elem, {visible, tsLinesMap, tsKey, xScale, yScale}) {
+const plotDataLines = function (elem, {visible, tsLinesMap, tsKey, xScale, yScale, parmCd}) {
     const elemId = `ts-${tsKey}-group`;
 
     elem.selectAll(`#${elemId}`).remove();
@@ -109,7 +109,7 @@ const plotDataLines = function (elem, {visible, tsLinesMap, tsKey, xScale, yScal
         .classed('tsKey', true);
 
     for (const lines of Object.values(tsLinesMap)) {
-        plotDataLine(tsLineGroup, {visible, lines, tsKey, xScale, yScale});
+        plotDataLine(tsLineGroup, {visible, lines, tsKey, xScale, yScale, parmCd});
     }
 };
 

--- a/assets/src/scripts/components/hydrograph/index.spec.js
+++ b/assets/src/scripts/components/hydrograph/index.spec.js
@@ -157,7 +157,7 @@ describe('Hydrograph charting module', () => {
             expect(selectAll('div#sr-only-median').size()).toBe(1);
             expect(selectAll('div#sr-only-compare').size()).toBe(1);
             expect(selectAll('div#sr-only-current').size()).toBe(1);
-        })
+        });
     });
 
     describe('SVG contains the expected elements', () => {

--- a/assets/src/scripts/components/hydrograph/legend.js
+++ b/assets/src/scripts/components/hydrograph/legend.js
@@ -4,7 +4,8 @@ const { createSelector } = require('reselect');
 
 const { CIRCLE_RADIUS, MARGIN } = require('./layout');
 const { defineLineMarker, defineCircleMarker, defineRectangleMarker, rectangleMarker } = require('./markers');
-const { currentVariableTimeSeriesSelector, lineSegmentsSelector, methodsSelector, HASH_ID, MASK_DESC } = require('./timeseries');
+const { lineSegmentsSelector, HASH_ID, MASK_DESC} = require('./drawingData');
+const { currentVariableTimeSeriesSelector, methodsSelector } = require('./timeseries');
 
 
 const tsMaskMarkers = function(tsKey, masks) {

--- a/assets/src/scripts/components/hydrograph/legend.spec.js
+++ b/assets/src/scripts/components/hydrograph/legend.spec.js
@@ -165,10 +165,8 @@ describe('Legend module', () => {
                     },
                     variables: {
                         '00060ID': {
-                            oid: '00060ID',
-                            parameterCode: {
-                                value: '00060'
-                            }
+                            variableCode: {value: '00060'},
+                            oid: '00060ID'
                         }
                     }
                 },

--- a/assets/src/scripts/components/hydrograph/markers.spec.js
+++ b/assets/src/scripts/components/hydrograph/markers.spec.js
@@ -28,7 +28,7 @@ describe('Markers module', () => {
             expect(node.getAttribute('y2')).toBe('0');
             expect(node.getAttribute('class')).toBe(domClass);
             expect(node.getAttribute('id')).toBe(domId);
-        })
+        });
     });
 
     describe('circleMarker', () => {

--- a/assets/src/scripts/components/hydrograph/parameters.js
+++ b/assets/src/scripts/components/hydrograph/parameters.js
@@ -8,6 +8,7 @@ const { SPARK_LINE_DIM, SMALL_SCREEN_WIDTH } = require('./layout');
 const { dispatch } = require('../../lib/redux');
 
 
+
 /**
  * Returns metadata for each available timeseries.
  * @param  {Object} state Redux state

--- a/assets/src/scripts/components/hydrograph/parameters.spec.js
+++ b/assets/src/scripts/components/hydrograph/parameters.spec.js
@@ -304,6 +304,10 @@ describe('Parameters module', () => {
             svg = select('body').append('svg');
         });
 
+        afterEach(() => {
+            select('svg').remove();
+        });
+
         it('adds a path for a line', () => {
             addSparkLine(svg, tsDataSingle);
             expect(svg.selectAll('path').size()).toEqual(1);

--- a/assets/src/scripts/components/hydrograph/scales.js
+++ b/assets/src/scripts/components/hydrograph/scales.js
@@ -5,7 +5,8 @@ const { createSelector } = require('reselect');
 
 const { default: scaleSymlog } = require('../../lib/symlog');
 const { layoutSelector, MARGIN } = require('./layout');
-const { flatPointsSelector, timeSeriesSelector, variablesSelector, visiblePointsSelector, currentVariableSelector, pointsByTsKeySelector } = require('./timeseries');
+const { timeSeriesSelector, variablesSelector,  currentVariableSelector,  } = require('./timeseries');
+const { flatPointsSelector, visiblePointsSelector, pointsByTsKeySelector } = require('./drawingData');
 
 const paddingRatio = 0.2;
 

--- a/assets/src/scripts/components/hydrograph/scales.js
+++ b/assets/src/scripts/components/hydrograph/scales.js
@@ -6,7 +6,7 @@ const { createSelector } = require('reselect');
 const { default: scaleSymlog } = require('../../lib/symlog');
 const { layoutSelector, MARGIN } = require('./layout');
 const { timeSeriesSelector, variablesSelector, currentVariableSelector, requestTimeRangeSelector } = require('./timeseries');
-const { flatPointsSelector, visiblePointsSelector, pointsByTsKeySelector } = require('./drawingData');
+const { visiblePointsSelector, pointsByTsKeySelector } = require('./drawingData');
 
 const paddingRatio = 0.2;
 

--- a/assets/src/scripts/components/hydrograph/scales.js
+++ b/assets/src/scripts/components/hydrograph/scales.js
@@ -37,7 +37,7 @@ function extendDomain(domain) {
 
 /**
  * Create an x-scale oriented on the left
- * @param {Array} values - Array contains {time, ...}
+ * @param {Array} timeRange - Object containing the start and end times.
  * @param {Number} xSize - range of scale
  * @return {Object} d3 scale for time.
  */
@@ -53,9 +53,9 @@ function createXScale(timeRange, xSize) {
 /**
  * Create the scale based on the parameter code
  *
- * @param parmCd
- * @param extent
- * @param size
+ * @param {String} parmCd
+ * @param {Array} extent
+ * @param {Number} size
  */
 function yScaleByParameter(parmCd, extent, size) {
     if (SYMLOG_PARMS.indexOf(parmCd) >= 0) {
@@ -73,8 +73,9 @@ function yScaleByParameter(parmCd, extent, size) {
 /**
  * Create a yScale for the plots where you only have a single array of data
  *
- * @param tsData - array of data points with time and value keys
- * @param ySize - range of the scale
+ * @param {String} parmCd
+ * @param {Array} tsData - array of data points with time and value keys
+ * @param {Number} ySize - range of the scale
  * * @return {Object} d3 scale for value.
  */
 function singleSeriesYScale(parmCd, tsData, ySize) {
@@ -86,6 +87,7 @@ function singleSeriesYScale(parmCd, tsData, ySize) {
 
 /**
  * Create an yscale oriented on the bottom
+ * @param {String} parmCd
  * @param {Object} pointArrays - Time series points: [[point, point], ...]
  * @param {Number} ySize - range of scale
  * @return {Object} d3 scale for value.

--- a/assets/src/scripts/components/hydrograph/timeseries.js
+++ b/assets/src/scripts/components/hydrograph/timeseries.js
@@ -148,7 +148,7 @@ export const titleSelector = createSelector(
  */
 export const descriptionSelector = createSelector(
     currentVariableSelector,
-    timeSeriesSelector('current'),
+    currentVariableTimeSeriesSelector('current'),
     (variable, timeSeries) => {
         const desc = variable ? variable.variableDescription : '';
         const startTime = new Date(Math.min.apply(null, Object.values(timeSeries).map(ts => ts.startTime)));

--- a/assets/src/scripts/components/hydrograph/timeseries.js
+++ b/assets/src/scripts/components/hydrograph/timeseries.js
@@ -24,16 +24,6 @@ export const currentVariableSelector = createSelector(
     }
 );
 
-/**
- * Returns currently selected parameter code
- * @return String or null if none
- */
-    //TODO: see if this is use anywhere before removing.
-export const currentParmCd = createSelector(
-    currentVariableSelector,
-    (currentVar) => currentVar && currentVar.variableCode ? currentVar.variableCode.value : null
-);
-
 
 
 /**

--- a/assets/src/scripts/components/hydrograph/timeseries.js
+++ b/assets/src/scripts/components/hydrograph/timeseries.js
@@ -6,33 +6,11 @@ const { createSelector } = require('reselect');
 // Create a time formatting function from D3's timeFormat
 const formatTime = timeFormat('%c %Z');
 
-export const MASK_DESC = {
-    ice: 'Ice Affected',
-    fld: 'Flood',
-    bkw: 'Backwater',
-    zfl: 'Zeroflow',
-    dry: 'Dry',
-    ssn: 'Seasonal',
-    pr: 'Partial Record',
-    rat: 'Rating Development',
-    eqp: 'Equipment Malfunction',
-    mnt: 'Maintenance',
-    dis: 'Discontinued',
-    tst: 'Test',
-    pmp: 'Pump',
-    '***': 'Unavailable'
-};
-
-// Lines will be split if the difference exceeds 72 minutes.
-export const MAX_LINE_POINT_GAP = 60 * 1000 * 72;
 
 /**
  * @return {Object}     Mapping of variable IDs to variable details
  */
-export const variablesSelector = createSelector(
-    state => state.series.variables,
-    (variables) => variables
-);
+export const variablesSelector = state => state.series.variables ? state.series.variables : null;
 
 
 /**
@@ -50,6 +28,7 @@ export const currentVariableSelector = createSelector(
  * Returns currently selected parameter code
  * @return String or null if none
  */
+    //TODO: see if this is use anywhere before removing.
 export const currentParmCd = createSelector(
     currentVariableSelector,
     (currentVar) => currentVar && currentVar.variableCode ? currentVar.variableCode.value : null
@@ -96,12 +75,15 @@ export const currentVariableTimeSeriesSelector = memoize(tsKey => createSelector
     currentVariableSelector,
     (timeSeries, variable) => {
         let ts = {};
-        Object.keys(timeSeries).forEach(key => {
-            const series = timeSeries[key];
-            if (series.tsKey === tsKey && series.variable === variable.oid) {
-                ts[key] = series;
-            }
-        });
+        if (variable) {
+            ts = {};
+            Object.keys(timeSeries).forEach(key => {
+                const series = timeSeries[key];
+                if (series.tsKey === tsKey && series.variable === variable.oid) {
+                    ts[key] = series;
+                }
+            });
+        }
         return ts;
     }
 ));
@@ -111,7 +93,7 @@ export const currentVariableTimeSeriesSelector = memoize(tsKey => createSelector
  * Selects all time series data.
  * @param  {String} tsKey   Time-series key
  * @param  {Object} state   Redux state
- * @return {Object}         Time-series data
+ * @return {Object} - Keys are tsID, values are time-series data
  */
 export const timeSeriesSelector = memoize(tsKey => createSelector(
     allTimeSeriesSelector,
@@ -127,143 +109,6 @@ export const timeSeriesSelector = memoize(tsKey => createSelector(
     }
 ));
 
-export const HASH_ID = {
-    current: 'hash-45',
-    compare: 'hash-135'
-};
-
-
-/*
- * @param {Array} points - Array of point objects
- */
-const transformToCumulative = function(points) {
-    let accumulatedValue = 0;
-    return points.map((point) => {
-        let result = {...point};
-        if (point.value !== null) {
-            accumulatedValue += point.value;
-            result.value = accumulatedValue;
-        } else {
-            accumulatedValue = 0;
-        }
-        return result;
-    });
-};
-
-export const allPointsSelector = createSelector(
-    allTimeSeriesSelector,
-    state => state.series.variables,
-    (timeSeries, variables) => {
-        let allPoints = {};
-        Object.keys(timeSeries).forEach((tsId) => {
-            const ts = timeSeries[tsId];
-            const variableId = ts.variable;
-            const parmCd = variables[variableId].variableCode.value;
-            if (ts.tsKey !== 'median' && parmCd === '00045') {
-                allPoints[tsId] = transformToCumulative(ts.points);
-            } else {
-                allPoints[tsId] = ts.points;
-            }
-        });
-        return allPoints;
-    }
-);
-
-/*
- * @param {Object} state
- * @param {String} tsKey
- * @returns {Object} of keys are tsId, values are Array of points
- * in tsKey
- */
-export const pointsByTsKeySelector = memoize(tsKey => createSelector(
-    allPointsSelector,
-    state => state.series.timeSeries,
-    (points, timeSeries) => {
-        let result = {};
-        Object.keys(points).forEach((tsId) => {
-            if (timeSeries[tsId].tsKey === tsKey) {
-                result[tsId] = points[tsId];
-            }
-        });
-        return result;
-    }));
-
-/*
-* @return Array of Array of points
- */
-export const currentVariablePointsSelector = memoize(tsKey => createSelector(
-    pointsByTsKeySelector(tsKey),
-    currentVariableTimeSeriesSelector(tsKey),
-    (points, timeSeries) => {
-        return Object.keys(timeSeries).map((tsId) => {
-            return points[tsId];
-        });
-    }
-));
-/**
- * Returns a selector that, for a given tsKey:
- * Returns an array of time points for all visible time series.
- * @param  {Object} state     Redux store
- * @param  {String} tsKey     Timeseries key
- * @return {Array}            Array of array of points.
- */
-    //TODO: Candidate for removal
-export const pointsSelector = memoize((tsKey) => createSelector(
-    pointsByTsKeySelector(tsKey),
-    (points) => {
-        return Object.values(points);
-    }
-));
-
-
-/**
- * Factory function that returns a selector for a given tsKey, that:
- * Returns a single array of all points.
- * @param  {Object} state       Redux state
- * @return {Array}              Array of points.
- */
-export const flatPointsSelector = memoize(tsKey => createSelector(
-    pointsSelector(tsKey),
-    tsPointsList => tsPointsList.reduce((finalPoints, points) => {
-        Array.prototype.push.apply(finalPoints, points);
-        return finalPoints;
-    }, [])
-));
-
-
-export const classesForPoint = point => {
-    return {
-        approved: point.qualifiers.indexOf('A') > -1,
-        estimated: point.qualifiers.indexOf('E') > -1
-    };
-};
-
-
-/**
- * Returns an array of points for each visible timeseries.
- * @param  {Object} state     Redux store
- * @return {Array}            Array of point arrays.
- */
-export const visiblePointsSelector = createSelector(
-    currentVariablePointsSelector('current'),
-    currentVariablePointsSelector('compare'),
-    currentVariablePointsSelector('median'),
-    (state) => state.showSeries,
-    (current, compare, median, showSeries) => {
-        const pointArray = [];
-        if (showSeries['current']) {
-            Array.prototype.push.apply(pointArray, current);
-
-        }
-        if (showSeries['compare']) {
-            Array.prototype.push.apply(pointArray, compare);
-        }
-        if (showSeries['median']) {
-            Array.prototype.push.apply(pointArray, median);
-        }
-        return pointArray;
-    }
-);
 
 
 /**
@@ -277,207 +122,6 @@ export const isVisibleSelector = memoize(tsKey => (state) => {
     return state.showSeries[tsKey];
 });
 
-
-/**
- * Factory function creates a function that, for a given tsKey:
- * Returns all point data as an array of [value, time, qualifiers].
- * @param {Object} state - Redux store
- * @param {String} tsKey - timeseries key
- * @param {Array of Array} for each point returns [value, time, qualifiers] or empty array.
- */
-    //TODO: This needs to be changes to use point selector since it should be showing the data being displayed
-export const pointsTableDataSelector = memoize(tsKey => createSelector(
-    allTimeSeriesSelector,
-    (timeSeries) => {
-        return Object.keys(timeSeries).reduce((dataByTsID, tsID) => {
-            const series = timeSeries[tsID];
-            if (series.tsKey !== tsKey) {
-                return dataByTsID;
-            }
-
-            dataByTsID[tsID] = series.points.map((value) => {
-                return [
-                    value.value || '',
-                    value.dateTime || '',
-                    value.qualifiers && value.qualifiers.length > 0 ? value.qualifiers.join(', ') : ''
-                ];
-            });
-
-            return dataByTsID;
-        }, {});
-    }
-));
-
-const getLineClasses = function(pt) {
-    let dataMask = null;
-    if (pt.value === null) {
-        let qualifiers = new Set(pt.qualifiers.map(q => q.toLowerCase()));
-
-        // current business rules specify that a particular data point
-        // will only have at most one masking qualifier
-        let maskIntersection = Object.keys(MASK_DESC).filter(x => qualifiers.has(x));
-        dataMask = maskIntersection[0];
-    }
-    return {
-        ...classesForPoint(pt),
-        dataMask
-    };
-};
-
-const cumulativeLineSegments = function(series) {
-    const points = series.points;
-    // Accumulate data into line groups, splitting on the estimated and
-    // approval status.
-    const lines = [];
-    let lastClasses = {};
-    let accumulatedValue = 0;
-
-    for (const pt of points) {
-        // Classes to put on the line with this point.
-        let lineClasses = getLineClasses(pt);
-        if (lineClasses.dataMask) {
-            accumulatedValue = 0;
-        }
-        if (pt.value) {
-            accumulatedValue += pt.value;
-        }
-        let newPoint = {...pt, value: accumulatedValue};
-
-        // If this point doesn't have the same classes as the last point,
-        // create a new line for it.
-        if (lastClasses.approved !== lineClasses.approved ||
-            lastClasses.estimated !== lineClasses.estimated ||
-            lastClasses.dataMask !== lineClasses.dataMask) {
-            lines.push({
-                classes: lineClasses,
-                points: []
-            });
-        }
-
-        // Add this point to the current line.
-        lines[lines.length - 1].points.push(newPoint);
-
-        // Cache the classes for the next loop iteration.
-        lastClasses = lineClasses;
-    }
-    return lines;
-};
-
-
-/**
- * Factory function creates a function that:
- * Returns all points in a timeseries grouped into line segments, for each time series.
- * @param  {Object} state     Redux store
- * @param  {String} tsKey Timeseries key
- * @return {Array}            Array of array of points.
- */
-export const lineSegmentsSelector = memoize(tsKey => createSelector(
-    pointsByTsKeySelector(tsKey),
-    (tsPoints) => {
-        let seriesLines = {};
-        Object.keys(tsPoints).forEach((tsId) => {
-            const points = tsPoints[tsId]
-            let lines = [];
-
-            // Accumulate data into line groups, splitting on the estimated and
-            // approval status.
-            let lastClasses = {};
-
-            for (let pt of points) {
-                // Classes to put on the line with this point.
-                let lineClasses = getLineClasses(pt);
-
-                // If this is a non-masked data point, split lines if the gap
-                // from the period point exceeds MAX_LINE_POINT_GAP.
-                let splitOnGap = false;
-                if (!lineClasses.dataMask && lines.length > 0) {
-                    const lastPoints = lines[lines.length - 1].points;
-                    const lastPtDateTime = lastPoints[lastPoints.length - 1].dateTime;
-                    if (pt.dateTime - lastPtDateTime > MAX_LINE_POINT_GAP) {
-                        splitOnGap = true;
-                    }
-                }
-
-                // If this point doesn't have the same classes as the last point,
-                // create a new line for it.
-                if (lastClasses.approved !== lineClasses.approved ||
-                    lastClasses.estimated !== lineClasses.estimated ||
-                    lastClasses.dataMask !== lineClasses.dataMask ||
-                    splitOnGap) {
-                    lines.push({
-                        classes: lineClasses,
-                        points: []
-                    });
-                }
-
-                // Add this point to the current line.
-                lines[lines.length - 1].points.push(pt);
-
-                // Cache the classes for the next loop iteration.
-                lastClasses = lineClasses;
-            }
-            seriesLines[tsId] = lines;
-        });
-        return seriesLines;
-    }
-));
-
-
-/**
- * Factory function creates a function that, for a given tsKey:
- * @return {Object}     Mapping of parameter to code list of line segments arrays.
- */
-export const lineSegmentsByParmCdSelector = memoize(tsKey => createSelector(
-    lineSegmentsSelector(tsKey),
-    timeSeriesSelector(tsKey),
-    variablesSelector,
-    (lineSegmentsBySeriesID, timeSeriesMap, variables) => {
-        return Object.keys(lineSegmentsBySeriesID).reduce((byVarID, sID) => {
-            const series = timeSeriesMap[sID];
-            const parmCd = variables[series.variable].variableCode.value;
-            byVarID[parmCd] = byVarID[parmCd] || [];
-            byVarID[parmCd].push(lineSegmentsBySeriesID[sID]);
-            return byVarID;
-        }, {});
-    }
-));
-
-
-/**
- * Factory function creates a function that, for a given tsKey:
- * Returns mapping of time series IDs to series for the current variable.
- * @return {Object}
- */
-const currentVariableTimeseriesSelector = memoize(tsKey => createSelector(
-    timeSeriesSelector(tsKey),
-    currentVariableSelector,
-    (seriesMap, variable) => {
-        return Object.keys(seriesMap).filter(
-                sID => seriesMap[sID].variable === variable.oid).reduce((curMap, sID) => {
-            curMap[sID] = seriesMap[sID];
-            return curMap;
-        }, {});
-    }
-));
-
-
-/**
- * Factory function creates a function that, for a given tsKey:
- * Returns mapping of series ID to line segments for the currently selected variable.
- * @return {Object}
- */
-export const currentVariableLineSegmentsSelector = memoize(tsKey => createSelector(
-    currentVariableTimeseriesSelector(tsKey),
-    lineSegmentsSelector(tsKey),
-    (seriesMap, linesMap) => {
-        const result = Object.keys(seriesMap).reduce((visMap, sID) => {
-                visMap[sID] = linesMap[sID];
-                return visMap;
-            }, {});
-        return result;
-
-    }
-));
 
 
 /**
@@ -500,7 +144,7 @@ export const titleSelector = createSelector(
 
 /**
  * @return {String}     Description for the currently display set of time
- *                      series, used by addSVGAccessibility.
+ *                      series
  */
 export const descriptionSelector = createSelector(
     currentVariableSelector,

--- a/assets/src/scripts/components/hydrograph/timeseries.spec.js
+++ b/assets/src/scripts/components/hydrograph/timeseries.spec.js
@@ -1,5 +1,5 @@
-const { variablesSelector, currentVariableSelector, timeSeriesSelector, isVisibleSelector,
-    currentVariableTimeSeriesSelector, allTimeSeriesSelector } = require('./timeseries');
+const { variablesSelector, currentVariableSelector, timeSeriesSelector, isVisibleSelector, yLabelSelector,
+    titleSelector, descriptionSelector, currentVariableTimeSeriesSelector, allTimeSeriesSelector } = require('./timeseries');
 
 
 const TEST_DATA = {
@@ -7,6 +7,9 @@ const TEST_DATA = {
         timeSeries: {
             '00060': {
                 tsKey: 'current',
+                startTime: new Date('2018-03-06T15:45:00.000Z'),
+                endTime: new Date('2018-03-13t13:45:00.000Z'),
+                variable: '45807197',
                 points: [{
                     value: 10,
                     qualifiers: ['P'],
@@ -24,8 +27,11 @@ const TEST_DATA = {
                     estimated: false
                 }]
             },
-            '000010': {
+            '00010': {
                 tsKey: 'compare',
+                startTime: new Date('2017-03-06T15:45:00.000Z'),
+                endTime: new Date('2017-03-13t13:45:00.000Z'),
+                variables: '45807196',
                 points: [{
                     value: 1,
                     qualifiers: ['P'],
@@ -57,14 +63,22 @@ const TEST_DATA = {
         variables: {
             '45807197': {
                 variableCode: '00060',
-                oid: 45807197
+                variableName: 'Streamflow',
+                variableDescription: 'Discharge, cubic feet per second',
+                oid: '45807197'
+            },
+            '45807196': {
+                variableCode: '00010',
+                variableName: 'Gage Height',
+                variableDescription: 'Gage Height in feet',
+                oid: '45807196'
             }
         }
     },
     currentVariableID: '45807197'
 };
 
-fdescribe('Timeseries module', () => {
+describe('Timeseries module', () => {
 
     const TEST_VARIABLES = {
             '45807042': {
@@ -261,6 +275,8 @@ fdescribe('Timeseries module', () => {
             expect(timeSeriesSelector('current')(TEST_DATA)).toEqual({
                 '00060': {
                     tsKey: 'current',
+                    startTime: new Date('2018-03-06T15:45:00.000Z'),
+                    endTime: new Date('2018-03-13t13:45:00.000Z'),
                     points: [{
                         value: 10,
                         qualifiers: ['P'],
@@ -276,7 +292,8 @@ fdescribe('Timeseries module', () => {
                         qualifiers: ['P', 'FLD'],
                         approved: false,
                         estimated: false
-                    }]
+                    }],
+                    variable: '45807197'
                 }
             });
         });
@@ -299,6 +316,41 @@ fdescribe('Timeseries module', () => {
             expect(isVisibleSelector('current')(store)).toBe(true);
             expect(isVisibleSelector('compare')(store)).toBe(false);
             expect(isVisibleSelector('median')(store)).toBe(true);
+        });
+    });
+
+    describe('yLabelSelector', () => {
+        it('Returns string to be used for labeling the y axis', () => {
+            expect(yLabelSelector(TEST_DATA)).toBe('Discharge, cubic feet per second');
+        });
+
+        it('Returns empty string if no variable selected', () => {
+            expect(yLabelSelector({
+                ...TEST_DATA,
+                currentVariableID: null
+            })).toBe('');
+        });
+    });
+
+    describe('titleSelector', () => {
+        it('Returns the string to used for graph title', () => {
+            expect(titleSelector(TEST_DATA)).toBe('Streamflow');
+        });
+        it('Returns empty string if no variable selected', () => {
+            expect(titleSelector({
+                ...TEST_DATA,
+                currentVariableID: null
+            })).toBe('');
+        });
+    });
+
+    describe('descriptionSelector', () => {
+        it('Returns a description with the date for the current times series', () => {
+            const result = descriptionSelector(TEST_DATA);
+
+            expect(result).toContain('Discharge, cubic feet per second');
+            expect(result).toContain('3/6/2018');
+            expect(result).toContain('3/13/2018');
         });
     });
 });

--- a/assets/src/scripts/components/hydrograph/timeseries.spec.js
+++ b/assets/src/scripts/components/hydrograph/timeseries.spec.js
@@ -9,7 +9,7 @@ const TEST_DATA = {
             '00060': {
                 tsKey: 'current',
                 startTime: new Date('2018-03-06T15:45:00.000Z'),
-                endTime: new Date('2018-03-13t13:45:00.000Z'),
+                endTime: new Date('2018-03-13T13:45:00.000Z'),
                 variable: '45807197',
                 points: [{
                     value: 10,
@@ -289,7 +289,7 @@ describe('Timeseries module', () => {
                 '00060': {
                     tsKey: 'current',
                     startTime: new Date('2018-03-06T15:45:00.000Z'),
-                    endTime: new Date('2018-03-13t13:45:00.000Z'),
+                    endTime: new Date('2018-03-13T13:45:00.000Z'),
                     points: [{
                         value: 10,
                         qualifiers: ['P'],

--- a/assets/src/scripts/components/hydrograph/timeseries.spec.js
+++ b/assets/src/scripts/components/hydrograph/timeseries.spec.js
@@ -1,6 +1,6 @@
-const { lineSegmentsSelector, pointsSelector,
-    currentVariableTimeSeriesSelector, pointsTableDataSelector, allTimeSeriesSelector, requestTimeRangeSelector
-    MAX_LINE_POINT_GAP } = require('./timeseries');
+const { variablesSelector, currentVariableSelector, timeSeriesSelector, isVisibleSelector, yLabelSelector,
+    titleSelector, descriptionSelector, currentVariableTimeSeriesSelector, allTimeSeriesSelector,
+    requestTimeRangeSelector} = require('./timeseries');
 
 
 const TEST_DATA = {
@@ -73,6 +73,18 @@ const TEST_DATA = {
                 variableName: 'Gage Height',
                 variableDescription: 'Gage Height in feet',
                 oid: '45807196'
+            }
+        },
+        queryInfo: {
+            current: {
+                notes: {
+                    requestDT: new Date('2017-01-09T20:46:07.542Z'),
+                    'filter:timeRange': {
+                        mode: 'PERIOD',
+                        periodDays: 7,
+                        modifiedSince: null
+                    }
+                }
             }
         }
     },
@@ -350,8 +362,8 @@ describe('Timeseries module', () => {
             const result = descriptionSelector(TEST_DATA);
 
             expect(result).toContain('Discharge, cubic feet per second');
-            expect(result).toContain('3/6/2018');
-            expect(result).toContain('3/13/2018');
+            expect(result).toContain('1/2/2017');
+            expect(result).toContain('1/9/2017');
         });
     });
 
@@ -375,7 +387,7 @@ describe('Timeseries module', () => {
             })).toEqual({
                 current: {
                     start: new Date('2017-01-02T20:46:07.542Z'),
-                    end: new Date('2017-01-09T20:46:07.542Z'),
+                    end: new Date('2017-01-09T20:46:07.542Z')
                 }
             });
         });

--- a/assets/src/scripts/components/hydrograph/tooltip.js
+++ b/assets/src/scripts/components/hydrograph/tooltip.js
@@ -7,7 +7,7 @@ const { createSelector, createStructuredSelector } = require('reselect');
 
 const { dispatch, link } = require('../../lib/redux');
 
-const { classesForPoint, currentVariableSelector, pointsSelector, MASK_DESC } = require('./timeseries');
+const { classesForPoint, currentVariableSelector, currentVariablePointsSelector, MASK_DESC } = require('./timeseries');
 const { Actions } = require('../../store');
 
 const formatTime = timeFormat('%b %-d, %Y, %-I:%M:%S %p');
@@ -89,7 +89,7 @@ const tooltipFocusTimeSelector = memoize(tsKey => createSelector(
  * @return {Object}
  */
 export const tsDatumSelector = memoize(tsKey => createSelector(
-    pointsSelector(tsKey),
+    currentVariablePointsSelector(tsKey),
     tooltipFocusTimeSelector(tsKey),
     (points, tooltipFocusTime) => {
         // FIXME: Handle more than just the first time series in the list

--- a/assets/src/scripts/components/hydrograph/tooltip.js
+++ b/assets/src/scripts/components/hydrograph/tooltip.js
@@ -7,7 +7,8 @@ const { createSelector, createStructuredSelector } = require('reselect');
 
 const { dispatch, link } = require('../../lib/redux');
 
-const { classesForPoint, currentVariableSelector, currentVariablePointsSelector, MASK_DESC } = require('./timeseries');
+const { classesForPoint, currentVariablePointsSelector, MASK_DESC } = require('./drawingData');
+const { currentVariableSelector } = require('./timeseries');
 const { Actions } = require('../../store');
 
 const formatTime = timeFormat('%b %-d, %Y, %-I:%M:%S %p');

--- a/assets/src/scripts/models.js
+++ b/assets/src/scripts/models.js
@@ -41,7 +41,11 @@ export function getTimeseries({sites, params=null, startDate=null, endDate=null}
         serviceRoot = tsServiceRoot(startDate);
     }
     let paramCds = params !== null ? `&parameterCd=${params.join(',')}` : '';
+
     let url = `${serviceRoot}/iv/?sites=${sites.join(',')}${paramCds}&${timeParams}&indent=on&siteStatus=all&format=json`;
+    if (sites.length === 1 && sites[0] === '02335700') {
+        url = 'http://localhost:9000/img/02335700_precip.json';
+    }
     return get(url)
         .then(response => JSON.parse(response))
         .catch(reason => {

--- a/assets/src/scripts/models.js
+++ b/assets/src/scripts/models.js
@@ -43,9 +43,6 @@ export function getTimeseries({sites, params=null, startDate=null, endDate=null}
     let paramCds = params !== null ? `&parameterCd=${params.join(',')}` : '';
 
     let url = `${serviceRoot}/iv/?sites=${sites.join(',')}${paramCds}&${timeParams}&indent=on&siteStatus=all&format=json`;
-    if (sites.length === 1 && sites[0] === '02335700') {
-        url = 'http://localhost:9000/img/02335700_precip.json';
-    }
     return get(url)
         .then(response => JSON.parse(response))
         .catch(reason => {


### PR DESCRIPTION
Refactored so that timeseries.js includes selectors that return information about timeseries without manipulating the points for display. The module drawingData contains selectors where the points are modified and the selectors for the line segments.