### PR TITLE
Python wheel assets symlink

### DIFF
--- a/wdfn-server/assets/dist
+++ b/wdfn-server/assets/dist
@@ -1,0 +1,1 @@
+../../assets/dist/


### PR DESCRIPTION
This fixes a deployment issue caused by the directory reordering. For the purposes of bundling data files in the wheel, I added a symlink to the built dist in the wdfn-server directory. Building locally, I got errors from setuptools about absolute paths - which don't occur on the Jenkins server - so had difficultly testing alternate options.

Before making a pull request
----------------------------

- [x] Make sure all tests run
- [x] Update the changelog appropriately

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
