### PR TITLE
Wdfn 302 ticks below xaxis fix

### DIFF
--- a/assets/src/scripts/components/hydrograph/domain.js
+++ b/assets/src/scripts/components/hydrograph/domain.js
@@ -156,7 +156,7 @@ export const getRoundedTickValues = function(additionalTickValues, yDomain) {
         roundedTickValues.push(value);
         }
     });
-console.log("this is it " + JSON.stringify(roundedTickValues))
+
     return roundedTickValues;
 };
 

--- a/assets/src/scripts/components/hydrograph/domain.js
+++ b/assets/src/scripts/components/hydrograph/domain.js
@@ -7,7 +7,6 @@ import { visiblePointsSelector } from './drawingData';
 import { getCurrentParmCd } from '../../selectors/timeSeriesSelector';
 
 
-const MULTIPLE_TO_ROUND_TO = 5;
 const PADDING_RATIO = 0.2;
 const Y_TICK_COUNT = 5;
 // array of parameters that should use
@@ -111,6 +110,35 @@ export const getLowestAbsoluteValueOfTickValues = function(tickValues) {
     return lowestAbsoluteValueOfTicks;
 };
 
+
+/**
+ * Helper function that rounds numerical values in an array based on the numerical value of the individual array item
+ * and a somewhat arbitrary numeric value, a multiple of which the targeted array item's value is rounded.
+ * @param {array} additionalTickValues, numerical values for y-axis ticks
+ * @returns {array} roundedTickValues, numerical values for y-axis ticks rounded to a multiple of a given number
+ */
+const getRoundedTickValues = function(additionalTickValues) {
+    let roundedTickValues = [];
+    // round the values based on an arbitrary breakpoints and rounding targets (may result in duplicate array values)
+    additionalTickValues.forEach(function(value) {
+        if (value > 1000) {
+            value = Math.ceil(value/1000)*1000;
+            roundedTickValues.push(value);
+        } if (value > 100) {
+            value = Math.ceil(value/100)*100;
+            roundedTickValues.push(value);
+        } else {
+            value = Math.ceil(value/5)*5;
+            roundedTickValues.push(value);
+        }
+    });
+
+    // remove values that are duplicates
+    roundedTickValues = Array.from(new Set(roundedTickValues));
+
+    return roundedTickValues;
+};
+
 /**
  * Function creates a new set of tick values that will fill in gaps in log scale ticks, then combines this new set with the
  * original set of tick marks.
@@ -127,14 +155,14 @@ export const getArrayOfAdditionalTickMarks = function(tickValues) {
         additionalTickValues.push(lowestTickValueOfLogScale);
     }
 
+    // round the values to a chosen multiple of a number
+    additionalTickValues = getRoundedTickValues(additionalTickValues);
+
     // if the log scale has negative values, add additional negative ticks with negative labels
     if (tickValues.some(value => value < 0)) {
         let tickValueArrayWithNegatives = additionalTickValues.map(x => x * -1);
         additionalTickValues = tickValueArrayWithNegatives.concat(additionalTickValues);
     }
-
-    // round the values to a chosen multiple of a number such as 5
-    additionalTickValues = additionalTickValues.map(value => Math.ceil(value/MULTIPLE_TO_ROUND_TO)*MULTIPLE_TO_ROUND_TO);
 
    return additionalTickValues.concat(tickValues);
 };

--- a/assets/src/scripts/components/hydrograph/domain.js
+++ b/assets/src/scripts/components/hydrograph/domain.js
@@ -153,6 +153,7 @@ export const getRoundedTickValues = function(additionalTickValues, yDomain) {
                 roundingFactor = 5;
             }
         value = Math.ceil(value / roundingFactor) * roundingFactor;
+
         roundedTickValues.push(value);
         }
     });

--- a/assets/src/scripts/components/hydrograph/domain.js
+++ b/assets/src/scripts/components/hydrograph/domain.js
@@ -41,7 +41,8 @@ export const extendDomain = function (domain, lowerBoundPOW10) {
             extendedDomain[1]
         ];
     }
-
+console.log("this is extended domain 0 " + JSON.stringify(extendedDomain[0]))
+ console.log("this is extended domain 1 " + JSON.stringify(extendedDomain[1]))   
     // For positive domains, a zero-lower bound on the y-axis is enforced.
     return [
         isPositive ? Math.max(0, extendedDomain[0]) : extendedDomain[0],

--- a/assets/src/scripts/components/hydrograph/domain.js
+++ b/assets/src/scripts/components/hydrograph/domain.js
@@ -128,7 +128,8 @@ export const generateAdditionalTickValues = function(lowestTickValueOfLogScale) 
 
 /**
  * Helper function that rounds numerical values in an array based on the numerical value of the individual array item
- * and a somewhat arbitrary numeric value, a multiple of which the targeted array item's value is rounded.
+ * and a somewhat arbitrary numeric (rounding) value. The value in the array is then rounded to a multiple of the
+ * arbitrary numeric rounding value.
  * @param {array} additionalTickValues, numerical values for y-axis ticks
  * @returns {array} roundedTickValues, numerical values for y-axis ticks rounded to a multiple of a given number
  */
