### PR TITLE
Revert properties to original cases

### DIFF
--- a/wdfn-server/waterdata/schema.py
+++ b/wdfn-server/waterdata/schema.py
@@ -220,10 +220,8 @@ class Query(ObjectType):
         url = 'https://www.waterqualitydata.us/data/Station/search?mimeType=geojson'
         data = kwargs
         resp = requests.post(url=url, data=data)
-        print(resp)
         features = json.dumps(resp.json()['features'])
         features_obj = json2obj(features)
-
         return {"count": len(features_obj), "features": features_obj}
 
     monitoring_location = Field(MonitoringLocation, site_no=String())

--- a/wdfn-server/waterdata/schema.py
+++ b/wdfn-server/waterdata/schema.py
@@ -158,18 +158,18 @@ class Properties(ObjectType):
     """
     Properties field for Feature
     """
-    monitoring_location_name = String()
-    provider_name = String()
-    organization_identifier = String()
-    organization_formal_name = String()
-    monitoring_location_identifier = ID()
-    monitoring_location_type_name = String()
-    resolvedmonitoring_location_type_name = String()
-    HUC_eight_digit_code = String()
-    site_url = String()
-    activity_count = String()
-    result_count = String()
-    state_name = String()
+    MonitoringLocationName = String()
+    ProviderName = String()
+    OrganizationIdentifier = String()
+    OrganizationFormalName = String()
+    MonitoringLocationIdentifier = ID()
+    MonitoringLocationTypeName = String()
+    ResolvedMonitoringLocationTypeName = String()
+    HUCEightDigitCode = String()
+    siteUrl = String()
+    activityCount = String()
+    resultCount = String()
+    stateName = String()
 
 
 class Geometry(ObjectType):
@@ -220,8 +220,10 @@ class Query(ObjectType):
         url = 'https://www.waterqualitydata.us/data/Station/search?mimeType=geojson'
         data = kwargs
         resp = requests.post(url=url, data=data)
+        print(resp)
         features = json.dumps(resp.json()['features'])
         features_obj = json2obj(features)
+
         return {"count": len(features_obj), "features": features_obj}
 
     monitoring_location = Field(MonitoringLocation, site_no=String())


### PR DESCRIPTION
Before making a pull request
----------------------------

- [ ] Make sure all tests run
- [ ] Update the changelog appropriately

Title
-----------
Revert properties to original cases

Description
-----------
Last PR #1135  attempted to rename properties to follow python standards, but it causes breaking in the result object.  Reverting back to the original cases they use first and will follow with a different PR to change names to follow standards.

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the JIRA ticket
- [ ] Assign someone to review unless the change is trivial
