### PR TITLE
Reference all SIFTA logos with https, irregardless of what the service returns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Cooperator logos are always loaded via https
+
 ## [0.12.0] - 2018-08-03
 - Cooperator logos lookup changed from static json file to external, SIFTA-based service
 

--- a/wdfn-server/waterdata/filters.py
+++ b/wdfn-server/waterdata/filters.py
@@ -135,4 +135,6 @@ def https_url(url):
     :return: URL, with the protocol set as HTTPS
     """
     parsed = urlparse(url)
+    if not parsed.netloc:
+        parsed = urlparse(f'//{url}')
     return ParseResult('https', parsed.netloc, parsed.path, *parsed[3:]).geturl()

--- a/wdfn-server/waterdata/filters.py
+++ b/wdfn-server/waterdata/filters.py
@@ -4,7 +4,7 @@ via the `app.template_filter` decorator.
 """
 import datetime
 from itertools import chain
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlparse, ParseResult
 
 from . import app
 
@@ -124,3 +124,15 @@ def tooltip_content_id(some_text):
 
     """
     return 'tooltip-{}'.format(some_text.lower().replace('_', '-'))
+
+
+@app.template_filter('https_url')
+def https_url(url):
+    """
+    Returns the HTTPS version of a URL.
+
+    :param str url: absolute URL
+    :return: URL, with the protocol set as HTTPS
+    """
+    parsed = urlparse(url)
+    return ParseResult('https', parsed.netloc, parsed.path, *parsed[3:]).geturl()

--- a/wdfn-server/waterdata/templates/monitoring_location.html
+++ b/wdfn-server/waterdata/templates/monitoring_location.html
@@ -158,8 +158,8 @@
                         <p>Operated in cooperation with:</p>
                         {% for cooperator in cooperators | sort(attribute='Name') %}
                             <figure class="cooperator_logo">
-                                <a href="{{ cooperators.URL }}">
-                                    <img src="{{ cooperator.IconURL }}" alt="logo for {{ cooperator.Name }}  }}" height = "50" >
+                                <a href="{{ cooperator.URL }}">
+                                    <img src="{{ cooperator.IconURL | https_url }}" alt="logo for {{ cooperator.Name }}" height="50">
                                 </a>
                                 <figcaption><a href="{{ cooperator.URL }}">{{ cooperator.Name }}</a></figcaption>
                             </figure>

--- a/wdfn-server/waterdata/tests/test_filters.py
+++ b/wdfn-server/waterdata/tests/test_filters.py
@@ -240,10 +240,10 @@ class TestTooltipContentIdFilter(TestCase):
         self.assertEqual(result, 'tooltip-blah-name')
 
 
-def https_url(app):
+def test_https_url(app):
     with app.test_request_context('http://abc.com/mypage'):
         url = filters.https_url('https://page.com/image.png')
-        assert url == 'https://abc.com://page.com/image.png'
+        assert url == 'https://page.com/image.png'
     with app.test_request_context('https://abc.com/mypage'):
         url = filters.https_url('https://page.com/image.png')
         assert url == 'https://page.com/image.png'

--- a/wdfn-server/waterdata/tests/test_filters.py
+++ b/wdfn-server/waterdata/tests/test_filters.py
@@ -238,3 +238,18 @@ class TestTooltipContentIdFilter(TestCase):
     def test_create(self):
         result = filters.tooltip_content_id(self.test_string)
         self.assertEqual(result, 'tooltip-blah-name')
+
+
+def https_url(app):
+    with app.test_request_context('http://abc.com/mypage'):
+        url = filters.https_url('https://page.com/image.png')
+        assert url == 'https://abc.com://page.com/image.png'
+    with app.test_request_context('https://abc.com/mypage'):
+        url = filters.https_url('https://page.com/image.png')
+        assert url == 'https://page.com/image.png'
+    with app.test_request_context('https://abc.com/mypage'):
+        url = filters.https_url('page.com/image.png')
+        assert url == 'https://page.com/image.png'
+    with app.test_request_context('http://abc.com/mypage'):
+        url = filters.https_url('page.com/image.png')
+        assert url == 'https://page.com/image.png'


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [x] Update the changelog appropriately

Description
-----------
Reference all SIFTA logos with https, irregardless of what the service returns. This is to avoid mixed-content warnings.

Using HTTPS rather than a protocol-relative URL because of this logic: https://twitter.com/paul_irish/status/588502455530311680?lang=en

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
