### PR TITLE
PNG service + legend/watermark + watermark mouseover bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Hydrograph can now show either last 7 days, last 30 days, or the last year of data for
 the selected timeseries. The Show last year feature also works for the three date ranges.
-- The beginnings of a node.js-based graph server was added, which returns an SVG image.
+- The beginnings of a node.js-based graph server was added, which returns a PNG image.
 - Content group tag wdfn_tng to the google analytics script.
 - Added a descriptive label and tooltip to the flood slider control.
 - Cooperator logos

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- The node.js-based graph server was updated to render PNGs rather than SVGs
 
 
 ## [0.8.0] - 2018-05-08
 ### Added
 - Hydrograph can now show either last 7 days, last 30 days, or the last year of data for
 the selected timeseries. The Show last year feature also works for the three date ranges.
-- The beginnings of a node.js-based graph server was added, which returns a PNG image.
+- The beginnings of a node.js-based graph server was added, which returns an SVG image.
 - Content group tag wdfn_tng to the google analytics script.
 - Added a descriptive label and tooltip to the flood slider control.
 - Cooperator logos

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
 - The node.js-based graph server was updated to render PNGs rather than SVGs
+
+### Fixed
+- A bug with the graph watermark intercepting mouseover events driving the tooltips was fixed.
 
 
 ## [0.8.0] - 2018-05-08

--- a/assets/src/scripts/components/hydrograph/domain.js
+++ b/assets/src/scripts/components/hydrograph/domain.js
@@ -119,11 +119,15 @@ export const getYTickDetails = function (yDomain, parmCd) {
 };
 
 
