### PR TITLE
WDFN-185 - Fix left margin sizing issues

### DIFF
--- a/assets/src/scripts/components/hydrograph/axes.js
+++ b/assets/src/scripts/components/hydrograph/axes.js
@@ -1,28 +1,14 @@
-const { ticks } = require('d3-array');
 const { axisBottom, axisLeft } = require('d3-axis');
-const { format } = require('d3-format');
 const { timeDay } = require('d3-time');
 const { timeFormat } = require('d3-time-format');
 const { createSelector } = require('reselect');
 
 const { wrap } = require('../../utils');
 
+const { getYTickDetails } = require('./domain');
 const { layoutSelector } = require('./layout');
 const { xScaleSelector, yScaleSelector } = require('./scales');
 const { yLabelSelector } = require('./timeseries');
-
-const Y_TICK_COUNT = 5;
-
-
-/**
- * Helper function which generates y tick values for a scale
- * @param {Object} yScale - d3 scale
- * @returns {Array} of tick values
- */
-function yTickValues(yScale) {
-    const yDomain = yScale.domain();
-    return ticks(yDomain[0], yDomain[1], Y_TICK_COUNT);
-}
 
 
 /**
@@ -41,14 +27,11 @@ function createAxes({xScale, yScale}, yTickSize) {
         .tickSizeOuter(0);
 
     // Create y-axis
-    const tickValues = yTickValues(yScale);
-    // If all ticks are integers, don't display right of the decimal place.
-    // Otherwise, format with two decimal points.
-    const tickFormat = tickValues.filter(t => !Number.isInteger(t)).length ? '.2f' : 'd';
+    const tickDetails = getYTickDetails(yScale.domain());
     const yAxis = axisLeft()
         .scale(yScale)
-        .tickValues(tickValues)
-        .tickFormat(format(tickFormat))
+        .tickValues(tickDetails.tickValues)
+        .tickFormat(tickDetails.tickFormat)
         .tickSizeInner(yTickSize)
         .tickPadding(3)
         .tickSizeOuter(0);

--- a/assets/src/scripts/components/hydrograph/domain.js
+++ b/assets/src/scripts/components/hydrograph/domain.js
@@ -1,0 +1,113 @@
+const { extent, ticks } = require('d3-array');
+const { format } = require('d3-format');
+const { createSelector } = require('reselect');
+
+const { currentVariableSelector } = require('./timeseries');
+const { visiblePointsSelector } = require('./drawingData');
+
+
+const PADDING_RATIO = 0.2;
+const Y_TICK_COUNT = 5;
+// array of parameters that should use
+// a symlog scale instead of a linear scale
+const SYMLOG_PARMS = [
+    '00060',
+    '72137'
+];
+
+
+/**
+ *  Return domain padded on both ends by paddingRatio.
+ *  For positive domains, a zero-lower bound on the y-axis is enforced.
+ *  @param {Array} domain - array of two numbers
+ *  @return {Array} - array of two numbers
+ */
+export const extendDomain = function (domain, lowerBoundPOW10) {
+    const isPositive = domain[0] >= 0 && domain[1] >= 0;
+    let extendedDomain;
+
+    // Pad domains on both ends by PADDING_RATIO.
+    const padding = PADDING_RATIO * (domain[1] - domain[0]);
+    extendedDomain = [
+        domain[0] - padding,
+        domain[1] + padding
+    ];
+
+    // Log scales lower-bounded by nearest power of 10 (10, 100, 1000, etc)
+    if (lowerBoundPOW10) {
+        extendedDomain = [
+            isPositive ? Math.pow(10, Math.floor(Math.log10(domain[0]))) : domain[0],
+            extendedDomain[1]
+        ];
+    }
+
+    // For positive domains, a zero-lower bound on the y-axis is enforced.
+    return [
+        isPositive ? Math.max(0, extendedDomain[0]) : extendedDomain[0],
+        extendedDomain[1]
+    ];
+};
+
+
+export const getYDomain = function (pointArrays, currentVar) {
+    let yExtent;
+    let scaleDomains = [];
+
+    let currentVarParmCd = currentVar && currentVar.variableCode ? currentVar.variableCode.value : null;
+
+    // Calculate max and min for data
+    for (const points of pointArrays) {
+        if (points.length === 0) {
+            continue;
+        }
+        scaleDomains.push(extent(points, d => d.value));
+    }
+    if (scaleDomains.length > 0) {
+        const flatDomains = [].concat(...scaleDomains).filter(val => isFinite(val));
+        if (flatDomains.length > 0) {
+            yExtent = [Math.min(...flatDomains), Math.max(...flatDomains)];
+        }
+    }
+    // Add padding to the extent and handle empty data sets.
+    if (yExtent) {
+        yExtent = extendDomain(yExtent, SYMLOG_PARMS.indexOf(currentVarParmCd) > -1);
+    } else {
+        yExtent = [0, 1];
+    }
+
+    return yExtent;
+};
+
+
+export const yDomainSelector = createSelector(
+    visiblePointsSelector,
+    currentVariableSelector,
+    getYDomain
+);
+
+
+/**
+ * Helper function which generates y tick values for a scale
+ * @param {Object} yScale - d3 scale
+ * @returns {Array} of tick values
+ */
+export const getYTickDetails = function (yDomain) {
+    const tickValues = ticks(yDomain[0], yDomain[1], Y_TICK_COUNT);
+    // If all ticks are integers, don't display right of the decimal place.
+    // Otherwise, format with two decimal points.
+    const tickFormat = tickValues.filter(t => !Number.isInteger(t)).length ? '.2f' : 'd';
+    return {
+        tickValues,
+        tickFormat: format(tickFormat)
+    };
+};
+
+
+export const tickSelector = createSelector(
+    visiblePointsSelector,
+    currentVariableSelector,
+    (pointArrays, currentVariable) => {
+        const yDomain = getYDomain(pointArrays, currentVariable);
+        return getYTickDetails(yDomain);
+    }
+);