@@ -156,8 +157,8 @@ export const getRoundedTickValues = function(additionalTickValues) {
 
 
 /**
- * Helper function that checks where the x-axis intersects the y-axis and then keeps any additional tick marks with
- * values above the point of intersection.
+ * Helper function that checks where the x-axis intersects the y-axis, keeps any additional tick marks with
+ * values above the point of intersection and ignores the rest.
  * @param {array} additionalTickValues, numerical values for y-axis ticks
  * @param {array} yDomain, an array of two points, the lower and upper extent of the y-axis
  * @returns {array} tickValuesAboveXaxis, numerical values for y-axis ticks with any value below the y-axis removed
@@ -167,7 +168,7 @@ export const removeTickValuesBelowXaxis = function(additionalTickValues, yDomain
 
     for (let value of additionalTickValues) {
         if (value > yDomain[0]) {
-           tickValuesAboveXaxis.push(value)
+           tickValuesAboveXaxis.push(value);
         }
     }
 

--- a/assets/src/scripts/components/hydrograph/domain.spec.js
+++ b/assets/src/scripts/components/hydrograph/domain.spec.js
@@ -3,7 +3,9 @@ import {
     getYDomain,
     getYTickDetails,
     getArrayOfAdditionalTickMarks,
-    getLowestAbsoluteValueOfTickValues
+    getLowestAbsoluteValueOfTickValues,
+    getRoundedTickValues,
+    removeTickValuesBelowXaxis, generateNegativeTicks
 } from './domain';
 
 
@@ -100,12 +102,13 @@ describe('domain module', () => {
 
     describe('getArrayOfAdditionalTickMarks', () => {
         it('return the complete array of tick values to compensate for gaps in log scale display', () => {
+            const yDomain = [-75, 15000];
             const tickValues1 = [-1000, -100, -50, 50, 100, 1000];
             const tickValues2 = [100, 200, 500, 1000];
-            const expectedReturnedArray1 = [-25,-10,-5,-0,-0,25,15,10,5,5,-1000,-100,-50,50,100,1000];
-            const expectedReturnedArray2 = [50,25,15,10,5,5,100,200,500,1000];
-            expect(getArrayOfAdditionalTickMarks(tickValues1)).toEqual(expectedReturnedArray1);
-            expect(getArrayOfAdditionalTickMarks(tickValues2)).toEqual(expectedReturnedArray2);
+            const expectedReturnedArray1 = [-25,-15,-10,-5,25,15,10,5,-1000,-100,-50,50,100,1000];
+            const expectedReturnedArray2 = [50,25,15,10,5,100,200,500,1000];
+            // expect(getArrayOfAdditionalTickMarks(tickValues1, yDomain)).toEqual(expectedReturnedArray1);
+            expect(getArrayOfAdditionalTickMarks(tickValues2, yDomain)).toEqual(expectedReturnedArray2);
         });
     });
 
@@ -118,4 +121,41 @@ describe('domain module', () => {
         });
     });
 
+    describe('getRoundedTickValues', () => {
+        it('returns a set of numbers rounded to the multiple of a desired  number', () => {
+            const testTickValues_1 = [3, 35, 210, 490, 780];
+            const testTickValues_2 = [54, 201, 2120, 99345, 234222];
+            const expectedReturnedArray_1 = [5,35,300,500,800];
+            const expectedReturnedArray_2 = [55,300,3000,100000,235000];
+            expect(getRoundedTickValues(testTickValues_1)).toEqual(expectedReturnedArray_1);
+            expect(getRoundedTickValues(testTickValues_2)).toEqual(expectedReturnedArray_2);
+        });
+    });
+
+    describe('removeTickValuesBelowXaxis', () => {
+        it('returns a set of numbers with values less than the lowest extent of the y-axis removed', () => {
+            const yDomain_0 = [-75, 15000];
+            const yDomain_1 = [75, 15000];
+            const yDomain_2 = [3000, 15000];
+            const testTickValues = [5, 20, 2000, 5000];
+            const expectedReturnedArray_0 = [5, 20, 2000, 5000];
+            const expectedReturnedArray_1 = [2000, 5000];
+            const expectedReturnedArray_2 = [5000];
+            expect(removeTickValuesBelowXaxis(testTickValues, yDomain_0)).toEqual(expectedReturnedArray_0);
+            expect(removeTickValuesBelowXaxis(testTickValues, yDomain_1)).toEqual(expectedReturnedArray_1);
+            expect(removeTickValuesBelowXaxis(testTickValues, yDomain_2)).toEqual(expectedReturnedArray_2);
+        });
+    });
+
+    describe('generateNegativeTicks', () => {
+        it('returns a set of numbers with additional negative values when needed', () => {
+            const testTickValues_1 = [100, 500, 1000, 2000];
+            const testTickValues_2 = [-500, 100, 500, 1000, 2000];
+            const additionalTickValues = [15, 25, 50];
+            const expectedReturnedArrayNoNegatives = [15, 25, 50];
+            const expectedReturnedArrayWithNegatives = [-15, -25, -50, 15, 25, 50];
+            expect(generateNegativeTicks(testTickValues_1, additionalTickValues)).toEqual(expectedReturnedArrayNoNegatives);
+            expect(generateNegativeTicks(testTickValues_2, additionalTickValues)).toEqual(expectedReturnedArrayWithNegatives);
+        });
+    });
 });

--- a/assets/src/scripts/components/hydrograph/domain.spec.js
+++ b/assets/src/scripts/components/hydrograph/domain.spec.js
@@ -5,7 +5,7 @@ import {
     getFullArrayOfAdditionalTickMarks,
     getLowestAbsoluteValueOfTickValues,
     getRoundedTickValues,
-    removeTickValuesBelowXaxis, generateNegativeTicks
+    generateNegativeTicks
 } from './domain';
 
 

--- a/assets/src/scripts/components/hydrograph/domain.spec.js
+++ b/assets/src/scripts/components/hydrograph/domain.spec.js
@@ -107,7 +107,7 @@ describe('domain module', () => {
             const tickValues2 = [100, 200, 500, 1000];
             const expectedReturnedArray1 = [-25,-15,-10,-5,25,15,10,5,-1000,-100,-50,50,100,1000];
             const expectedReturnedArray2 = [50,25,15,10,5,100,200,500,1000];
-            // expect(getArrayOfAdditionalTickMarks(tickValues1, yDomain)).toEqual(expectedReturnedArray1);
+            expect(getArrayOfAdditionalTickMarks(tickValues1, yDomain)).toEqual(expectedReturnedArray1);
             expect(getArrayOfAdditionalTickMarks(tickValues2, yDomain)).toEqual(expectedReturnedArray2);
         });
     });

--- a/assets/src/scripts/components/hydrograph/domain.spec.js
+++ b/assets/src/scripts/components/hydrograph/domain.spec.js
@@ -2,7 +2,7 @@ import {
     extendDomain,
     getYDomain,
     getYTickDetails,
-    getArrayOfAdditionalTickMarks,
+    getFullArrayOfAdditionalTickMarks,
     getLowestAbsoluteValueOfTickValues,
     getRoundedTickValues,
     removeTickValuesBelowXaxis, generateNegativeTicks
@@ -100,15 +100,15 @@ describe('domain module', () => {
         });
     });
 
-    describe('getArrayOfAdditionalTickMarks', () => {
+    describe('getFullArrayOfAdditionalTickMarks', () => {
         it('return the complete array of tick values to compensate for gaps in log scale display', () => {
             const yDomain = [-75, 15000];
             const tickValues1 = [-1000, -100, -50, 50, 100, 1000];
             const tickValues2 = [100, 200, 500, 1000];
-            const expectedReturnedArray1 = [-25,-15,-10,-5,25,15,10,5,-1000,-100,-50,50,100,1000];
-            const expectedReturnedArray2 = [50,25,15,10,5,100,200,500,1000];
-            expect(getArrayOfAdditionalTickMarks(tickValues1, yDomain)).toEqual(expectedReturnedArray1);
-            expect(getArrayOfAdditionalTickMarks(tickValues2, yDomain)).toEqual(expectedReturnedArray2);
+            const expectedReturnedArray1 = [-30,-15,-10,-4,-2,30,15,10,4,2,-1000,-100,-50,50,100,1000];
+            const expectedReturnedArray2 = [50,30,15,10,4,2,100,200,500,1000];
+            expect(getFullArrayOfAdditionalTickMarks(tickValues1, yDomain)).toEqual(expectedReturnedArray1);
+            expect(getFullArrayOfAdditionalTickMarks(tickValues2, yDomain)).toEqual(expectedReturnedArray2);
         });
     });
 
@@ -123,27 +123,23 @@ describe('domain module', () => {
 
     describe('getRoundedTickValues', () => {
         it('returns a set of numbers rounded to the multiple of a desired  number', () => {
-            const testTickValues_1 = [3, 35, 210, 490, 780];
-            const testTickValues_2 = [54, 201, 2120, 99345, 234222];
-            const expectedReturnedArray_1 = [5,35,300,500,800];
-            const expectedReturnedArray_2 = [55,300,3000,100000,235000];
-            expect(getRoundedTickValues(testTickValues_1)).toEqual(expectedReturnedArray_1);
-            expect(getRoundedTickValues(testTickValues_2)).toEqual(expectedReturnedArray_2);
-        });
-    });
-
-    describe('removeTickValuesBelowXaxis', () => {
-        it('returns a set of numbers with values less than the lowest extent of the y-axis removed', () => {
             const yDomain_0 = [-75, 15000];
             const yDomain_1 = [75, 15000];
             const yDomain_2 = [3000, 15000];
-            const testTickValues = [5, 20, 2000, 5000];
-            const expectedReturnedArray_0 = [5, 20, 2000, 5000];
-            const expectedReturnedArray_1 = [2000, 5000];
-            const expectedReturnedArray_2 = [5000];
-            expect(removeTickValuesBelowXaxis(testTickValues, yDomain_0)).toEqual(expectedReturnedArray_0);
-            expect(removeTickValuesBelowXaxis(testTickValues, yDomain_1)).toEqual(expectedReturnedArray_1);
-            expect(removeTickValuesBelowXaxis(testTickValues, yDomain_2)).toEqual(expectedReturnedArray_2);
+            const testTickValues_1 = [3, 35, 210, 490, 780];
+            const testTickValues_2 = [54, 201, 2120, 99345, 234222];
+            const expectedReturnedArray_1_1 = [3,40,300,500,800];
+            const expectedReturnedArray_1_2 = [300,500,800];
+            const expectedReturnedArray_1_3 = [];
+            const expectedReturnedArray_2_1 = [60,300,3000,100000,240000];
+            const expectedReturnedArray_2_2 = [300,3000,100000,240000];
+            const expectedReturnedArray_2_3 = [100000,240000];
+            expect(getRoundedTickValues(testTickValues_1, yDomain_0)).toEqual(expectedReturnedArray_1_1);
+            expect(getRoundedTickValues(testTickValues_1, yDomain_1)).toEqual(expectedReturnedArray_1_2);
+            expect(getRoundedTickValues(testTickValues_1, yDomain_2)).toEqual(expectedReturnedArray_1_3);
+            expect(getRoundedTickValues(testTickValues_2, yDomain_0)).toEqual(expectedReturnedArray_2_1);
+            expect(getRoundedTickValues(testTickValues_2, yDomain_1)).toEqual(expectedReturnedArray_2_2);
+            expect(getRoundedTickValues(testTickValues_2, yDomain_2)).toEqual(expectedReturnedArray_2_3);
         });
     });
 


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [x] Update the changelog appropriately

WDFN-302 Part 2, Bug fix for tick marks below x-axis
-----------
Added logic to stop the additional tick marks from showing below the x-axis
Fixed the uneven display of negative vs positive tick marks
Made rounding of numbers relative to the size of the tick value rounded 

Description
-----------
Repairs several issues found while testing

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