-export const tickSelector = createSelector(
+const yDomainSelector = createSelector(
     visiblePointsSelector,
     getCurrentParmCd,
-    (pointArrays, currentParmCd) => {
-        const yDomain = getYDomain(pointArrays, currentParmCd);
-        return getYTickDetails(yDomain, currentParmCd);
-    }
+    getYDomain
+);
+
+
+export const tickSelector = createSelector(
+    yDomainSelector,
+    getCurrentParmCd,
+    getYTickDetails
 );

--- a/assets/src/scripts/components/hydrograph/index.js
+++ b/assets/src/scripts/components/hydrograph/index.js
@@ -239,7 +239,7 @@ const watermark = function (elem) {
         .attr('href', STATIC_URL + '/img/USGS_green_logo.svg')
         .call(link(function(elem, layout) {
             const transformStringSmallScreen = `matrix(0.5, 0, 0, 0.5, ${(layout.width - layout.margin.left) * .025
-                    + layout.margin.left - 50}, ${layout.height * .60})`;
+                    + layout.margin.left}, ${layout.height * .60})`;
             const transformStringForAllOtherScreens = `matrix(1, 0, 0, 1, ${(layout.width - layout.margin.left) * .025
                     + layout.margin.left}, ${(layout.height * .75 - (-1 * layout.height + 503) * .12)})`;
             if (!mediaQuery(USWDS_SMALL_SCREEN)) {

--- a/assets/src/scripts/components/hydrograph/index.js
+++ b/assets/src/scripts/components/hydrograph/index.js
@@ -234,9 +234,9 @@ const createTitle = function(elem) {
 };
 
 const watermark = function (elem) {
-    elem.append('img')
+    elem.append('image')
         .classed('watermark', true)
-        .attr('src', STATIC_URL + '/img/USGS_green_logo.svg')
+        .attr('href', STATIC_URL + '/img/USGS_green_logo.svg')
         .call(link(function(elem, layout) {
             const transformStringSmallScreen = `matrix(0.5, 0, 0, 0.5, ${(layout.width - layout.margin.left) * .025
                     + layout.margin.left - 50}, ${layout.height * .60})`;
@@ -258,8 +258,7 @@ const watermark = function (elem) {
 };
 
 const timeSeriesGraph = function (elem) {
-    elem.call(watermark)
-        .append('div')
+    elem.append('div')
         .attr('class', 'hydrograph-container')
         .call(createTitle)
         .call(createTooltipText)
@@ -277,6 +276,7 @@ const timeSeriesGraph = function (elem) {
                 isInteractive: () => true
             })))
             .call(plotSvgDefs)
+            .call(watermark)
             .call(svg => {
                 svg.append('g')
                     .call(link((elem, layout) => elem.attr('transform', `translate(${layout.margin.left},${layout.margin.top})`), layoutSelector))

--- a/assets/src/scripts/layout.js
+++ b/assets/src/scripts/layout.js
@@ -1,0 +1,53 @@
+const { local } = require('d3-selection');
+
+const layoutLocal = local();
+
+
+/**
+ * Specify a layout function to be called on a D3 selection when child nodes
+ * invalidate the layout.
+ *
+ * Example usage:
+ *
+ * elem.call(layout(function (data) {
+ *     // This function will be called when children call `invalidate`
+ *     // data == {graph: {width: 200, height: 200}}
+ * });
+ * elem.append('div')
+ *     .call(invalidate({graph: {width: 200, height: 200}}));
+ *
+ * @param  {Function} layoutFunction
+ * @return {Function}
+ */
+export function layout(layoutFunction) {
+    return function (selection) {
+        selection.each(function () {
+            layoutLocal.set(this, {
+                invalidate: layoutFunction.bind(this),
+                data: {}
+            });
+        });
+    };
+}
+
+
+/**
+ * Invalidates the layout, calling the previously defined `layout` function.
+ * @param  {Object} data Layout data to accumulate for the `layout` function.
+ * @return {Function}
+ */
+export const invalidate = function (data) {
+    return function (selection) {
+        selection.each(function () {
+            const localLayout = layoutLocal.get(this);
+            if (localLayout) {
+                localLayout.data = {
+                    ...localLayout.data,
+                    ...data
+                };
+                localLayout.invalidate(localLayout.data);
+            }
+        });
+    };
+};
+

--- a/assets/src/scripts/layout.spec.js
+++ b/assets/src/scripts/layout.spec.js
@@ -1,0 +1,54 @@
+const { select } = require('d3-selection');
+
+const { layout, invalidate } = require('./layout');
+
+
+describe('layout', () => {
+    let layoutRoot;
+
+    beforeEach(() => {
+        layoutRoot = select('body').append('div');
+    });
+
+    afterEach(() => {
+        layoutRoot.remove();
+    });
+
+    it('has this bound to current node', () => {
+        layoutRoot.call(layout(function () {
+            expect(this).toBe(layoutRoot.node());
+        }));
+        layoutRoot.call(invalidate());
+    });
+
+    it('invalidation accumulates layout data', () => {
+        let acc;
+        layoutRoot.call(layout(function (data) {
+            expect(data).toBeDefined();
+            acc = data;
+        }));
+        layoutRoot.call(invalidate({'rootInfo': '1'}));
+        layoutRoot.call(invalidate({'rootInfo2': '2'}));
+        layoutRoot.call(invalidate({'rootInfo': '3'}));
+        expect(acc).toEqual({
+            'rootInfo': '3',
+            'rootInfo2': '2'
+        });
+    });
+
+    it('invalidation accumulates layout data on children', () => {
+        let acc;
+        layoutRoot.call(layout(function (data) {
+            expect(data).toBeDefined();
+            acc = data;
+        }));
+        layoutRoot.append('div')
+            .call(invalidate({'child1': '1'}));
+        layoutRoot.append('div')
+            .call(invalidate({'child2': '2'}));
+        expect(acc).toEqual({
+            'child1': '1',
+            'child2': '2'
+        });
+    });
+});

--- a/assets/src/styles/components/hydrograph/_app.scss
+++ b/assets/src/styles/components/hydrograph/_app.scss
@@ -100,14 +100,6 @@
     // Import the SVG styles for the graph
     @import './graph';
 
-    .time-series-graph-title {
-        @include h4();
-        @include media($medium-screen) {
-            @include h3();
-        }
-        text-align: center;
-    }
-
     .tooltip-text-group {
         pointer-events: none;
         position: absolute;

--- a/assets/src/styles/components/hydrograph/_app.scss
+++ b/assets/src/styles/components/hydrograph/_app.scss
@@ -136,11 +136,6 @@
     }
 }
 
-.watermark {
-    position: absolute;
-    opacity: .08;
-}
-
 .slider-wrapper {
     height: 0;
     input#cursor-slider {

--- a/assets/src/styles/components/hydrograph/_graph.scss
+++ b/assets/src/styles/components/hydrograph/_graph.scss
@@ -5,6 +5,14 @@
 
 @import './variables';
 
+.time-series-graph-title {
+    @include h4();
+    @include media($medium-screen) {
+        @include h3();
+    }
+    text-align: center;
+}
+
 svg {
     .overlay {
         fill: none;

--- a/assets/src/styles/components/hydrograph/_graph.scss
+++ b/assets/src/styles/components/hydrograph/_graph.scss
@@ -172,4 +172,8 @@ svg {
     .pump-mask {
         fill: #3498db;
     }
+    .watermark {
+        position: absolute;
+        opacity: .08;
+    }
 }

--- a/assets/src/styles/graph.scss
+++ b/assets/src/styles/graph.scss
@@ -1,2 +1,7 @@
 @import './common';
 @import './components/hydrograph/graph';
+
+.graph-controls-container,
+.slider-wrapper {
+    display: none;
+}

--- a/graph-server/README.md
+++ b/graph-server/README.md
@@ -9,6 +9,9 @@ The entrypoint is `src/index.js`, which accepts the following environment
 variables as arguments:
 
 - NODE_PORT: Port to run http server on. Default 2929.
+- SERVICE_ROOT: Default: https://waterservices.usgs.gov/nwis
+- PAST_SERVICE_ROOT: Default: https://nwis.waterservices.usgs.gov/nwis
+- STATIC_ROOT: Default: https://waterdata.usgs.gov/nwisweb/wsgi/static
 
 For example:
 

--- a/graph-server/package.json
+++ b/graph-server/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.js",
   "scripts": {
     "test": "jasmine",
-    "watch": "nodemon src"
+    "watch": "STATIC_ROOT=http://localhost:9000 nodemon src"
   },
   "engines": {
     "node": "8.9.3"

--- a/graph-server/src/renderer/impl/puppeteer.js
+++ b/graph-server/src/renderer/impl/puppeteer.js
@@ -10,8 +10,8 @@ const puppeteer = require('puppeteer');
 // node instances, and let the web server load balance between them.
 // For now, just use a single Chromium instance.
 
-async function getSvg(bundles, {pageContent, viewportSize, componentOptions}) {
-    const browser = await puppeteer.launch({headless: false});
+async function getPNG(bundles, {pageContent, viewportSize, componentOptions}) {
+    const browser = await puppeteer.launch({headless: true});
 
     // Initialize an empty page with the appropriate wdfn-component
     // TODO: Call the rendering function directly rather than rely on wdfn-component?
@@ -39,17 +39,14 @@ async function getSvg(bundles, {pageContent, viewportSize, componentOptions}) {
     const waitFor = componentOptions.compare ? '.ts-compare' : '.ts-current';
     await page.waitForSelector(waitFor);
 
-    // Get the SVG string
-    const svgHandle = await page.$('.hydrograph-container svg');
-    const svgStr = await page.evaluate((svg) => {
-        return svg.outerHTML;
-    }, svgHandle);
+    const graphHandle = await page.$('.graph-container');
+    const buffer = await graphHandle.screenshot();
 
     await page.close();
     await browser.close();
 
-    return svgStr;
+    return buffer;
 };
 
 
-module.exports = getSvg;
+module.exports = getPNG;

--- a/graph-server/src/renderer/index.js
+++ b/graph-server/src/renderer/index.js
@@ -9,8 +9,9 @@ const getSvgImpl = {
 const DEFAULT_IMPLEMENTATION = 'puppeteer';
 
 
-const SERVICE_ROOT = 'https://waterservices.usgs.gov/nwis';
-const PAST_SERVICE_ROOT = 'https://nwis.waterservices.usgs.gov/nwis';
+const SERVICE_ROOT = process.env.SERVICE_ROOT || 'https://waterservices.usgs.gov/nwis';
+const PAST_SERVICE_ROOT = process.env.PAST_SERVICE_ROOT || 'https://nwis.waterservices.usgs.gov/nwis';
+const STATIC_ROOT = process.env.STATIC_ROOT || 'https://waterdata.usgs.gov/nwisweb/wsgi/static';
 
 
 const renderToRespone = function (res, {siteID, parameterCode, compare, renderer}) {
@@ -29,7 +30,8 @@ const renderToRespone = function (res, {siteID, parameterCode, compare, renderer
                     <script type="text/javascript">
                         var CONFIG = {
                             SERVICE_ROOT: '${SERVICE_ROOT}',
-                            PAST_SERVICE_ROOT: '${PAST_SERVICE_ROOT}'
+                            PAST_SERVICE_ROOT: '${PAST_SERVICE_ROOT}',
+                            STATIC_URL: '${STATIC_ROOT}'
                         };
                     </script>
                 </head>

--- a/graph-server/src/renderer/index.js
+++ b/graph-server/src/renderer/index.js
@@ -1,8 +1,7 @@
-const { processSvg } = require('./image-util');
 const BUNDLES = require('../assets');
 
 
-const getSvgImpl = {
+const getPNGImpl = {
     puppeteer: require('./impl/puppeteer'),
     phantomjs: require('./impl/phantomjs')
 };
@@ -15,14 +14,14 @@ const STATIC_ROOT = process.env.STATIC_ROOT || 'https://waterdata.usgs.gov/nwisw
 
 
 const renderToRespone = function (res, {siteID, parameterCode, compare, renderer}) {
-    const getSvg = getSvgImpl[renderer] || getSvgImpl[DEFAULT_IMPLEMENTATION];
+    const getPNG = getPNGImpl[renderer] || getPNGImpl[DEFAULT_IMPLEMENTATION];
     const componentOptions = {
         siteno: siteID,
         parameter: parameterCode,
         compare: compare,
         cursorOffset: false
     };
-    getSvg(BUNDLES, {
+    getPNG(BUNDLES, {
         pageURL: 'http://wdfn-graph-server',
         pageContent: `<!DOCTYPE html>
             <html lang="en">
@@ -48,17 +47,10 @@ const renderToRespone = function (res, {siteID, parameterCode, compare, renderer
         },
         componentOptions
     })
-    .then(processSvg.bind(null, BUNDLES.styles))
-    .then((svgStr) => {
-        res.setHeader('Content-Type', 'image/svg+xml');
-        res.send(svgStr);
-
-        /* to write a screenshot:
-        const buffer = await page.screenshot();
+    .then((buffer) => {
         res.setHeader('Content-Type', 'image/png');
         res.write(buffer, 'binary');
         res.end(null, 'binary');
-        */
     })
     .catch(error => {
         console.log(error);


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [x] Update the changelog appropriately

WDFN-244 / WDFN-245 / WDFN-260
-----------
This PR addresses several tickets and removes the original SVG support from WDFN-243. PNGs of the complete graph (including watermark and legend) are now being returned.

On localhost, here's a sample URL:
http://localhost:2929/monitoring-location/07144100/?parameterCode=00010&compare=1


After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [ ] Assign someone to review unless the change is trivial
