### PR TITLE
Dispatch setCurrentDateRange() after the time series has been retrieved.

### DIFF
--- a/assets/src/scripts/store/index.js
+++ b/assets/src/scripts/store/index.js
@@ -113,7 +113,6 @@ export const Actions = {
             const state = getState();
             const parmCd = getCurrentParmCd(state);
             const requestKey = getTsRequestKey ('current', period, parmCd)(state);
-            dispatch(Actions.setCurrentDateRange(period));
             if (!hasTimeSeries('current', period, parmCd)(state)) {
                 const endTime = new Date(getRequestTimeRange('current', 'P7D')(state).end);
                 let startTime = calcStartTime(period, endTime);
@@ -127,6 +126,7 @@ export const Actions = {
                     series => {
                         const collection = normalize(series, requestKey);
                         dispatch(Actions.addSeriesCollection(requestKey, collection));
+                        dispatch(Actions.setCurrentDateRange(period));
                         dispatch(Actions.retrieveCompareTimeSeries(site, period, startTime, endTime));
                     },
                     () => {
@@ -134,6 +134,8 @@ export const Actions = {
                         dispatch(Actions.addSeriesCollection(requestKey, {}));
                     }
                 );
+            } else {
+                dispatch(Actions.setCurrentDateRange(period));
             }
         };
     },

--- a/assets/src/scripts/store/index.js
+++ b/assets/src/scripts/store/index.js
@@ -126,14 +126,15 @@ export const Actions = {
                     series => {
                         const collection = normalize(series, requestKey);
                         dispatch(Actions.addSeriesCollection(requestKey, collection));
-                        dispatch(Actions.setCurrentDateRange(period));
                         dispatch(Actions.retrieveCompareTimeSeries(site, period, startTime, endTime));
                     },
                     () => {
                         console.log(`Unable to fetch data for period ${period} and parameter code ${parmCd}`);
                         dispatch(Actions.addSeriesCollection(requestKey, {}));
                     }
-                );
+                ).then(() => {
+                    dispatch(Actions.setCurrentDateRange(period));
+                });
             } else {
                 dispatch(Actions.setCurrentDateRange(period));
             }

--- a/assets/src/scripts/store/index.spec.js
+++ b/assets/src/scripts/store/index.spec.js
@@ -323,10 +323,11 @@ describe('Redux store', () => {
 
             it('Should dispatch the action to set the current date range', () => {
                 mockGetState.and.returnValue(TEST_STATE);
-                store.Actions.retrieveExtendedTimeSeries('12345678', 'P30D')(mockDispatch, mockGetState);
-                expect(mockDispatch).toHaveBeenCalledWith({
-                    type: 'SET_CURRENT_DATE_RANGE',
-                    period: 'P30D'
+                store.Actions.retrieveExtendedTimeSeries('12345678', 'P30D')(mockDispatch, mockGetState).then(() => {
+                    expect(mockDispatch).toHaveBeenCalledWith({
+                        type: 'SET_CURRENT_DATE_RANGE',
+                        period: 'P30D'
+                    });
                 });
             });
 
@@ -347,7 +348,7 @@ describe('Redux store', () => {
                 let p = store.Actions.retrieveExtendedTimeSeries('12345678', 'P30D')(mockDispatch, mockGetState);
                 p.then(() => {
                     expect(mockDispatch.calls.count()).toBe(3);
-                    let arg = mockDispatch.calls.argsFor(1)[0];
+                    let arg = mockDispatch.calls.argsFor(0)[0];
                     expect(arg.type).toBe('ADD_TIMESERIES_COLLECTION');
                     expect(arg.key).toBe('current:P30D:00060');
 
@@ -450,7 +451,7 @@ describe('Redux store', () => {
 
                 p.then(() => {
                     expect(mockDispatch.calls.count()).toBe(2);
-                    let arg = mockDispatch.calls.argsFor(1)[0];
+                    let arg = mockDispatch.calls.argsFor(0)[0];
                     expect(arg.type).toBe('ADD_TIMESERIES_COLLECTION');
                     expect(arg.key).toBe('current:P30D:00060');
                     expect(arg.data).toEqual({});


### PR DESCRIPTION
This seems to fix things on Safari Desktop - would this have any consequences?