### PR TITLE
Wdfn213 revert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ the selected timeseries.
 
 ### Changed
 - Cursor location / tooltip defaults to last point in the time series.
-- Date labels moved to and centered in areas between midnight tick marks
 
 
 ## [0.7.0] - 2018-04-23

--- a/assets/src/scripts/components/hydrograph/axes.spec.js
+++ b/assets/src/scripts/components/hydrograph/axes.spec.js
@@ -18,14 +18,13 @@ describe('Chart axes', () => {
             left: 65
         }
     };
-    const {xAxis, xAxisWithDateTimeLabels, yAxis} = createAxes({xScale, yScale}, 100, '00060', 'P7D');
+    const {xAxis, yAxis} = createAxes({xScale, yScale}, 100, '00060', 'P7D');
     let svg;
 
     beforeEach(() => {
         svg = select(document.body).append('svg');
         appendAxes(svg, {
             xAxis,
-            xAxisWithDateTimeLabels,
             yAxis,
             layout,
             yTitle: 'Label title'
@@ -38,7 +37,6 @@ describe('Chart axes', () => {
 
     it('axes created', () => {
         expect(xAxis).toEqual(jasmine.any(Function));
-        expect(xAxisWithDateTimeLabels).toEqual(jasmine.any(Function));
         expect(yAxis).toEqual(jasmine.any(Function));
         expect(yAxis.tickSizeInner()).toBe(100);
         expect(xAxis.scale()).toBe(xScale);


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [X] Update the changelog appropriately

Title
-----------
Reverting changes made for WDFN 213. 

Description
-----------
For this task the hydrograph date labels were placed between the midnight hour tick marks by use of a second x-axis that overlaid the first and held the date labels centered on non-visible noon ticks. This worked except that the last date label was partially cut off on the far right side of the graph at certain times during the day. There was no sound and simple solution to this so the changes were reverted.

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