--- a/assets/src/scripts/components/hydrograph/domain.js
+++ b/assets/src/scripts/components/hydrograph/domain.js
@@ -60,7 +60,8 @@ export const getYDomain = function (pointArrays, currentVar) {
         if (points.length === 0) {
             continue;
         }
-        scaleDomains.push(extent(points, d => d.value));
+        const finitePts = points.map(pt => pt.value).filter(val => isFinite(val));
+        scaleDomains.push(extent(finitePts));
     }
     if (scaleDomains.length > 0) {
         const flatDomains = [].concat(...scaleDomains).filter(val => isFinite(val));

--- a/assets/src/scripts/components/hydrograph/domain.spec.js
+++ b/assets/src/scripts/components/hydrograph/domain.spec.js
@@ -1,4 +1,4 @@
-const { extendDomain } = require('./domain');
+const { extendDomain, getYDomain, getYTickDetails } = require('./domain');
 
 
 describe('domain module', () => {
@@ -35,6 +35,52 @@ describe('domain module', () => {
             domain = [-9000, 10000];
             padding = (domain[1] - domain[0]) * .2;
             expect(extendDomain(domain, false)).toEqual([domain[0] - padding, domain[1] + padding]);
+        });
+    });
+
+    describe('getYDomain', () => {
+        function pts(arr) {
+            return arr.map(val => {
+                return {
+                    value: val
+                };
+            });
+        }
+
+        it('is inclusive to all points with symlog', () => {
+            const domain = getYDomain(
+                [pts([1, 2, 3]), pts([5, 6, 7]), pts([-10, 2])],
+                {variableCode: {value: '00060'}}
+            );
+            expect(domain[0]).toBeLessThanOrEqual(-10);
+            expect(domain[1]).toBeGreaterThanOrEqual(7);
+        });
+
+        it('is inclusive to all points with linear', () => {
+            const domain = getYDomain(
+                [pts([1, 2, 3]), pts([5, 6, 7]), pts([-10, 2])],
+                {variableCode: {value: '00065'}}
+            );
+            expect(domain[0]).toBeLessThanOrEqual(-10);
+            expect(domain[1]).toBeGreaterThanOrEqual(7);
+        });
+
+        it('ignores non-finite values', () => {
+            const domain = getYDomain(
+                [pts([-Infinity, NaN, 1, 2, 3, Infinity])],
+                {variableCode: {value: '00065'}}
+            );
+            const padding = (3 - 1) * .2;
+            expect(domain).toEqual([1 - padding, 3 + padding]);
+        });
+    });
+
+    describe('getYTickDetails', () => {
+        it('returns ticks and a formatting function', () => {
+            const tickDetails = getYTickDetails([0, 1]);
+            expect(tickDetails.tickValues).toEqual(jasmine.any(Array));
+            expect(tickDetails.tickFormat).toEqual(jasmine.any(Function));
+            expect(tickDetails.tickFormat(1)).toEqual(jasmine.any(String));
         });
     });
 });

