### PR TITLE
Removed the hover:hover media query because it is not implemented in …

### DIFF
--- a/assets/src/styles/partials/_tooltip.scss
+++ b/assets/src/styles/partials/_tooltip.scss
@@ -17,22 +17,22 @@
     position: relative;
     text-align: center;
 
-    // On pointer devices, use the focus and hover state to indicate visibility.
-    @media (hover: hover) {
-        &:focus,
-        &:hover .tooltip {
-            opacity: 1;
-            visibility: visible;
-        }
+    // On pointer devices, use the focus and hover state to indicate visibility. Can't use hover media query as it is
+    // not implemented on Firefox or IE11.
+    &:focus,
+    &:hover .tooltip {
+        opacity: 1;
+        visibility: visible;
     }
+
     // On touch devices, use the show-tooltip class to indicate visibility.
     // See helpers.js for corresponding Javascript.
     @media (hover: none) {
         &.show-tooltip .tooltip {
-            opacity: 1;
+           opacity: 1;
             visibility: visible;
         }
-    }
+     }
 
     .tooltip {
         word-wrap: normal;


### PR DESCRIPTION
…Firefox or IE11

Before making a pull request
----------------------------

- [X] Make sure all tests run
- [ ] Update the changelog appropriately - Not needed as this fixes a bug that was the result of work on this release

Title
-----------
Hover on tooltip icons works on Firefox and IE11

Description
-----------

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
