### PR TITLE
Wdfn 218 - make Provisional/approved more blatant

### DIFF
--- a/assets/src/scripts/components/hydrograph/index.spec.js
+++ b/assets/src/scripts/components/hydrograph/index.spec.js
@@ -316,19 +316,19 @@ describe('Hydrograph charting module', () => {
                 .call(timeSeriesLegend);
         });
 
-        it('Should have three legend markers', () => {
-            expect(selectAll('g.legend-marker').size()).toBe(3);
+        it('Should have 6 legend markers', () => {
+            expect(selectAll('.legend g').size()).toBe(6);
         });
 
-        it('Should have two legend markers after the compare time series is removed', () => {
+        it('Should have four legend markers after the compare time series is removed', () => {
             store.dispatch(Actions.toggleTimeseries('compare', false));
-            expect(selectAll('g.legend-marker').size()).toBe(2);
+            expect(selectAll('.legend g').size()).toBe(4);
         });
 
-        it('Should have one legend marker after the compare and median time series are removed', () => {
+        it('Should have two legend marker after the compare and median time series are removed', () => {
             store.dispatch(Actions.toggleTimeseries('compare', false));
             store.dispatch(Actions.toggleTimeseries('median', false));
-            expect(selectAll('g.legend-marker').size()).toBe(1);
+            expect(selectAll('.legend g').size()).toBe(2);
         });
     });
 

--- a/assets/src/scripts/components/hydrograph/legend.js
+++ b/assets/src/scripts/components/hydrograph/legend.js
@@ -148,7 +148,7 @@ export const drawSimpleLegend = function(div, {legendMarkerRows, layout}) {
                 xPosition = markerGroupBBox.x + markerGroupBBox.width + markerGroupXOffset;
 
             } catch(error) {
-                console.log('Group bbox error on ' + marker.text);
+                null;
             }
         });
     });

--- a/assets/src/scripts/components/hydrograph/legend.js
+++ b/assets/src/scripts/components/hydrograph/legend.js
@@ -28,13 +28,13 @@ const tsLineMarkers = function(tsKey, lineClasses) {
     let result = [];
 
     if (lineClasses.default) {
-        result.push(defineLineMarker(`ts-legend-${tsKey}-default`, 'line-segment', 'Provisional', GROUP_ID));
+        result.push(defineLineMarker(null, `line-segment ts-${tsKey}`, 'Provisional', GROUP_ID));
     }
     if (lineClasses.approved) {
-        result.push(defineLineMarker(`ts-legend-${tsKey}-approved`, 'line-segment approved', 'Approved', GROUP_ID));
+        result.push(defineLineMarker(null, `line-segment approved ts-${tsKey}`, 'Approved', GROUP_ID));
     }
     if (lineClasses.estimated) {
-        result.push(defineLineMarker(`ts-legend-${tsKey}-estinated`, 'line-segment estimated', 'Estimated', GROUP_ID));
+        result.push(defineLineMarker(null, `line-segment estimated ts-${tsKey}`, 'Estimated', GROUP_ID));
     }
     return result;
 };
@@ -114,10 +114,8 @@ function drawSimpleLegend(div, {legendMarkerRows, layout}) {
         return;
     }
 
-    const markerYPosition = -4;
     const markerGroupXOffset = 15;
     const verticalRowOffset = 18;
-    const markerTextXOffset = 6;
 
     let svg = div.append('svg')
         .attr('class', 'legend-svg');

--- a/assets/src/scripts/components/hydrograph/legend.js
+++ b/assets/src/scripts/components/hydrograph/legend.js
@@ -19,7 +19,7 @@ const tsMaskMarkers = function(tsKey, masks) {
         const maskName = MASK_DESC[mask];
         const tsClass = `${maskName.replace(' ', '-').toLowerCase()}-mask`;
         const fill = `url(#${HASH_ID[tsKey]})`;
-        return defineRectangleMarker(null, `mask ${tsClass}`, maskName, null, fill);
+        return defineRectangleMarker(null, `mask ${tsClass}`, maskName, fill);
     });
 };
 

--- a/assets/src/scripts/components/hydrograph/legend.js
+++ b/assets/src/scripts/components/hydrograph/legend.js
@@ -142,6 +142,15 @@ export const drawSimpleLegend = function(div, {legendMarkerRows, layout}) {
             };
             let markerGroup = marker.type(legend, markerArgs);
             let markerGroupBBox;