--- a/assets/src/scripts/components/hydrograph/domain.spec.js
+++ b/assets/src/scripts/components/hydrograph/domain.spec.js
@@ -1,0 +1,40 @@
+const { extendDomain } = require('./domain');
+
+
+describe('domain module', () => {
+    describe('extendDomain', () => {
+        it('lower bounds on nearest power of 10 with symlog parameter, upper bound 20%', () => {
+            expect(extendDomain([50, 1000], true)).toEqual([10, 1000 + (1000 - 50) * .2]);
+            expect(extendDomain([175, 1000], true)).toEqual([100, 1000 + (1000 - 175) * .2]);
+            expect(extendDomain([9000, 10000], true)).toEqual([1000, 10000 + (10000 - 9000) * .2]);
+        });
+
+        it('20% padding on linear scales, zero lower bound', () => {
+            let domain = [50, 1000];
+            let padding = (domain[1] - domain[0]) * .2;
+            expect(extendDomain(domain, false)).toEqual([0, domain[1] + padding]);
+
+            domain = [175, 1000];
+            padding = (domain[1] - domain[0]) * .2;
+            expect(extendDomain(domain, false)).toEqual([domain[0] - padding, domain[1] + padding]);
+
+            domain = [9000, 10000];
+            padding = (domain[1] - domain[0]) * .2;
+            expect(extendDomain(domain, false)).toEqual([domain[0] - padding, domain[1] + padding]);
+        });
+
+        it('20% padding on linear scales with negative lower bound', () => {
+            let domain = [-50, 1000];
+            let padding = (domain[1] - domain[0]) * .2;
+            expect(extendDomain(domain, false)).toEqual([domain[0] - padding, domain[1] + padding]);
+
+            domain = [-175, 1000];
+            padding = (domain[1] - domain[0]) * .2;
+            expect(extendDomain(domain, false)).toEqual([domain[0] - padding, domain[1] + padding]);
+
+            domain = [-9000, 10000];
+            padding = (domain[1] - domain[0]) * .2;
+            expect(extendDomain(domain, false)).toEqual([domain[0] - padding, domain[1] + padding]);
+        });
+    });
+});

--- a/assets/src/scripts/components/hydrograph/drawingData.js
+++ b/assets/src/scripts/components/hydrograph/drawingData.js
@@ -1,6 +1,6 @@
 const memoize = require('fast-memoize');
 const { createSelector } = require('reselect');
-const { format } = require('d3-format')
+const { format } = require('d3-format');
 
 const {allTimeSeriesSelector, currentVariableTimeSeriesSelector, timeSeriesSelector, variablesSelector } = require('./timeseries');
 

