### PR TITLE
Brush offset did not reset when periods changed

### DIFF
--- a/assets/src/scripts/components/hydrograph/date-controls.js
+++ b/assets/src/scripts/components/hydrograph/date-controls.js
@@ -137,7 +137,7 @@ export const drawDateRangeControls = function(elem, store, siteno) {
                     siteno,
                     userSpecifiedStart,
                     userSpecifiedEnd
-                )).then(() => store.dispatch(Actions.clearHydrographXRange()));
+                )).then(() => store.dispatch(Actions.clearHydrographBrushOffset()));
             }
         });
 
@@ -175,7 +175,7 @@ export const drawDateRangeControls = function(elem, store, siteno) {
                     siteno,
                     li.select('input:checked').attr('value')
                 )).then(() => {
-                    store.dispatch(Actions.clearHydrographXRange());
+                    store.dispatch(Actions.clearHydrographBrushOffset());
                 });
             }
         });

--- a/assets/src/scripts/components/hydrograph/index.spec.js
+++ b/assets/src/scripts/components/hydrograph/index.spec.js
@@ -428,12 +428,12 @@ describe('Hydrograph charting and Loading indicators and data alerts', () => {
                     currentVariableID: '45807197',
                     currentDateRange: 'P7D',
                     currentMethodID: 'method1',
-                    loadingTSKeys: []
+                    loadingTSKeys: [],
+                    hydrographBrushOffset: null
                 },
                 ui: {
                     windowWidth: 400,
-                    width: 400,
-                    hydrographXRange: undefined
+                    width: 400
                 }
 
             });
@@ -548,12 +548,12 @@ describe('Hydrograph charting and Loading indicators and data alerts', () => {
                     currentVariableID: '45807197',
                     currentDateRange: 'P7D',
                     currentMethodID: 'method1',
-                    loadingTSKeys: []
+                    loadingTSKeys: [],
+                    hydrographBrushOffset: null
                 },
                 ui: {
                     windowWidth: 400,
-                    width: 400,
-                    hydrographXRange: undefined
+                    width: 400
                 }
 
             });

--- a/wdfn-server/waterdata/utils.py
+++ b/wdfn-server/waterdata/utils.py
@@ -23,7 +23,7 @@ def execute_get_request(hostname, path=None, params=None):
     """
     target = urljoin(hostname, path)
     try:
-        resp = r.get(target, params=params)S
+        resp = r.get(target, params=params)
     except (r.exceptions.Timeout, r.exceptions.ConnectionError) as err:
         app.logger.debug(repr(err))
         resp = r.Response()  # return an empty response object

--- a/wdfn-server/waterdata/utils.py
+++ b/wdfn-server/waterdata/utils.py
@@ -23,7 +23,7 @@ def execute_get_request(hostname, path=None, params=None):
     """
     target = urljoin(hostname, path)
     try:
-        resp = r.get(target, params=params)
+        resp = r.get(target, params=params)S
     except (r.exceptions.Timeout, r.exceptions.ConnectionError) as err:
         app.logger.debug(repr(err))
         resp = r.Response()  # return an empty response object


### PR DESCRIPTION
All tests pass

IOW-299

During testing on Dev found that after toggling back from a retrieved 1 year time series to a 30 month or 7 day time series the brush offsets would not reset.  This is addressing that problem.

Thanks.