+            // Long story short, firefox is unable to get the bounding box if
+            // the svg element isn't actually taking up space and visible. Folks on the
+            // internet seem to have gotten around this by setting `visibility:hidden`
+            // to hide things, but that would still mean the elements will take up space.
+            // which we don't want. So, here's some error handling for getBBox failures.
+            // This handling ends up not creating the legend, but that's okay because the
+            // graph is being shown anyway. A more detailed discussion of this can be found at:
+            // https://bugzilla.mozilla.org/show_bug.cgi?id=612118 and
+            // https://stackoverflow.com/questions/28282295/getbbox-of-svg-when-hidden.
             try {
                 markerGroupBBox = markerGroup.node().getBBox();
                 xPosition = markerGroupBBox.x + markerGroupBBox.width + markerGroupXOffset;

--- a/assets/src/scripts/components/hydrograph/legend.js
+++ b/assets/src/scripts/components/hydrograph/legend.js
@@ -4,7 +4,7 @@ const { createSelector } = require('reselect');
 
 const { CIRCLE_RADIUS } = require('./layout');
 const { defineLineMarker, defineCircleMarker, defineRectangleMarker, rectangleMarker } = require('./markers');
-const { lineSegmentsSelector, HASH_ID, MASK_DESC} = require('./drawingData');
+const { currentVariableLineSegmentsSelector, HASH_ID, MASK_DESC} = require('./drawingData');
 const { currentVariableTimeSeriesSelector, methodsSelector } = require('./timeseries');
 
 
@@ -162,7 +162,7 @@ function drawSimpleLegend(div, {legendMarkerRows, layout}) {
 }
 
 const uniqueMasksSelector = memoize(tsKey => createSelector(
-    lineSegmentsSelector(tsKey),
+    currentVariableLineSegmentsSelector(tsKey),
     (tsLineSegments) => {
         return new Set(Object.values(tsLineSegments).reduce((masks, lineSegments) => {
             Array.prototype.push.apply(masks, lineSegments.map((segment) => segment.classes.dataMask));
@@ -170,6 +170,8 @@ const uniqueMasksSelector = memoize(tsKey => createSelector(
         }, []).filter(x => x !== null));
     }
 ));
+
+
 
 /**
  * Select attributes from the state useful for legend creation

--- a/assets/src/scripts/components/hydrograph/legend.js
+++ b/assets/src/scripts/components/hydrograph/legend.js
@@ -156,7 +156,7 @@ export const drawSimpleLegend = function(div, {legendMarkerRows, layout}) {
                 xPosition = markerGroupBBox.x + markerGroupBBox.width + markerGroupXOffset;
 
             } catch(error) {
-                null;
+                // See above explanation
             }
         });
     });
@@ -176,15 +176,9 @@ const uniqueClassesSelector = memoize(tsKey => createSelector(
     (tsLineSegments) => {
         let classes = [].concat(...Object.values(tsLineSegments)).map((line) => line.classes);
         return {
-            default: classes.find((cls) => {
-               return !cls.approved && !cls.estimated && !cls.dataMask;
-            }) ? true : false,
-            approved: classes.find((cls) => {
-                return cls.approved;
-            })? true : false,
-            estimated: classes.find((cls) => {
-                return cls.estimated;
-            }) ? true : false,
+            default: classes.some((cls) => !cls.approved && !cls.estimated && !cls.dataMask),
+            approved: classes.some((cls) => cls.approved),
+            estimated: classes.some((cls) => cls.estimated),
             dataMasks: new Set(classes.map((cls) => cls.dataMask).filter((mask) => {
                 return mask;
             }))

--- a/assets/src/scripts/components/hydrograph/legend.js
+++ b/assets/src/scripts/components/hydrograph/legend.js
@@ -3,7 +3,7 @@ const memoize = require('fast-memoize');
 const { createSelector } = require('reselect');
 
 const { CIRCLE_RADIUS } = require('./layout');
-const { defineLineMarker, defineTextOnlyMarker, defineCircleMarker, defineRectangleMarker, rectangleMarker } = require('./markers');
+const { defineLineMarker, defineTextOnlyMarker, defineCircleMarker, defineRectangleMarker} = require('./markers');
 const { currentVariableLineSegmentsSelector, HASH_ID, MASK_DESC} = require('./drawingData');
 const { currentVariableTimeSeriesSelector, methodsSelector } = require('./timeseries');
 
@@ -57,7 +57,7 @@ const createLegendMarkers = function(displayItems) {
         ];
         if (currentMarkers.length) {
             legendMarkers.push([
-                defineTextOnlyMarker('ts-legend-current-text', null, TS_LABEL.current),
+                defineTextOnlyMarker(TS_LABEL.current, null, 'ts-legend-current-text'),
                 ...currentMarkers
             ]);
         }
@@ -69,7 +69,7 @@ const createLegendMarkers = function(displayItems) {
         ];
         if (compareMarkers.length) {
             legendMarkers.push([
-                defineTextOnlyMarker('ts-legend-compare-text', null, TS_LABEL.compare),
+                defineTextOnlyMarker(TS_LABEL.compare, null, 'ts-legend-compare-text'),
                 ...compareMarkers
             ]);
         }
@@ -92,7 +92,7 @@ const createLegendMarkers = function(displayItems) {
             const label = `${descriptionText}${dateText}`;
 
             legendMarkers.push([
-                defineTextOnlyMarker(null, null, TS_LABEL.median),
+                defineTextOnlyMarker(TS_LABEL.median),
                 defineCircleMarker(CIRCLE_RADIUS, null, classes, label)]);
         }
     }
@@ -107,10 +107,10 @@ const createLegendMarkers = function(displayItems) {
  * @param {Object} legendMarkerRows - Array of rows. Each row should be an array of legend markers.
  * @param {Object} layout - width and height of svg.
  */
-function drawSimpleLegend(div, {legendMarkerRows, layout}) {
+export const drawSimpleLegend = function(div, {legendMarkerRows, layout}) {
     div.selectAll('.legend-svg').remove();
 
-    if (!legendMarkerRows || !layout) {
+    if (!legendMarkerRows.length || !layout) {
         return;
     }
 
@@ -152,9 +152,7 @@ function drawSimpleLegend(div, {legendMarkerRows, layout}) {
             }
         });
     });
-/*
 
-*/
     // Set the size of the containing svg node to the size of the legend.
     let bBox;
     try {
@@ -163,7 +161,7 @@ function drawSimpleLegend(div, {legendMarkerRows, layout}) {
         return;
     }
     svg.attr('viewBox', `-${CIRCLE_RADIUS} 0 ${layout.width} ${bBox.height + 10}`);
-}
+};
 
 const uniqueClassesSelector = memoize(tsKey => createSelector(
     currentVariableLineSegmentsSelector(tsKey),
@@ -213,9 +211,13 @@ const legendDisplaySelector = createSelector(
 );
 
 
-const legendMarkerRowsSelector = createSelector(
+/*
+ * Factory function  that returns an array of array of markers to be used for the
+ * timeseries graph legend
+ * @return {Array of Array} of markers
+ */
+export const legendMarkerRowsSelector = createSelector(
     legendDisplaySelector,
     displayItems => createLegendMarkers(displayItems)
 );
 
-module.exports = {drawSimpleLegend, createLegendMarkers, legendDisplaySelector, legendMarkerRowsSelector}

--- a/assets/src/scripts/components/hydrograph/legend.js
+++ b/assets/src/scripts/components/hydrograph/legend.js
@@ -24,17 +24,16 @@ const tsMaskMarkers = function(tsKey, masks) {
 };
 
 const tsLineMarkers = function(tsKey, lineClasses) {
-    const GROUP_ID = `${tsKey}-line-marker`;
     let result = [];
 
     if (lineClasses.default) {
-        result.push(defineLineMarker(null, `line-segment ts-${tsKey}`, 'Provisional', GROUP_ID));
+        result.push(defineLineMarker(null, `line-segment ts-${tsKey}`, 'Provisional'));
     }
     if (lineClasses.approved) {
-        result.push(defineLineMarker(null, `line-segment approved ts-${tsKey}`, 'Approved', GROUP_ID));
+        result.push(defineLineMarker(null, `line-segment approved ts-${tsKey}`, 'Approved'));
     }
     if (lineClasses.estimated) {
-        result.push(defineLineMarker(null, `line-segment estimated ts-${tsKey}`, 'Estimated', GROUP_ID));
+        result.push(defineLineMarker(null, `line-segment estimated ts-${tsKey}`, 'Estimated'));
     }
     return result;
 };

--- a/assets/src/scripts/components/hydrograph/legend.spec.js
+++ b/assets/src/scripts/components/hydrograph/legend.spec.js
@@ -1,32 +1,33 @@
 const { select } = require('d3-selection');
 
-const { drawSimpleLegend, legendDisplaySelector, createLegendMarkers } = require('./legend');
-const { lineMarker, circleMarker, rectangleMarker } = require('./markers');
-jasmine.pp = function (obj) {
-    return JSON.stringify(obj, undefined, 4);
-};
+const { drawSimpleLegend, legendMarkerRowsSelector } = require('./legend');
+const { lineMarker, circleMarker, rectangleMarker, textOnlyMarker } = require('./markers');
+
 describe('Legend module', () => {
 
     describe('drawSimpleLegend', () => {
 
-        let svgNode;
+        let container;
 
-        let legendMarkerRows = [
+        const legendMarkerRows = [
             [{
                 type: lineMarker,
                 length: 20,
                 domId: 'some-id',
                 domClass: 'some-class',
-                text: 'Some Text',
-                groupId: 'my-line-marker'
+                text: 'Some Text'
             }, {
                 type: rectangleMarker,
                 domId: 'some-rectangle-id',
                 domClass: 'some-rectangle-class',
-                text: 'Rectangle Marker',
-                groupId: 'rectangle-marker-group'
+                text: 'Rectangle Marker'
             }],
             [{
+                type: textOnlyMarker,
+                domId: 'text-id',
+                domClass: 'text-class',
+                text: 'Label'
+            }, {
                 type: circleMarker,
                 r: 4,
                 domId: null,
@@ -34,259 +35,200 @@ describe('Legend module', () => {
                 text: 'Circle Text'
             }]
         ];
+        const layout = {
+            width: 100,
+            height: 100,
+            margin: {
+                top: 0,
+                right: 0,
+                bottom: 0,
+                left: 0
+            }
+        };
 
         beforeEach(() => {
-            svgNode = select('body').append('svg')
-                .style('width', '800px')
-                .style('height', '400px')
-                .attr('viewBox', '0 0 800 400')
-                .attr('preserveAspectRatio', 'xMinYMin meet');
+            container = select('body').append('div');
         });
 
         afterEach(() => {
-            svgNode.remove();
+            container.remove();
+        });
+
+        it('Does not add a legend svg if no markers are provided', () => {
+            drawSimpleLegend(container, {
+                legendMarkerRows: [],
+                layout: layout
+            });
+
+            expect(container.select('svg').size()).toBe(0);
+        });
+
+        it('Does not add a legend if the layout is null', () => {
+            drawSimpleLegend(container, {
+                legendMarkerRows: legendMarkerRows,
+                layout: undefined
+            });
+
+            expect(container.select('svg').size()).toBe(0);
         });
 
         it('Adds a legend when width is provided', () => {
-            drawSimpleLegend(svgNode, {legendMarkerRows, layout: {
-                width: 100,
-                height: 100,
-                margin: {
-                    top: 0,
-                    right: 0,
-                    bottom: 0,
-                    left: 0
+            drawSimpleLegend(container, {legendMarkerRows, layout});
+
+            expect(container.select('svg').size()).toBe(1);
+            expect(container.selectAll('line').size()).toBe(1);
+            expect(container.selectAll('circle').size()).toBe(1);
+            expect(container.selectAll('rect').size()).toBe(1);
+            expect(container.selectAll('text').size()).toBe(4);
+        });
+    });
+
+    describe('legendMarkerRowSelector', () => {
+
+        const TEST_DATA = {
+            series: {
+                timeSeries: {
+                    '00060:current': {
+                        tsKey: 'current',
+                        startTime: new Date('2018-03-06T15:45:00.000Z'),
+                        endTime: new Date('2018-03-13t13:45:00.000Z'),
+                        variable: '45807197',
+                        points: [{
+                            value: 10,
+                            qualifiers: ['P'],
+                            approved: false,
+                            estimated: false
+                        }, {
+                            value: null,
+                            qualifiers: ['P', 'ICE'],
+                            approved: false,
+                            estimated: false
+                        }, {
+                            value: null,
+                            qualifiers: ['P', 'FLD'],
+                            approved: false,
+                            estimated: false
+                        }]
+                    },
+
+                    '00065:compare': {
+                        tsKey: 'compare',
+                        startTime: new Date('2017-03-06T15:45:00.000Z'),
+                        endTime: new Date('2017-03-13t13:45:00.000Z'),
+                        variable: '45807202',
+                        points: [{
+                            value: 1,
+                            qualifiers: ['P'],
+                            approved: false,
+                            estimated: false
+                        }, {
+                            value: 2,
+                            qualifiers: ['P'],
+                            approved: false,
+                            estimated: false
+                        }, {
+                            value: 3,
+                            qualifiers: ['P'],
+                            approved: false,
+                            estimated: false
+                        }]
+                    },
+                    '00065:median': {
+                        tsKey: 'median',
+                        startTime: new Date('2007-03-06T15:45:00.000Z'),
+                        endTime: new Date('2017-03-13t13:45:00.000Z'),
+                        variable: '45807202',
+                        points: [{
+                            value: 1
+                        }, {
+                            value: 2
+                        }, {
+                            value: 3
+                        }],
+                        metadata: {
+                            beginYear: '1931',
+                            endYear: '2017'
+                        }
+                    }
+                },
+                variables: {
+                    '45807197': {
+                        variableCode: {value: '00060'},
+                        variableName: 'Streamflow',
+                        variableDescription: 'Discharge, cubic feet per second',
+                        oid: '45807197'
+                    },
+                    '45807202': {
+                        variableCode: {value: '00065'},
+                        variableName: 'Gage height',
+                        oid: '45807202'
+                    }
                 }
-            }});
+            },
+            currentVariableID: '45807197',
+            showSeries: {
+                current: true,
+                compare: true,
+                median: true
+            }
+        };
 
-            expect(svgNode.selectAll('.legend').size()).toBe(1);
-            expect(svgNode.selectAll('line').size()).toBe(1);
-            expect(svgNode.selectAll('circle').size()).toBe(1);
-            expect(svgNode.selectAll('rect').size()).toBe(1);
-            expect(svgNode.selectAll('text').size()).toBe(3);
-            let line = svgNode.select('line');
-            expect(line.attr('x1')).toBe('0');
-            expect(line.attr('x2')).toBe('20');
-            let circle = svgNode.select('circle');
-            expect(circle.attr('class')).toBe('some-other-class');
-            let rect = svgNode.select('rect');
-            expect(rect.attr('class')).toBe('some-rectangle-class');
-        });
-    });
-
-    describe('createLegendMarkers', () => {
-
-        it('should return markers for display', () => {
-            let result = createLegendMarkers({
-                current: {masks: ['ice']},
-                median: [{
-                    beginYear: 2010,
-                    endYear: 2012
-                }]
-            });
-            expect(result).toEqual([
-                [{
-                    type: lineMarker,
-                    domId: 'ts-legend-current',
-                    domClass: 'line-segment',
-                    text: 'Current Year',
-                    groupId: 'current-year-line-marker'
-                }, {
-                    type: rectangleMarker,
-                    domId: null,
-                    domClass: 'mask ice-affected-mask',
-                    text: 'Ice Affected',
-                    groupId: null,
-                    fill: 'url(#hash-45)'
-                }], [{
-                    type: circleMarker,
-                    r: 4,
-                    domId: null,
-                    domClass: 'median-data-series median-modulo-0',
-                    groupId: null,
-                    text: 'Median 2010 - 2012',
-                    fill: null
-                }]
-            ]);
-        });
-
-        it('should return an object with no markers', () => {
-            let result = createLegendMarkers({});
-            expect(result.length).toEqual(0);
-
-        });
-
-        it('should still work if stat begin and end years are absent', () => {
-            let result = createLegendMarkers({
-                median: [{
-                    beginYear: undefined,
-                    endYear: undefined
-                }]
-            });
-            expect(result).toEqual([
-                [{
-                    type: circleMarker,
-                    r: 4,
-                    domId: null,
-                    domClass: 'median-data-series median-modulo-0',
-                    groupId: null,
-                    text: 'Median ',
-                    fill: null
-                }]
-            ]);
-        });
-    });
-
-    describe('legendDisplaySelector', () => {
-
-        it('should return a marker if a time series is shown', () => {
-            let result = legendDisplaySelector({
+        it('Should return no markers if no timeseries to show', () => {
+            let newData = {
+                ...TEST_DATA,
                 series: {
-                    timeSeries: {
-                        medianTS: {
-                            startTime: new Date('2010-10-10'),
-                            endTime: new Date('2012-10-10'),
-                            method: 'methodID',
-                            points: [1, 2, 3],
-                            tsKey: 'median',
-                            variable: '00060ID',
-                            metadata: {
-                                beginYear: '2010',
-                                endYear: '2012'
-                            }
-                        }
-                    },
-                    methods: {
-                        methodID: {
-                            methodDescription: 'method description'
-                        }
-                    },
-                    timeSeriesCollections: {
-                        collectionID: {
-                            variable: '00060ID',
-                            timeSeries: ['medianTS']
-                        }
-                    },
-                    requests: {
-                        median: {
-                            timeSeriesCollections: ['collectionID']
-                        }
-                    },
-                    variables: {
-                        '00060ID': {
-                            variableCode: {value: '00060'},
-                            oid: '00060ID'
-                        }
-                    }
-                },
-                showSeries: {
-                    current: true,
-                    compare: false,
-                    median: true
-                },
-                currentVariableID: '00060ID'
-            });
-            expect(result).toEqual({
-                current: {masks: new Set()},
-                compare: undefined,
-                median: [{
-                    beginYear: '2010',
-                    endYear: '2012',
-                    description: 'method description'
-                }]
-            });
-        });
-
-        it('Should return the masks marker for the selected time series', () => {
-            const TEST_DATA = {
-                series: {
-                    timeSeries: {
-                        '00060': {
-                            tsKey: 'current',
-                            startTime: new Date('2018-03-06T15:45:00.000Z'),
-                            endTime: new Date('2018-03-13t13:45:00.000Z'),
-                            variable: '45807197',
-                            points: [{
-                                value: 10,
-                                qualifiers: ['P'],
-                                approved: false,
-                                estimated: false
-                            }, {
-                                value: null,
-                                qualifiers: ['P', 'ICE'],
-                                approved: false,
-                                estimated: false
-                            }, {
-                                value: null,
-                                qualifiers: ['P', 'FLD'],
-                                approved: false,
-                                estimated: false
-                            }]
-                        },
-                        '00010': {
-                            tsKey: 'compare',
-                            startTime: new Date('2017-03-06T15:45:00.000Z'),
-                            endTime: new Date('2017-03-13t13:45:00.000Z'),
-                            variable: '45807196',
-                            points: [{
-                                value: 1,
-                                qualifiers: ['P'],
-                                approved: false,
-                                estimated: false
-                            }, {
-                                value: 2,
-                                qualifiers: ['P'],
-                                approved: false,
-                                estimated: false
-                            }, {
-                                value: 3,
-                                qualifiers: ['P'],
-                                approved: false,
-                                estimated: false
-                            }]
-                        }
-                    },
-                    variables: {
-                        '45807197': {
-                            variableCode: {value: '00060'},
-                            variableName: 'Streamflow',
-                            variableDescription: 'Discharge, cubic feet per second',
-                            oid: '45807197'
-                        },
-                        '45807196': {
-                            variableCode: {value: '00010'},
-                            variableName: 'Gage Height',
-                            variableDescription: 'Gage Height in feet',
-                            oid: '45807196'
-                        }
-                    }
-                },
-                showSeries: {
-                    current: true
+                    ...TEST_DATA.series,
+                    timeSeries: {}
                 }
             };
 
-            let result = legendDisplaySelector({
-                ...TEST_DATA,
-                currentVariableID: '45807197'
-            });
-            expect([...result.current.masks]).toEqual(['ice', 'fld']);
-
-            result = legendDisplaySelector({
-                ...TEST_DATA,
-                currentVariableID: '45807196'
-            });
-            expect([...result.current.masks]).toEqual([]);
+            expect(legendMarkerRowsSelector(newData)).toEqual([]);
         });
 
-        it('should not choke if median time series is absent', () => {
-            let result = legendDisplaySelector({
-                series: {},
+        it('Should return markers for the selected variable', () => {
+            const result = legendMarkerRowsSelector(TEST_DATA);
+
+            expect(result.length).toBe(1);
+            expect(result[0].length).toBe(4);
+            expect(result[0][0].type).toEqual(textOnlyMarker);
+            expect(result[0][1].type).toEqual(lineMarker);
+            expect(result[0][2].type).toEqual(rectangleMarker);
+            expect(result[0][3].type).toEqual(rectangleMarker);
+        });
+
+        it('Should return markers for a different selected variable', () => {
+            const newData = {
+                ...TEST_DATA,
+                currentVariableID: '45807202'
+            };
+            const result = legendMarkerRowsSelector(newData);
+
+            expect(result.length).toBe(2);
+            expect(result[0].length).toBe(2);
+            expect(result[0][0].type).toEqual(textOnlyMarker);
+            expect(result[0][1].type).toEqual(lineMarker);
+            expect(result[1].length).toBe(2);
+            expect(result[1][0].type).toEqual(textOnlyMarker);
+            expect(result[1][1].type).toEqual(circleMarker);
+        });
+
+        it('Should return markers only for time series shown', () => {
+            const newData = {
+                ...TEST_DATA,
+                currentVariableID: '45807202',
                 showSeries: {
-                    median: true
+                    'current': true,
+                    'compare': false,
+                    'median': true
                 }
-            });
-            expect(result.median).toEqual([]);
+            };
+
+            const result = legendMarkerRowsSelector(newData);
+
+            expect(result.length).toBe(1);
+            expect(result[0].length).toBe(2);
+            expect(result[0][0].type).toEqual(textOnlyMarker);
+            expect(result[0][1].type).toEqual(circleMarker);
         });
     });
 });

--- a/assets/src/scripts/components/hydrograph/legend.spec.js
+++ b/assets/src/scripts/components/hydrograph/legend.spec.js
@@ -118,17 +118,17 @@ describe('Legend module', () => {
                         variable: '45807202',
                         points: [{
                             value: 1,
-                            qualifiers: ['P'],
+                            qualifiers: ['A'],
                             approved: false,
                             estimated: false
                         }, {
                             value: 2,
-                            qualifiers: ['P'],
+                            qualifiers: ['A'],
                             approved: false,
                             estimated: false
                         }, {
                             value: 3,
-                            qualifiers: ['P'],
+                            qualifiers: ['E'],
                             approved: false,
                             estimated: false
                         }]
@@ -204,9 +204,10 @@ describe('Legend module', () => {
             const result = legendMarkerRowsSelector(newData);
 
             expect(result.length).toBe(2);
-            expect(result[0].length).toBe(2);
+            expect(result[0].length).toBe(3);
             expect(result[0][0].type).toEqual(textOnlyMarker);
             expect(result[0][1].type).toEqual(lineMarker);
+            expect(result[0][2].type).toEqual(lineMarker);
             expect(result[1].length).toBe(2);
             expect(result[1][0].type).toEqual(textOnlyMarker);
             expect(result[1][1].type).toEqual(circleMarker);

--- a/assets/src/scripts/components/hydrograph/legend.spec.js
+++ b/assets/src/scripts/components/hydrograph/legend.spec.js
@@ -197,6 +197,88 @@ describe('Legend module', () => {
             });
         });
 
+        fit('Should return the masks marker for the selected time series', () => {
+            const TEST_DATA = {
+                series: {
+                    timeSeries: {
+                        '00060': {
+                            tsKey: 'current',
+                            startTime: new Date('2018-03-06T15:45:00.000Z'),
+                            endTime: new Date('2018-03-13t13:45:00.000Z'),
+                            variable: '45807197',
+                            points: [{
+                                value: 10,
+                                qualifiers: ['P'],
+                                approved: false,
+                                estimated: false
+                            }, {
+                                value: null,
+                                qualifiers: ['P', 'ICE'],
+                                approved: false,
+                                estimated: false
+                            }, {
+                                value: null,
+                                qualifiers: ['P', 'FLD'],
+                                approved: false,
+                                estimated: false
+                            }]
+                        },
+                        '00010': {
+                            tsKey: 'compare',
+                            startTime: new Date('2017-03-06T15:45:00.000Z'),
+                            endTime: new Date('2017-03-13t13:45:00.000Z'),
+                            variable: '45807196',
+                            points: [{
+                                value: 1,
+                                qualifiers: ['P'],
+                                approved: false,
+                                estimated: false
+                            }, {
+                                value: 2,
+                                qualifiers: ['P'],
+                                approved: false,
+                                estimated: false
+                            }, {
+                                value: 3,
+                                qualifiers: ['P'],
+                                approved: false,
+                                estimated: false
+                            }]
+                        }
+                    },
+                    variables: {
+                        '45807197': {
+                            variableCode: {value: '00060'},
+                            variableName: 'Streamflow',
+                            variableDescription: 'Discharge, cubic feet per second',
+                            oid: '45807197'
+                        },
+                        '45807196': {
+                            variableCode: {value: '00010'},
+                            variableName: 'Gage Height',
+                            variableDescription: 'Gage Height in feet',
+                            oid: '45807196'
+                        }
+                    }
+                },
+                showSeries: {
+                    current: true
+                }
+            };
+
+            let result = legendDisplaySelector({
+                ...TEST_DATA,
+                currentVariableID: '45807197'
+            });
+            expect([...result.current.masks]).toEqual(['ice', 'fld']);
+
+            result = legendDisplaySelector({
+                ...TEST_DATA,
+                currentVariableID: '45807196'
+            });
+            expect([...result.current.masks]).toEqual([]);
+        });
+
         it('should not choke if median time series is absent', () => {
             let result = legendDisplaySelector({
                 series: {},

--- a/assets/src/scripts/components/hydrograph/legend.spec.js
+++ b/assets/src/scripts/components/hydrograph/legend.spec.js
@@ -197,7 +197,7 @@ describe('Legend module', () => {
             });
         });
 
-        fit('Should return the masks marker for the selected time series', () => {
+        it('Should return the masks marker for the selected time series', () => {
             const TEST_DATA = {
                 series: {
                     timeSeries: {

--- a/assets/src/scripts/components/hydrograph/markers.js
+++ b/assets/src/scripts/components/hydrograph/markers.js
@@ -122,7 +122,7 @@ export const defineLineMarker = function(domId=null, domClass=null, text=null) {
     };
 };
 
-export const defineTextOnlyMarker = function(domId=null, domClass=null, text) {
+export const defineTextOnlyMarker = function(text, domId=null, domClass=null ) {
     return {
         type: textOnlyMarker,
         domId: domId,

--- a/assets/src/scripts/components/hydrograph/markers.js
+++ b/assets/src/scripts/components/hydrograph/markers.js
@@ -1,14 +1,24 @@
 
-const markerTextXOffset = 6;
-const markerYOffset = -4;
-const rectangleMarkerYOffset = -10;
+const TEXT_X_OFFSET = 6;
+const Y_OFFSET = -4;
+const RECTANGLE_Y_OFFSET = -10;
+
+const markerText = function(group, y, text) {
+    if (text) {
+        let groupBBox = group.node().getBBox();
+        group.append('text')
+            .attr('x', groupBBox.x + groupBBox.width + TEXT_X_OFFSET)
+            .attr('y', y)
+            .text(text);
+    }
+};
 
 export const circleMarker = function(elem, {r, x, y, text=null, domId=null, domClass=null, fill=null}) {
     let group = elem.append('g');
     let circle = group.append('circle')
         .attr('r', r)
         .attr('cx', x)
-        .attr('cy', y + markerYOffset);
+        .attr('cy', y + Y_OFFSET);
     if (domId !== null) {
         circle.attr('id', domId);
     }
@@ -28,21 +38,15 @@ export const circleMarker = function(elem, {r, x, y, text=null, domId=null, domC
             .attr('cy', y)
             .attr('fill', fill);
     }
+    markerText(group, y, text);
 
-    if (text) {
-        let groupBBox = group.node().getBBox();
-        group.append('text')
-            .attr('x', groupBBox.x + groupBBox.width + markerTextXOffset)
-            .attr('y', y)
-            .text(text);
-    }
     return group;
 };
 
 
 export const rectangleMarker = function(elem, {x, y, width, height, text=null, domId=null, domClass=null, fill=null}) {
     let group = elem.append('g');
-    const rectangleY = y + rectangleMarkerYOffset;
+    const rectangleY = y + RECTANGLE_Y_OFFSET;
     let rectangle = group.append('rect')
         .attr('x', x)
         .attr('y', rectangleY)
@@ -68,20 +72,15 @@ export const rectangleMarker = function(elem, {x, y, width, height, text=null, d
             .attr('height', height)
             .attr('fill', fill);
     }
-    if (text) {
-        let groupBBox = group.node().getBBox();
-        group.append('text')
-            .attr('x', groupBBox.x + groupBBox.width + markerTextXOffset)
-            .attr('y', y)
-            .text(text);
-    }
+    markerText(group, y, text);
+
     return group;
 };
 
 
 export const lineMarker = function(elem, {x, y, length, text=null, domId=null, domClass=null}) {
     const group = elem.append('g');
-    const lineY = y + markerYOffset;
+    const lineY = y + Y_OFFSET;
     let line = group.append('line')
         .attr('x1', x)
         .attr('x2', x + length)
@@ -94,13 +93,7 @@ export const lineMarker = function(elem, {x, y, length, text=null, domId=null, d
         line.attr('class', domClass);
     }
 
-    if (text) {
-        let groupBBox = group.node().getBBox();
-        group.append('text')
-            .attr('x', groupBBox.x + groupBBox.width + markerTextXOffset)
-            .attr('y', y)
-            .text(text);
-    }
+    markerText(group, y, text);
     return group;
 };
 
@@ -109,7 +102,7 @@ export const textOnlyMarker = function(elem, {x, y, text, domId=null, domClass=n
     let markerText = group.append('text')
         .text(text)
         .attr('x', x)
-        .attr('y', y)
+        .attr('y', y);
     if (domId) {
         markerText.attr('id', domId);
     }
@@ -120,46 +113,42 @@ export const textOnlyMarker = function(elem, {x, y, text, domId=null, domClass=n
 };
 
 
-export const defineLineMarker = function(domId=null, domClass=null, text=null, groupId=null) {
+export const defineLineMarker = function(domId=null, domClass=null, text=null) {
     return {
         type: lineMarker,
         domId: domId,
         domClass: domClass,
-        text: text,
-        groupId: groupId
+        text: text
     };
 };
 
-export const defineTextOnlyMarker = function(domId=null, domClass=null, text, groupId=null) {
+export const defineTextOnlyMarker = function(domId=null, domClass=null, text) {
     return {
         type: textOnlyMarker,
         domId: domId,
         domClass: domClass,
-        text: text,
-        groupId: groupId
+        text: text
     };
 };
 
 
 
-export const defineRectangleMarker = function(domId=null, domClass=null, text=null, groupId=null, fill=null) {
+export const defineRectangleMarker = function(domId=null, domClass=null, text=null, fill=null) {
     return {
         type: rectangleMarker,
         domId: domId,
         domClass: domClass,
         text: text,
-        groupId: groupId,
         fill: fill
     };
 };
 
-export const defineCircleMarker = function(radius, domId=null, domClass=null, text=null, groupId=null, fill=null) {
+export const defineCircleMarker = function(radius, domId=null, domClass=null, text=null, fill=null) {
     return {
         type: circleMarker,
         r: radius,
         domId: domId,
         domClass: domClass,
-        groupId: groupId,
         text: text,
         fill: fill
     };

--- a/assets/src/scripts/components/hydrograph/markers.js
+++ b/assets/src/scripts/components/hydrograph/markers.js
@@ -1,12 +1,14 @@
-const { select, namespaces } = require('d3-selection');
 
+const markerTextXOffset = 6;
+const markerYOffset = -4;
+const rectangleMarkerYOffset = -10;
 
-const circleMarker = function({r, x, y, domId=null, domClass=null, fill=null}) {
-    let group = select(document.createElementNS(namespaces.svg, 'g'));
+export const circleMarker = function(elem, {r, x, y, text=null, domId=null, domClass=null, fill=null}) {
+    let group = elem.append('g');
     let circle = group.append('circle')
         .attr('r', r)
         .attr('cx', x)
-        .attr('cy', y);
+        .attr('cy', y + markerYOffset);
     if (domId !== null) {
         circle.attr('id', domId);
     }
@@ -27,15 +29,23 @@ const circleMarker = function({r, x, y, domId=null, domClass=null, fill=null}) {
             .attr('fill', fill);
     }
 
+    if (text) {
+        let groupBBox = group.node().getBBox();
+        group.append('text')
+            .attr('x', groupBBox.x + groupBBox.width + markerTextXOffset)
+            .attr('y', y)
+            .text(text);
+    }
     return group;
 };
 
 
-const rectangleMarker = function({x, y, width, height, domId=null, domClass=null, fill=null}) {
-    let group = select(document.createElementNS(namespaces.svg, 'g'));
+export const rectangleMarker = function(elem, {x, y, width, height, text=null, domId=null, domClass=null, fill=null}) {
+    let group = elem.append('g');
+    const rectangleY = y + rectangleMarkerYOffset;
     let rectangle = group.append('rect')
         .attr('x', x)
-        .attr('y', y)
+        .attr('y', rectangleY)
         .attr('width', width)
         .attr('height', height);
     if (domId !== null) {
@@ -53,39 +63,64 @@ const rectangleMarker = function({x, y, width, height, domId=null, domClass=null
         // overlayed rectangle.
         group.append('rect')
             .attr('x', x)
-            .attr('y', y)
+            .attr('y', rectangleY)
             .attr('width', width)
             .attr('height', height)
             .attr('fill', fill);
     }
+    if (text) {
+        let groupBBox = group.node().getBBox();
+        group.append('text')
+            .attr('x', groupBBox.x + groupBBox.width + markerTextXOffset)
+            .attr('y', y)
+            .text(text);
+    }
     return group;
 };
 
 
-const lineMarker = function({x, y, length, domId=null, domClass=null}) {
-    let group = select(document.createElementNS(namespaces.svg, 'g'));
+export const lineMarker = function(elem, {x, y, length, text=null, domId=null, domClass=null}) {
+    const group = elem.append('g');
+    const lineY = y + markerYOffset;
     let line = group.append('line')
         .attr('x1', x)
         .attr('x2', x + length)
-        .attr('y1', y)
-        .attr('y2', y);
-    if (domId !== null) {
+        .attr('y1', lineY)
+        .attr('y2', lineY);
+    if (domId) {
         line.attr('id', domId);
     }
-    if (domClass !== null) {
+    if (domClass) {
         line.attr('class', domClass);
+    }
+
+    if (text) {
+        let groupBBox = group.node().getBBox();
+        group.append('text')
+            .attr('x', groupBBox.x + groupBBox.width + markerTextXOffset)
+            .attr('y', y)
+            .text(text);
     }
     return group;
 };
 
-const textOnlyMarker = function({x, y, domId=null, domClass=null}) {
-   let group = select(document.createElementNS(namespaces.svg, 'g'));
-   // TODO: Refactor so that text is drawn in this package, not in legend since text is associated with each marker.
+export const textOnlyMarker = function(elem, {x, y, text, domId=null, domClass=null}) {
+    const group = elem.append('g');
+    let markerText = group.append('text')
+        .text(text)
+        .attr('x', x)
+        .attr('y', y)
+    if (domId) {
+        markerText.attr('id', domId);
+    }
+    if (domClass) {
+        markerText.attr('class', domClass);
+    }
     return group;
 };
 
 
-const defineLineMarker = function(domId=null, domClass=null, text=null, groupId=null) {
+export const defineLineMarker = function(domId=null, domClass=null, text=null, groupId=null) {
     return {
         type: lineMarker,
         domId: domId,
@@ -95,7 +130,7 @@ const defineLineMarker = function(domId=null, domClass=null, text=null, groupId=
     };
 };
 
-const defineTextOnlyMarker = function(domId=null, domClass=null, text, groupId=null) {
+export const defineTextOnlyMarker = function(domId=null, domClass=null, text, groupId=null) {
     return {
         type: textOnlyMarker,
         domId: domId,
@@ -107,7 +142,7 @@ const defineTextOnlyMarker = function(domId=null, domClass=null, text, groupId=n
 
 
 
-const defineRectangleMarker = function(domId=null, domClass=null, text=null, groupId=null, fill=null) {
+export const defineRectangleMarker = function(domId=null, domClass=null, text=null, groupId=null, fill=null) {
     return {
         type: rectangleMarker,
         domId: domId,
@@ -118,7 +153,7 @@ const defineRectangleMarker = function(domId=null, domClass=null, text=null, gro
     };
 };
 
-const defineCircleMarker = function(radius, domId=null, domClass=null, text=null, groupId=null, fill=null) {
+export const defineCircleMarker = function(radius, domId=null, domClass=null, text=null, groupId=null, fill=null) {
     return {
         type: circleMarker,
         r: radius,
@@ -130,6 +165,3 @@ const defineCircleMarker = function(radius, domId=null, domClass=null, text=null
     };
 };
 
-
-module.exports = {circleMarker, rectangleMarker, lineMarker, textOnlyMarker,
-    defineLineMarker, defineCircleMarker, defineRectangleMarker, defineTextOnlyMarker};

--- a/assets/src/scripts/components/hydrograph/markers.js
+++ b/assets/src/scripts/components/hydrograph/markers.js
@@ -78,6 +78,12 @@ const lineMarker = function({x, y, length, domId=null, domClass=null}) {
     return group;
 };
 
+const textOnlyMarker = function({x, y, domId=null, domClass=null}) {
+   let group = select(document.createElementNS(namespaces.svg, 'g'));
+   // TODO: Refactor so that text is drawn in this package, not in legend since text is associated with each marker.
+    return group;
+};
+
 
 const defineLineMarker = function(domId=null, domClass=null, text=null, groupId=null) {
     return {
@@ -88,6 +94,17 @@ const defineLineMarker = function(domId=null, domClass=null, text=null, groupId=
         groupId: groupId
     };
 };
+
+const defineTextOnlyMarker = function(domId=null, domClass=null, text, groupId=null) {
+    return {
+        type: textOnlyMarker,
+        domId: domId,
+        domClass: domClass,
+        text: text,
+        groupId: groupId
+    };
+};
+
 
 
 const defineRectangleMarker = function(domId=null, domClass=null, text=null, groupId=null, fill=null) {
@@ -114,5 +131,5 @@ const defineCircleMarker = function(radius, domId=null, domClass=null, text=null
 };
 
 
-module.exports = {circleMarker, rectangleMarker, lineMarker,defineLineMarker, defineCircleMarker,
-    defineRectangleMarker};
+module.exports = {circleMarker, rectangleMarker, lineMarker, textOnlyMarker,
+    defineLineMarker, defineCircleMarker, defineRectangleMarker, defineTextOnlyMarker};

--- a/assets/src/scripts/components/hydrograph/markers.spec.js
+++ b/assets/src/scripts/components/hydrograph/markers.spec.js
@@ -1,33 +1,57 @@
-const { lineMarker, circleMarker, rectangleMarker } = require('./markers');
+const { select } = require('d3-selection');
+
+const { lineMarker, circleMarker, rectangleMarker, textOnlyMarker } = require('./markers');
 
 describe('Markers module', () => {
 
-    describe('linkMarker', () => {
+    let svg;
+    beforeEach(() => {
+       svg = select('body').append('svg');
+    });
 
-        let x = 0;
-        let y = 0;
-        let length = 20;
-        let domId = 'line-id';
-        let domClass = 'line-class';
+    afterEach(() => {
+        svg.remove();
+    });
+
+    describe('lineMarker', () => {
+        const x = 5;
+        const y = 10;
+        const length = 20;
+        const domId = 'line-id';
+        const domClass = 'line-class';
 
         it('returns an SVG line element', () => {
-            let lineGroup = lineMarker({x: x, y: y, length: length});
+            let lineGroup = lineMarker(svg, {x: x, y: y, length: length});
             let node = lineGroup.select('line').node();
-            expect(node.getAttribute('x1')).toBe('0');
-            expect(node.getAttribute('x2')).toBe('20');
-            expect(node.getAttribute('y1')).toBe('0');
-            expect(node.getAttribute('y2')).toBe('0');
+
+            expect(node.getAttribute('x1')).toBe('5');
+            expect(node.getAttribute('x2')).toBe('25');
+            expect(node.getAttribute('y1')).toBe('6');
+            expect(node.getAttribute('y2')).toBe('6');
+            expect(node.getAttribute('class')).toBeNull();
+            expect(node.getAttribute('id')).toBeNull();
+            expect(lineGroup.select('text').size()).toBe(0);
         });
 
         it('returns an SVG line with id and class', () => {
-            let lineGroup = lineMarker({x: x, y: y, length: length, domId: domId, domClass: domClass});
+            let lineGroup = lineMarker(svg, {x: x, y: y, length: length, domId: domId, domClass: domClass});
             let node = lineGroup.select('line').node();
-            expect(node.getAttribute('x1')).toBe('0');
-            expect(node.getAttribute('x2')).toBe('20');
-            expect(node.getAttribute('y1')).toBe('0');
-            expect(node.getAttribute('y2')).toBe('0');
+
+            expect(node.getAttribute('x1')).toBe('5');
+            expect(node.getAttribute('x2')).toBe('25');
+            expect(node.getAttribute('y1')).toBe('6');
+            expect(node.getAttribute('y2')).toBe('6');
             expect(node.getAttribute('class')).toBe(domClass);
             expect(node.getAttribute('id')).toBe(domId);
+        });
+
+        it('Expects that the text appears after the line', () => {
+            let lineGroup = lineMarker(svg, {x: x, y: y, length: length, text: 'Line'});
+            let text = lineGroup.select('text');
+
+            expect(text.size()).toBe(1);
+            expect(text.text()).toBe('Line');
+            expect(parseInt(text.attr('x'))).toBeGreaterThan(25);
         });
     });
 
@@ -39,28 +63,31 @@ describe('Markers module', () => {
         let domClass = 'circle-class';
 
         it('returns circle element with correct attributes', () => {
-            let circleGroup = circleMarker({r: r, x: x, y: y});
+            let circleGroup = circleMarker(svg, {r: r, x: x, y: y});
             let node = circleGroup.select('circle').node();
+
             expect(node.nodeName).toBe('circle');
             expect(node.getAttribute('r')).toBe('10');
             expect(node.getAttribute('cx')).toBe('2');
-            expect(node.getAttribute('cy')).toBe('9');
+            expect(node.getAttribute('cy')).toBe('5');
         });
 
         it('returns circle element with id and class', () => {
-            let circleGroup = circleMarker({r: r, x: x, y: y, domId: domId, domClass: domClass});
+            let circleGroup = circleMarker(svg, {r: r, x: x, y: y, domId: domId, domClass: domClass});
             let node = circleGroup.select('circle').node();
+
             expect(node.nodeName).toBe('circle');
             expect(node.getAttribute('r')).toBe('10');
             expect(node.getAttribute('cx')).toBe('2');
-            expect(node.getAttribute('cy')).toBe('9');
+            expect(node.getAttribute('cy')).toBe('5');
             expect(node.getAttribute('class')).toBe(domClass);
             expect(node.getAttribute('id')).toBe(domId);
         });
 
         it('returns two circles if a fill is provided', () => {
-            let circleGroup = circleMarker({r: r, x: x, y: y, fill: 'green'});
+            let circleGroup = circleMarker(svg, {r: r, x: x, y: y, fill: 'green'});
             let circles = circleGroup.selectAll('circle');
+
             expect(circles.size()).toEqual(2);
         });
     });
@@ -74,16 +101,17 @@ describe('Markers module', () => {
         let domClass = 'rect-class';
 
         it('returns a group containing a rectangle', () => {
-            let rectangleGroup = rectangleMarker({x: x, y: y, width: width, height: height});
+            let rectangleGroup = rectangleMarker(svg, {x: x, y: y, width: width, height: height});
             let node = rectangleGroup.select('rect').node();
+
             expect(node.getAttribute('x')).toBe('3');
-            expect(node.getAttribute('y')).toBe('-6');
+            expect(node.getAttribute('y')).toBe('-16');
             expect(node.getAttribute('width')).toBe('20');
             expect(node.getAttribute('height')).toBe('10');
         });
 
         it('returns a group containing a rectangle with id and class', () => {
-            let rectangleGroup = rectangleMarker({
+            let rectangleGroup = rectangleMarker(svg, {
                 x: x,
                 y: y,
                 width: width,
@@ -92,8 +120,9 @@ describe('Markers module', () => {
                 domId: domId
             });
             let node = rectangleGroup.select('rect').node();
+
             expect(node.getAttribute('x')).toBe('3');
-            expect(node.getAttribute('y')).toBe('-6');
+            expect(node.getAttribute('y')).toBe('-16');
             expect(node.getAttribute('width')).toBe('20');
             expect(node.getAttribute('height')).toBe('10');
             expect(node.getAttribute('class')).toBe(domClass);
@@ -101,9 +130,44 @@ describe('Markers module', () => {
         });
 
         it('returns two rectangles if fill is provided', () => {
-            let rectangleGroup = rectangleMarker({x: x, y: y, width: width, height: height, fill: 'green'});
+            let rectangleGroup = rectangleMarker(svg, {x: x, y: y, width: width, height: height, fill: 'green'});
             let rectangles = rectangleGroup.selectAll('rect');
+
             expect(rectangles.size()).toEqual(2);
+        });
+    });
+
+    describe('textOnlyMarker', () => {
+        const x = 5;
+        const y = 10;
+        const text = 'Text only';
+        const domId = 'text-only-marker';
+        const domClass = 'text-only-marker-class';
+
+        it('returns a single text element with the correct position', () => {
+           const marker = textOnlyMarker(svg, {
+               x: x,
+               y: y,
+               text: text
+           });
+           const markerText = marker.selectAll('text');
+
+           expect(markerText.size()).toBe(1);
+           expect(markerText.text()).toBe(text);
+        });
+
+        it('Returns a single text element with the expect id and class', () => {
+            const marker = textOnlyMarker(svg, {
+                x: x,
+                y: y,
+                text: text,
+                domId: domId,
+                domClass: domClass
+            });
+            const markerText = marker.selectAll('text');
+
+            expect(markerText.attr('class')).toBe(domClass);
+            expect(markerText.attr('id')).toBe(domId);
         });
     });
 

--- a/assets/src/styles/components/_hydrograph.scss
+++ b/assets/src/styles/components/_hydrograph.scss
@@ -1,5 +1,6 @@
-$approved: darkgreen;
-$estimated: black;
+$approved-timeseries: darkgreen;
+$estimated-timeseries: black;
+$default-timeseries: blue;
 $selected: $color-aqua-lightest;
 $highlight: $color-gray-lightest;
 
@@ -102,6 +103,7 @@ $highlight: $color-gray-lightest;
         background: rgba(255, 255, 255, 0.8);
         margin: 0 0 0 40px;
         font-size: 0.5em;
+        color: $default-timeseries;
         @include media($medium-screen) {
             font-size: 0.75em;
         }
@@ -112,10 +114,10 @@ $highlight: $color-gray-lightest;
             font-weight: bold;
         }
         .approved {
-            color: $approved;
+            color: $approved-timeseries;
         }
         .estimated {
-            color: $estimated;
+            color: $estimated-timeseries;
         }
         .compare-tooltip-text {
             font-weight: normal
@@ -135,7 +137,7 @@ $highlight: $color-gray-lightest;
             line {
                 opacity: .5;
                 stroke: #436BAF;
-                stroke-width: 1;
+                stroke-width: 1px;
                 stroke-dasharray: 5, 5
             }
 
@@ -143,12 +145,12 @@ $highlight: $color-gray-lightest;
         .line-segment {
             fill: none;
             stroke-width: 3px;
-            stroke: $usgs-blue;
+            stroke: $default-timeseries;
             &.approved {
-                stroke: $approved;
+                stroke: $approved-timeseries;
             }
             &.estimated {
-                stroke: $estimated;
+                stroke: $estimated-timeseries;
                 stroke-dasharray: 1, 3;
             }
         }

--- a/assets/src/styles/components/_hydrograph.scss
+++ b/assets/src/styles/components/_hydrograph.scss
@@ -176,7 +176,6 @@ $highlight: $color-gray-lightest;
         .y-axis {
             text {
                 fill: black;
-                text-anchor: left;
                 &.y-axis-label {
                     text-anchor: middle;
                     display: none;
@@ -273,7 +272,7 @@ $highlight: $color-gray-lightest;
 }
 
 .slider-wrapper {
-    height: 0px;
+    height: 0;
     input#cursor-slider {
         max-width: none;
         position: relative;
@@ -302,7 +301,7 @@ $highlight: $color-gray-lightest;
     .graph-controls-container {
         position: absolute;
         display: inline-block;
-        top: 0px;
-        right: 0px;
+        top: 0;
+        right: 0;
     }
 }

--- a/assets/src/styles/components/_hydrograph.scss
+++ b/assets/src/styles/components/_hydrograph.scss
@@ -1,4 +1,4 @@
-$approved-timeseries: darkgreen;
+$approved-timeseries: #2db92d;
 $estimated-timeseries: black;
 $default-timeseries: blue;
 $selected: $color-aqua-lightest;

--- a/assets/src/styles/components/_hydrograph.scss
+++ b/assets/src/styles/components/_hydrograph.scss
@@ -154,7 +154,7 @@ $highlight: $color-gray-lightest;
                 stroke-dasharray: 1, 3;
             }
         }
-        .ts-compare, #ts-legend-compare {
+        .ts-compare{
             stroke-width: 1px;
         }
         .axis {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "waterdataui-assets",
-  "version": "0.6.0dev",
+  "version": "0.7.0dev",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [ ] Update the changelog appropriately 

I will update the changelog in a subsequent PR once more feedback is received for the changes to the legend.

Title
-----------
make Provisional/approved more blatantDescription

Description
-----------
This only address part of the ticket. I've reorganized the legend and added the ability to draw all line colors for the time series in the legend. For example if the current year data has provisional and estimated, both of those will appear in the legend.

I refactored markers. The functions to render the markers now take an elem so they follow the pattern other code does when rendering. They also include the code to render the text labels for the markers. This makes the legend module simpler.

Subsequent PRs will be used to address the tooltips and links to provisional data.

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
