### PR TITLE
revert core-js to 2.6.5, last working version

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -2018,9 +2018,9 @@
       }
     },
     "core-js": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.0.1.tgz",
-      "integrity": "sha512-sco40rF+2KlE0ROMvydjkrVMMG1vYilP2ALoRXcYR4obqbYIuV3Bg+51GEDW+HF8n7NRA+iaA4qD0nD9lo9mew=="
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
+      "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A=="
     },
     "core-util-is": {
       "version": "1.0.2",

--- a/assets/package.json
+++ b/assets/package.json
@@ -81,7 +81,7 @@
   },
   "dependencies": {
     "autotrack": "^2.4.1",
-    "core-js": "^3.0.1",
+    "core-js": "^2.6.5",
     "d3": "^5.9.2",
     "date-time-format-timezone": "^1.0.21",
     "element-closest": "^3.0.1",


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [ ] Update the changelog appropriately

Revert Core-JS to 2.6.5, Last Know Working Version
-----------
The Travis build is failing after a set of dependency updates. The update to Core-js, originally failed the Travis build and seems suspect. This reversion is to test that theory.

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the JIRA ticket
- [ ] Assign someone to review unless the change is trivial
