### PR TITLE
Removed helpers import that made build fail

### DIFF
--- a/assets/src/scripts/network/index.js
+++ b/assets/src/scripts/network/index.js
@@ -2,10 +2,6 @@ import '../polyfills';
 
 import wdfnviz from 'wdfn-viz';
 
-// Load misc Javascript helpers for general page interactivity.
-import {register} from '../helpers';
-register();
-
 import {configureStore} from './store';
 
 import {attachToNode as NetworkMapComponent} from './components/network-sites';


### PR DESCRIPTION
- [x] Make sure all tests run
- [x] Update the changelog appropriately

Title
-----------
Removed import for tooltip helpers

Description
-----------
Tooltip helpers file was deleted, but still imported into a file, causing build to fail. This PR removes that import.