--- a/assets/src/scripts/components/hydrograph/layout.js
+++ b/assets/src/scripts/components/hydrograph/layout.js
@@ -45,7 +45,7 @@ const layoutSelector = createSelector(
     (width, windowWidth, tickDetails) => {
         const margin = mediaQuery(USWDS_SITE_MAX_WIDTH) ? MARGIN : MARGIN_SMALL_DEVICE;
         const tickLengths = tickDetails.tickValues.map(v => tickDetails.tickFormat(v).length);
-        const approxLabelLength = Math.max.apply(null, tickLengths) * 10;
+        const approxLabelLength = Math.max(...tickLengths) * 10;
         return {
             width: width,
             height: width * ASPECT_RATIO,

--- a/assets/src/scripts/components/hydrograph/layout.js
+++ b/assets/src/scripts/components/hydrograph/layout.js
@@ -4,6 +4,9 @@ const { createSelector } = require('reselect');
 
 const { mediaQuery } = require('../../utils');
 
+const { tickSelector } = require('./domain');
+
+
 // The point at which mobile/desktop layout changes take effect.
 // This is defined as $site-max-width in USWDS.
 const USWDS_SITE_MAX_WIDTH = 1040;
@@ -14,13 +17,13 @@ const MARGIN = {
     top: 25,
     right: 0,
     bottom: 10,
-    left: 80
+    left: 45
 };
 const MARGIN_SMALL_DEVICE = {
     top: 25,
     right: 0,
     bottom: 10,
-    left: 35
+    left: 0
 };
 const CIRCLE_RADIUS = 4;
 const CIRCLE_RADIUS_SINGLE_PT = 1;
@@ -38,12 +41,19 @@ const SPARK_LINE_DIM = {
 const layoutSelector = createSelector(
     (state) => state.width,
     (state) => state.windowWidth,
-    (width, windowWidth) => {
+    tickSelector,
+    (width, windowWidth, tickDetails) => {
+        const margin = mediaQuery(USWDS_SITE_MAX_WIDTH) ? MARGIN : MARGIN_SMALL_DEVICE;
+        const tickLengths = tickDetails.tickValues.map(v => tickDetails.tickFormat(v).length);
+        const approxLabelLength = Math.max.apply(null, tickLengths) * 10;
         return {
             width: width,
             height: width * ASPECT_RATIO,
             windowWidth: windowWidth,
-            margin: mediaQuery(USWDS_SITE_MAX_WIDTH) ? MARGIN : MARGIN_SMALL_DEVICE
+            margin: {
+                ...margin,
+                left: margin.left + approxLabelLength
+            }
         };
     }
 );

--- a/assets/src/scripts/components/hydrograph/layout.spec.js
+++ b/assets/src/scripts/components/hydrograph/layout.spec.js
@@ -1,9 +1,26 @@
+const proxyquire = require('proxyquireify')(require);
+const { format } = require('d3-format');
 
-const { layoutSelector, ASPECT_RATIO } = require('./layout');
+const { ASPECT_RATIO } = require('./layout');
+
 
 describe('points module', () => {
+    let layoutMock = proxyquire('./layout', {
+        './domain': {
+            tickSelector: () => {
+                return {
+                    tickValues: [5, 10, 15],
+                    tickFormat: format('d')
+                };
+            }
+        }
+    });
+
     it('Should return the width and height with the predefined ASPECT_RATIO', () => {
-        let layout = layoutSelector({width: 200, windowWidth: 600});
+        let layout = layoutMock.layoutSelector({
+            width: 200,
+            windowWidth: 600
+        });
         expect(layout.width).toEqual(200);
         expect(layout.height).toEqual(200 * ASPECT_RATIO);
         expect(layout.windowWidth).toEqual(600);

--- a/assets/src/scripts/components/hydrograph/scales.spec.js
+++ b/assets/src/scripts/components/hydrograph/scales.spec.js
@@ -1,27 +1,27 @@
-const { createXScale, createYScale, singleSeriesYScale, yScaleSelector, extendDomain } = require('./scales');
+const { extent } = require('d3-array');
+
+const { createXScale, createYScale, yScaleSelector } = require('./scales');
 
 
 describe('Charting scales', () => {
-    let points = Array(23).fill(0).map((_, hour) => {
+    const points = Array(23).fill(0).map((_, hour) => {
         return {
             dateTime: new Date(2017, 10, 10, hour, 0, 0, 0),
             value: hour
         };
     });
+    const yDomain = extent(points.map(p => p.value));
     const xDomain = {
         start: points[0].dateTime,
         end: points[points.length - 1].dateTime
     };
-    let xScale = createXScale(xDomain, 200);
-    let yScale = createYScale('00060', [points], 100);
-    let yScaleLinear = createYScale('ABCDE', [points], 100);
-    let singleYScale = singleSeriesYScale('00060', points, 100);
-    let singleYScaleLinear = singleSeriesYScale('ABCDE', points, 100);
+    const xScale = createXScale(xDomain, 200);
+    const yScale = createYScale('00060', yDomain, 100);
+    const yScaleLinear = createYScale('ABCDE', yDomain, 100);
 
     it('scales created', () => {
         expect(xScale).toEqual(jasmine.any(Function));
         expect(yScale).toEqual(jasmine.any(Function));
-        expect(singleYScale).toEqual(jasmine.any(Function));
     });
 
     it('xScale domain is correct', () => {
@@ -42,12 +42,6 @@ describe('Charting scales', () => {
         expect(range[1]).toEqual(0);
     });
 
-    it('singleYscale range is correctly right-oriented', () => {
-        let range = singleYScale.range();
-        expect(range[0]).toEqual(100);
-        expect(range[1]).toEqual(0);
-    });
-
     it('WDFN-66: yScale deals with range [0,1] correctly', () => {
         expect(yScale(1)).not.toBeNaN();
         expect(yScale(.5)).not.toBeNaN();
@@ -60,9 +54,9 @@ describe('Charting scales', () => {
         const log100 = yScale(100);
         const log1000 = yScale(1000);
 
-        const singleLog10 = singleYScale(10);
-        const singleLog100 = singleYScale(100);
-        const singleLog1000 = singleYScale(1000);
+        const singleLog10 = yScale(10);
+        const singleLog100 = yScale(100);
+        const singleLog1000 = yScale(1000);
 
         expect(log10 - log100).toBeCloseTo(log100 - log1000);
         expect(singleLog10 - singleLog100).toBeCloseTo(singleLog100 - singleLog1000);
@@ -73,9 +67,9 @@ describe('Charting scales', () => {
         const linear20 = yScaleLinear(20);
         const linear30 = yScaleLinear(30);
 
-        const singleLinear10 = singleYScaleLinear(10);
-        const singleLinear20 = singleYScaleLinear(20);
-        const singleLinear30 = singleYScaleLinear(30);
+        const singleLinear10 = yScaleLinear(10);
+        const singleLinear20 = yScaleLinear(20);
+        const singleLinear30 = yScaleLinear(30);
 
         expect(linear10 - linear20).toBeCloseTo(linear20 - linear30);
         expect(singleLinear10 - singleLinear20).toBeCloseTo(singleLinear20 - singleLinear30);
@@ -112,42 +106,6 @@ describe('Charting scales', () => {
                 width: 200,
                 windowWidth: 600
             }).name).toBe('scale');
-        });
-    });
-
-    describe('extendDomain', () => {
-        it('lower bounds on nearest power of 10 with symlog parameter, upper bound 20%', () => {
-            expect(extendDomain([50, 1000], '00060')).toEqual([10, 1000 + (1000 - 50) * .2]);
-            expect(extendDomain([175, 1000], '00060')).toEqual([100, 1000 + (1000 - 175) * .2]);
-            expect(extendDomain([9000, 10000], '00060')).toEqual([1000, 10000 + (10000 - 9000) * .2]);
-        });
-
-        it('20% padding on linear scales, zero lower bound', () => {
-            let domain = [50, 1000];
-            let padding = (domain[1] - domain[0]) * .2;
-            expect(extendDomain(domain, '00065')).toEqual([0, domain[1] + padding]);
-
-            domain = [175, 1000];
-            padding = (domain[1] - domain[0]) * .2;
-            expect(extendDomain(domain, '00065')).toEqual([domain[0] - padding, domain[1] + padding]);
-
-            domain = [9000, 10000];
-            padding = (domain[1] - domain[0]) * .2;
-            expect(extendDomain(domain, '00065')).toEqual([domain[0] - padding, domain[1] + padding]);
-        });
-
-        it('20% padding on linear scales with negative lower bound', () => {
-            let domain = [-50, 1000];
-            let padding = (domain[1] - domain[0]) * .2;
-            expect(extendDomain(domain, '00065')).toEqual([domain[0] - padding, domain[1] + padding]);
-
-            domain = [-175, 1000];
-            padding = (domain[1] - domain[0]) * .2;
-            expect(extendDomain(domain, '00065')).toEqual([domain[0] - padding, domain[1] + padding]);
-
-            domain = [-9000, 10000];
-            padding = (domain[1] - domain[0]) * .2;
-            expect(extendDomain(domain, '00065')).toEqual([domain[0] - padding, domain[1] + padding]);
         });
     });
 });


### PR DESCRIPTION
Move domain code out of scales.js into domain.js, so we can import it in layout.js without circular dependencies. Use the tick labels to calculate the necessary left margin size.

I'm not 100% happy with this, but it does fix the margin issue...

I had also looked into creating a margin.js module separate from layout.js, but that produces circular dependencies on axes.js.

If we moved the rendering code out of axes.js into index.js, that might move things a bit closer. However, we currently need both margin and layout info to create the scales, which would in turn be needed to create the margins.

Perhaps a proper solution includes making the scale ranges solely a function of the browser width (and not the margins). But that might have larger implications that I don't want to deal with as a part of this.
