### PR TITLE
Wdfn 342 rel noopener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/usgs/waterdataui/compare/waterdataui-0.36.0...master)
+### Added
+- Added rel="noopener" attribute to links with target="_blank" attribute.
 
 ## [0.36.0](https://github.com/usgs/waterdataui/compare/waterdataui-0.35.0...waterdataui-0.36.0) - 2020-08-25
 ### Changed

--- a/wdfn-server/waterdata/templates/macros/components.html
+++ b/wdfn-server/waterdata/templates/macros/components.html
@@ -41,7 +41,7 @@
         <div id="flood-layer-control-container"></div>
         <div id="site-map"></div>
         <div>
-            <a class="usa-link" href="https://waterdata.usgs.gov/blog/nldi-intro/" target="_blank" >About the Network-Linked Data Index (NLDI)</a>
+            <a class="usa-link" href="https://waterdata.usgs.gov/blog/nldi-intro/" target="_blank" rel="noopener" >About the Network-Linked Data Index (NLDI)</a>
         </div>
     </div>
 {%- endmacro %}

--- a/wdfn-server/waterdata/templates/monitoring_location.html
+++ b/wdfn-server/waterdata/templates/monitoring_location.html
@@ -72,7 +72,7 @@
                     <h1>{{ stations[0].station_nm }}</h1>
                     <div>
                         <span class="usa-tag">Important</span>
-                        <a id="classic-page-link" class="usa-link" aria-describedby="{{ 'classic'|tooltip_content_id }}" href="{{ config.NWIS_ENDPOINTS.UV}}?site_no={{stations[0].site_no}}" target="_blank">Classic Page</a>
+                        <a id="classic-page-link" class="usa-link" aria-describedby="{{ 'classic'|tooltip_content_id }}" href="{{ config.NWIS_ENDPOINTS.UV}}?site_no={{stations[0].site_no}}" target="_blank" rel="noopener">Classic Page</a>
                         {{ components.QuestionTooltip('classic', 'View all current conditions values on the classic Water Data for the Nation interface.', True) }}
                     </div>
                     <p id="site-description">{{ components.Description(stations[0].site_no, location_with_values, parm_grp_summary) }}</p>
@@ -88,18 +88,18 @@
                         <div id="ts-a1a" class="usa-accordion__content">
                             <div>Most recent image</div>
                             <div style="float:left">
-                                <a href="{{ monitoring_camera.video  }}" title="click image to open full-size video" target="_blank">
+                                <a href="{{ monitoring_camera.video  }}" title="click image to open full-size video" target="_blank" rel="noopener">
                                     <img width="200" src="{{ monitoring_camera.thumb }}" alt="lastest camera image thumbnail">
                                 </a>
                             </div>
                             <div style="float:right">
                                 <div><b>Frames Gallery: </b>
-                                    <a href="{{ monitoring_camera.frame_gallery }}" target="_blank">
+                                    <a href="{{ monitoring_camera.frame_gallery }}" target="_blank" rel="noopener">
                                         Last 99 Frames
                                     </a>
                                 </div>
                                 <div><b>Video Folder: </b>
-                                    <a href="{{ monitoring_camera.video_index }}" target="_blank">
+                                    <a href="{{ monitoring_camera.video_index }}" target="_blank" rel="noopener">
                                         Index of videos and images
                                     </a>
                                 </div>
@@ -160,7 +160,7 @@
                                     {% endfor %}
                                 </tbody>
                             </table>
-                            <a class="usa-link" href="{{ config.NWIS_ENDPOINTS.INVENTORY}}?site_no={{ stations[0].site_no }}" target="_blank">Classic Water Data for the Nation Inventory</a>
+                            <a class="usa-link" href="{{ config.NWIS_ENDPOINTS.INVENTORY}}?site_no={{ stations[0].site_no }}" target="_blank" rel="noopener">Classic Water Data for the Nation Inventory</a>
                         </div>
                     </div>
                 {% endif %}

--- a/wdfn-server/waterdata/templates/partials/base.html
+++ b/wdfn-server/waterdata/templates/partials/base.html
@@ -6,7 +6,7 @@
                 <label title="Close" class="close" for="wdfn-alert-dismiss"><i class="fas fa-times"></i></label>
                 <div>
                     <ul>
-                        <li>Beta release. Use <a class="usa-link" target="_blank" href="https://water.usgs.gov/contact/gsanswers?pemail=gs-w_water_data_for_the_nation&subject=Water%20Data%20for%20the%20Nation%20Feedback&viewnote=%3CH1%3EUSGS+WDFN+TNG+Feedback%3C/H1%3E">this form</a> to provide feedback.</li>
+                        <li>Beta release. Use <a class="usa-link" target="_blank" rel="noopener" href="https://water.usgs.gov/contact/gsanswers?pemail=gs-w_water_data_for_the_nation&subject=Water%20Data%20for%20the%20Nation%20Feedback&viewnote=%3CH1%3EUSGS+WDFN+TNG+Feedback%3C/H1%3E">this form</a> to provide feedback.</li>
                         {% for notice in config.BANNER_NOTICES %}
                             <li>{{ notice|safe }}</li>
                         {% endfor %}

--- a/wdfn-server/waterdata/templates/partials/social_share.html
+++ b/wdfn-server/waterdata/templates/partials/social_share.html
@@ -2,10 +2,10 @@
 
 {% with share_encoded_url = url_for(request.endpoint, _external=True, **request.view_args)|urlencode %}
     <div class="social-share">
-        <a href="https://www.facebook.com/sharer/sharer.php?u={{ share_encoded_url }}" target="_blank">
+        <a href="https://www.facebook.com/sharer/sharer.php?u={{ share_encoded_url }}" target="_blank" rel="noopener">
             <i class="fab fa-facebook-square" aria-label="Share on Facebook"></i>
         </a>
-        <a href="https://twitter.com/home?status={{ share_encoded_url }}" target="_blank">
+        <a href="https://twitter.com/home?status={{ share_encoded_url }}" target="_blank" rel="noopener">
             <i class="fab fa-twitter-square" aria-label="Share on Twitter"></i>
         </a>
         <span class="embed-container">


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [x] Update the changelog appropriately

WDFN-342 Add Attribute rel="noopener"
-----------
Adds the rel='noopener' attribute to links with the target='_blank' attribute. 

Description
-----------
Minor change that adds the attribute of rel="noopener" to links with the target='_blank' attribute to prevent malicious websites opened in a new tab from hijacking the window.opener method of the originating window and altering the contents. While it seems that this would be a pretty minor issue for us, since all of our links go to fine upstanding residents of the internet, Google indicates that this is best practice. I wasn't able to get Lighthouse to run a report locally so testing this may require deployment to 'dev.' I searched the project thoroughly and only found eight occurrences of links with the attribute target="_blank" that didn't have the rel="noopener", all of which where in wdfn-server files. I found two instances of links in the assets server files but those already had the rel="noopener" attribute added. 

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
