### PR TITLE
Add site summaries to search results

### DIFF
--- a/assets/src/scripts/wdfn-home/index.js
+++ b/assets/src/scripts/wdfn-home/index.js
@@ -10,8 +10,10 @@ import {configureStore} from './store/wdfn-store';
 
 import {attachToNode as USMapComponent} from './usmap';
 import {attachToNode as WDFNParamFilters} from './wdfn-param-filters';
+import {attachToNode as SiteSummaries} from './site-summary';
 
 const COMPONENTS = {
+    'site-summaries': SiteSummaries,
     'us-map': USMapComponent,
     'wdfn-param-filters': WDFNParamFilters
 };

--- a/assets/src/scripts/wdfn-home/selectors/wdfn-selector.js
+++ b/assets/src/scripts/wdfn-home/selectors/wdfn-selector.js
@@ -1,5 +1,6 @@
 import { createSelector } from 'reselect';
 
+export const getLoadingState = state => state.wdfnData.uiState.loading || '';
 export const Sites = state => state.wdfnData.sites || {};
 export const siteTypes = state => state.wdfnData.filters.siteTypes || {};
 export const Filters = state => state.wdfnData.filters || {};

--- a/assets/src/scripts/wdfn-home/site-summary/index.js
+++ b/assets/src/scripts/wdfn-home/site-summary/index.js
@@ -1,0 +1,36 @@
+import { select } from 'd3-selection';
+import { link } from '../../lib/d3-redux';
+import { Sites } from '../selectors/wdfn-selector';
+
+const SiteSummaries = (node, store) => {
+    const siteSummaryTmpl = (siteName, siteId) => {
+      return `<li>
+                <h3>${siteName}</h3>
+                <p class="site-id">${siteId}</p>
+              </li>`;
+    };
+
+    const populateSiteSummaries = (node, sites) => {
+      const mapContainer = document.getElementById('wdfn-map-container');
+      const siteSummariesList = document.querySelector('#site-summaries ul');
+
+      if (sites && sites.length > 0) {
+        mapContainer.dataset.summariesVisible = 'true';
+
+        const siteListMarkup = sites.map(s => {
+          return siteSummaryTmpl(s.properties.MonitoringLocationName, 
+            s.properties.MonitoringLocationIdentifier);
+        });
+
+        siteSummariesList.innerHTML = siteListMarkup.join('');
+      }
+    };
+
+    node
+        .call(link(store, populateSiteSummaries, Sites));
+};
+
+export const attachToNode = function(store, node) {
+  select(node)
+    .call(SiteSummaries, store);
+};

--- a/assets/src/scripts/wdfn-home/site-summary/index.js
+++ b/assets/src/scripts/wdfn-home/site-summary/index.js
@@ -20,9 +20,9 @@ const SiteSummaries = (node, store) => {
 
         const siteListMarkup = sites.map(s => {
           return siteSummaryTmpl(
-            s.properties.MonitoringLocationName, 
-            s.properties.MonitoringLocationIdentifier,
-            s.properties.MonitoringLocationTypeName
+            s.properties.monitoringLocationName, 
+            s.properties.monitoringLocationIdentifier,
+            s.properties.monitoringLocationTypeName
           );
         });
 

--- a/assets/src/scripts/wdfn-home/site-summary/index.js
+++ b/assets/src/scripts/wdfn-home/site-summary/index.js
@@ -3,10 +3,11 @@ import { link } from '../../lib/d3-redux';
 import { Sites } from '../selectors/wdfn-selector';
 
 const SiteSummaries = (node, store) => {
-    const siteSummaryTmpl = (siteName, siteId) => {
+    const siteSummaryTmpl = (siteName, siteId, siteType) => {
       return `<li>
                 <h3>${siteName}</h3>
                 <p class="site-id">${siteId}</p>
+                <p class="site-type">${siteType}</p>
               </li>`;
     };
 
@@ -18,8 +19,11 @@ const SiteSummaries = (node, store) => {
         mapContainer.dataset.summariesVisible = 'true';
 
         const siteListMarkup = sites.map(s => {
-          return siteSummaryTmpl(s.properties.MonitoringLocationName, 
-            s.properties.MonitoringLocationIdentifier);
+          return siteSummaryTmpl(
+            s.properties.MonitoringLocationName, 
+            s.properties.MonitoringLocationIdentifier,
+            s.properties.MonitoringLocationTypeName
+          );
         });
 
         siteSummariesList.innerHTML = siteListMarkup.join('');

--- a/assets/src/scripts/wdfn-home/store/wdfn-data-reducer.js
+++ b/assets/src/scripts/wdfn-home/store/wdfn-data-reducer.js
@@ -4,7 +4,8 @@ import {
   APPLY_SITE_TYPE_FILTER, 
   APPLY_PARAMETER_FILTER,
   SET_COUNT,
-  APPLY_PERIOD_FILTER
+  APPLY_PERIOD_FILTER,
+  SET_LOADING_STATE
 } from './wdfn-store';
 
 const INITIAL_DATA = {
@@ -62,6 +63,14 @@ export const wdfnDataReducer = function(wdfnData=INITIAL_DATA, action) {
                 ...wdfnData,
                 count: action.count
             };
+      case SET_LOADING_STATE:
+        return {
+          ...wdfnData,
+          uiState: {
+            ...wdfnData.uiState,
+            loading: action.loadingState
+          }
+        };
         default: return wdfnData;
     }
 };

--- a/assets/src/scripts/wdfn-home/store/wdfn-store.js
+++ b/assets/src/scripts/wdfn-home/store/wdfn-store.js
@@ -191,11 +191,14 @@ export const retrieveWdfnData = function ({ siteTypes, bBox, parameters, timePer
           variables.startDateLo = timePeriod;
         }
 
+        dispatch(applyLoadingState('loading'));
+
         executeGraphQlQuery(mapQuery, variables)
             .then(resp => JSON.parse(resp))
             .then(({ data }) => {
-                dispatch(setWdfnFeatures(data.monitoringLocations.features));
-                dispatch(setCount(data.monitoringLocations.count));
+                dispatch(setWdfnFeatures(data.allFeatures.features));
+                dispatch(setCount(data.allFeatures.count));
+                dispatch(applyLoadingState('loaded'));
             });
     };
 };

--- a/assets/src/scripts/wdfn-home/store/wdfn-store.js
+++ b/assets/src/scripts/wdfn-home/store/wdfn-store.js
@@ -199,6 +199,10 @@ export const retrieveWdfnData = function ({ siteTypes, bBox, parameters, timePer
                 dispatch(setWdfnFeatures(data.allFeatures.features));
                 dispatch(setCount(data.allFeatures.count));
                 dispatch(applyLoadingState('loaded'));
+            })
+            .catch(error => {
+                console.error(error);
+                dispatch(applyLoadingState('error'));
             });
     };
 };

--- a/assets/src/scripts/wdfn-home/store/wdfn-store.js
+++ b/assets/src/scripts/wdfn-home/store/wdfn-store.js
@@ -7,6 +7,7 @@ import {wdfnDataReducer as wdfnData} from './wdfn-data-reducer';
 
 export const SET_COUNT = 'SET_COUNT';
 export const SET_WDFN_FEATURES = 'SET_WDFN_FEATURES';
+export const SET_LOADING_STATE = 'SET_LOADING_STATE';
 export const APPLY_PARAMETER_FILTER = 'APPLY_PARAMETER_FILTER';
 export const APPLY_PERIOD_FILTER = 'APPLY_PERIOD_FILTER';
 export const APPLY_SITE_TYPE_FILTER = 'APPLY_SITE_TYPE_FILTER';
@@ -31,7 +32,10 @@ export const STORE_STRUCTURE = {
           parameters: []
       },
       count: 0,
-      sites: []
+      sites: [],
+      uiState: {
+        loading: false
+      }
   }
 };
 
@@ -142,6 +146,24 @@ const setPeriodFilter = function (startDate) {
 export const applyPeriodFilter = function (startDate) {
   return function (dispatch) {
     dispatch(setPeriodFilter(startDate));
+  };
+};
+
+const setLoadingState = function (loadingState) {
+  return {
+    type: SET_LOADING_STATE,
+    loadingState
+  };
+};
+
+/*
+ * Asynchronous Redux action to set the loading state 
+ * @param { String } loadingState
+ * @returns Redux dispatch function
+ */
+export const applyLoadingState = function (loadingState) {
+  return function (dispatch) {
+    dispatch(setLoadingState(loadingState));
   };
 };
 

--- a/assets/src/scripts/wdfn-home/store/wdfn-store.js
+++ b/assets/src/scripts/wdfn-home/store/wdfn-store.js
@@ -46,11 +46,11 @@ export const STORE_STRUCTURE = {
  */
 const lookupSiteTypesFullNames = function (siteTypes) {
     const dictionary = {
-        groundwater: ['Aggregate groundwater use', 'Well', 'Subsurface'],
-        surfacewater: ['Aggregate surface-water-use', 'Stream', 'Lake, Reservoir, Impoundment'],
+        groundwater: ['Well', 'Subsurface'],
+        surfacewater: ['Estuary', 'Stream', 'Lake, Reservoir, Impoundment', 'Ocean', 'Wetland'],
         atmospheric: 'Atmosphere',
         spring: 'Spring',
-        other: ['Facility', 'Land']
+        other: ['Facility', 'Land', 'Aggregate groundwater use', 'Aggregate surface-water-use', 'Glacier']
     };
 
     siteTypes = Object.keys(siteTypes).flatMap(st => {

--- a/assets/src/scripts/wdfn-home/store/wdfn-store.js
+++ b/assets/src/scripts/wdfn-home/store/wdfn-store.js
@@ -196,8 +196,8 @@ export const retrieveWdfnData = function ({ siteTypes, bBox, parameters, timePer
         executeGraphQlQuery(mapQuery, variables)
             .then(resp => JSON.parse(resp))
             .then(({ data }) => {
-                dispatch(setWdfnFeatures(data.allFeatures.features));
-                dispatch(setCount(data.allFeatures.count));
+                dispatch(setWdfnFeatures(data.monitoringLocations.features));
+                dispatch(setCount(data.monitoringLocations.count));
                 dispatch(applyLoadingState('loaded'));
             })
             .catch(error => {

--- a/assets/src/scripts/wdfn-home/usmap/index.js
+++ b/assets/src/scripts/wdfn-home/usmap/index.js
@@ -3,8 +3,7 @@ import { link } from '../../lib/d3-redux';
 import { Sites } from '../selectors/wdfn-selector';
 import config from '../../config';
 import { 
-  applyGeographicFilter,
-  retrieveWdfnData 
+  applyGeographicFilter
 } from '../store/wdfn-store';
 
 /*

--- a/assets/src/scripts/wdfn-home/usmap/index.js
+++ b/assets/src/scripts/wdfn-home/usmap/index.js
@@ -55,7 +55,7 @@ const usMap = function(node, {latitude, longitude, zoom}, store) {
             if (f.geometry && f.properties) {
                 const marker = L.circle(f.geometry.coordinates.reverse(), {
                     radius: 5000,
-                    className: `site-marker ${f.properties.MonitoringLocationIdentifier}`
+                    className: `site-marker ${f.properties.monitoringLocationIdentifier}`
                 });
                 marker.addTo(markerGroup);
             }

--- a/assets/src/scripts/wdfn-home/usmap/index.js
+++ b/assets/src/scripts/wdfn-home/usmap/index.js
@@ -53,12 +53,10 @@ const usMap = function(node, {latitude, longitude, zoom}, store) {
         markerGroup.addTo(map);
 
         features.forEach(f => {
-            if (f.geometry) {
+            if (f.geometry && f.properties) {
                 const marker = L.circle(f.geometry.coordinates.reverse(), {
-                    color: 'red',
-                    fillColor: '#f03',
-                    fillOpacity: 0.2,
-                    radius: 5000
+                    radius: 5000,
+                    className: `site-marker ${f.properties.MonitoringLocationIdentifier}`
                 });
                 marker.addTo(markerGroup);
             }

--- a/assets/src/scripts/wdfn-home/usmap/index.js
+++ b/assets/src/scripts/wdfn-home/usmap/index.js
@@ -47,7 +47,7 @@ const usMap = function(node, {latitude, longitude, zoom}, store) {
 
     map.on('moveend', setBboxFilter);
 
-    const addSiteCircles = (node, features) => {
+    const addSiteCircles = (_, features) => {
         markerGroup.clearLayers();
         markerGroup.addTo(map);
 

--- a/assets/src/scripts/wdfn-home/wdfn-param-filters/index.js
+++ b/assets/src/scripts/wdfn-home/wdfn-param-filters/index.js
@@ -100,8 +100,6 @@ const WDFNParamFilters = (node, store) => {
 
       if (hasSiteType)
           store.dispatch(retrieveWdfnData(filters));
-      
-      store.dispatch(applyLoadingState('loading'));
   };
 
   const filterForm = document.getElementById('monitoring-location-search');
@@ -120,6 +118,7 @@ const WDFNParamFilters = (node, store) => {
   const setLoadingState = (_, loadingState) => {
     const mapContainerEl = document.getElementById('wdfn-map-container');
     const submitBtn = document.getElementById('wdfn-search-submit');
+
     mapContainerEl.dataset.loadingState = loadingState;
     if (loadingState == 'loaded') submitBtn.innerText = 'Update results';
   };

--- a/assets/src/scripts/wdfn-home/wdfn-param-filters/index.js
+++ b/assets/src/scripts/wdfn-home/wdfn-param-filters/index.js
@@ -119,7 +119,9 @@ const WDFNParamFilters = (node, store) => {
 
   const setLoadingState = (_, loadingState) => {
     const mapContainerEl = document.getElementById('wdfn-map-container');
+    const submitBtn = document.getElementById('wdfn-search-submit');
     mapContainerEl.dataset.loadingState = loadingState;
+    if (loadingState == 'loaded') submitBtn.innerText = 'Update results';
   };
 
   const toggleSearchEnabled = (_, filters) => {

--- a/assets/src/scripts/wdfn-home/wdfn-param-filters/index.js
+++ b/assets/src/scripts/wdfn-home/wdfn-param-filters/index.js
@@ -1,11 +1,12 @@
 import { select } from 'd3-selection';
 import { link } from '../../lib/d3-redux';
-import { Filters, Count } from '../selectors/wdfn-selector';
+import { Filters, Count, getLoadingState } from '../selectors/wdfn-selector';
 import { 
   applySiteTypeFilter,
   applyParamFilter,
   applyPeriodFilter,
-  retrieveWdfnData
+  retrieveWdfnData,
+  applyLoadingState
 } from '../store/wdfn-store';
 
 const getDateRanges = () => {
@@ -99,6 +100,8 @@ const WDFNParamFilters = (node, store) => {
 
       if (hasSiteType)
           store.dispatch(retrieveWdfnData(filters));
+      
+      store.dispatch(applyLoadingState('loading'));
   };
 
   const filterForm = document.getElementById('monitoring-location-search');
@@ -111,10 +114,18 @@ const WDFNParamFilters = (node, store) => {
   const setCount = (_, count) => {
       if (typeof count !== 'number') return 0;
       document.querySelector('#result-count span').textContent = count;
+      store.dispatch(applyLoadingState('loaded'));
+  };
+
+  const setLoadingState = (_, loadingState) => {
+    const mapContainerEl = document.getElementById('wdfn-map-container');
+    mapContainerEl.dataset.loadingState = loadingState;
   };
 
   node
       .call(link(store, setCount, Count));
+  node
+      .call(link(store, setLoadingState, getLoadingState));
 };
 
 export const attachToNode = function(store, node) {

--- a/assets/src/scripts/wdfn-home/wdfn-param-filters/index.js
+++ b/assets/src/scripts/wdfn-home/wdfn-param-filters/index.js
@@ -124,6 +124,7 @@ const WDFNParamFilters = (node, store) => {
 
   const toggleSearchEnabled = (_, filters) => {
     let activeFilters = 0;
+    const filterInstructions = document.querySelector('.filter-instructions');
 
     const submitBtn = document.getElementById('wdfn-search-submit');
 
@@ -140,6 +141,7 @@ const WDFNParamFilters = (node, store) => {
     const isDisabled = activeFilters < 2;
     submitBtn.ariaDisabled = isDisabled;
     submitBtn.disabled = isDisabled;
+    filterInstructions.hidden = !isDisabled;
   };
 
   node

--- a/assets/src/scripts/wdfn-home/wdfn-param-filters/index.js
+++ b/assets/src/scripts/wdfn-home/wdfn-param-filters/index.js
@@ -122,10 +122,32 @@ const WDFNParamFilters = (node, store) => {
     mapContainerEl.dataset.loadingState = loadingState;
   };
 
+  const toggleSearchEnabled = (_, filters) => {
+    let activeFilters = 0;
+
+    const submitBtn = document.getElementById('wdfn-search-submit');
+
+    const siteTypeFilters = Object.values(filters.siteTypes);
+    if (siteTypeFilters.some(v => v)) activeFilters += 1;
+
+    if (filters.timePeriod) activeFilters += 1;
+
+    const bboxFilters = Object.values(filters.bBox);
+    if (bboxFilters.every(v => v)) activeFilters += 1;
+
+    if (filters.parameters.length > 0) activeFilters += 1;
+
+    const isDisabled = activeFilters < 2;
+    submitBtn.ariaDisabled = isDisabled;
+    submitBtn.disabled = isDisabled;
+  };
+
   node
       .call(link(store, setCount, Count));
   node
       .call(link(store, setLoadingState, getLoadingState));
+  node
+      .call(link(store, toggleSearchEnabled, Filters));
 };
 
 export const attachToNode = function(store, node) {

--- a/assets/src/scripts/wdfn-home/wdfn-param-filters/index.js
+++ b/assets/src/scripts/wdfn-home/wdfn-param-filters/index.js
@@ -64,9 +64,13 @@ const WDFNParamFilters = (node, store) => {
     const checkedParams = document.querySelectorAll('#filter-site-params input:checked');
     const checkedParamsValues = Array.from(checkedParams).map(checkbox => {
       const value = checkbox.value;
-      if (value != '/') return value;
+      if (value != '/') {
+        return value; 
+      }
     }).filter(el => {
-      if (typeof el != 'undefined') return el;
+      if (typeof el != 'undefined') {
+        return el;
+      }
     });
 
     store.dispatch(applyParamFilter(checkedParamsValues));
@@ -120,7 +124,10 @@ const WDFNParamFilters = (node, store) => {
     const submitBtn = document.getElementById('wdfn-search-submit');
 
     mapContainerEl.dataset.loadingState = loadingState;
-    if (loadingState == 'loaded') submitBtn.innerText = 'Update results';
+
+    if (loadingState == 'loaded') {
+      submitBtn.innerText = 'Update results';
+    }
   };
 
   const toggleSearchEnabled = (_, filters) => {
@@ -130,14 +137,22 @@ const WDFNParamFilters = (node, store) => {
     const submitBtn = document.getElementById('wdfn-search-submit');
 
     const siteTypeFilters = Object.values(filters.siteTypes);
-    if (siteTypeFilters.some(v => v)) activeFilters += 1;
+    if (siteTypeFilters.some(v => v)) { 
+      activeFilters += 1; 
+    }
 
-    if (filters.timePeriod) activeFilters += 1;
+    if (filters.timePeriod) { 
+      activeFilters += 1; 
+    }
 
     const bboxFilters = Object.values(filters.bBox);
-    if (bboxFilters.every(v => v)) activeFilters += 1;
+    if (bboxFilters.every(v => v)) { 
+      activeFilters += 1; 
+    }
 
-    if (filters.parameters.length > 0) activeFilters += 1;
+    if (filters.parameters.length > 0) { 
+      activeFilters += 1;
+    }
 
     const isDisabled = activeFilters < 2;
     submitBtn.ariaDisabled = isDisabled;

--- a/assets/src/scripts/web-services/graphql.js
+++ b/assets/src/scripts/web-services/graphql.js
@@ -22,6 +22,7 @@ query($bBox: String,
         monitoringLocationName
         siteUrl
         monitoringLocationIdentifier
+        monitoringLocationTypeName
       }
     }
     count

--- a/assets/src/styles/pages/_wdfn-site-search.scss
+++ b/assets/src/styles/pages/_wdfn-site-search.scss
@@ -60,20 +60,11 @@
   border-top: 1px solid color($theme-color-base-light);
   margin-top: 1rem;
   padding-top: 1rem;
+  position: relative;
   width: 100%;
 
   .result-count {
     margin-right: 1rem;
-  }
-
-  .explanation {
-    visibility: hidden;
-  }
-
-  &:hover {
-    button:disabled + .explanation {
-      visibility: visible;
-    }
   }
 }
 

--- a/assets/src/styles/pages/_wdfn-site-search.scss
+++ b/assets/src/styles/pages/_wdfn-site-search.scss
@@ -66,3 +66,53 @@
     margin-right: 1rem;
   }
 }
+
+.wdfn-map-container {
+  position: relative;
+  $site-summary-column-width: 300px;
+
+  .site-summaries {
+    display: none;
+  }
+  
+  &[data-summaries-visible="true"] {
+    .site-summaries {
+      background-color: color('green-cool-5v');
+      display: block;
+      height: 350px;
+      width: $site-summary-column-width;
+      overflow: scroll;
+      position: absolute;
+      z-index: 1100;
+
+      $list-border-style: 1px solid color('gray-cool-20');
+
+      ul {
+        border: $list-border-style;
+        list-style-type: none;
+        margin: 0;
+        padding: 0;
+      }
+
+      li {
+        border-bottom: $list-border-style;
+        padding: units(1) units(2);
+      }
+
+      h3 {
+        font-size: size('body', 'sm');
+        margin: units('05') 0;
+      }
+
+      .site-id {
+        color: color('base');
+        font-size: size('body', '2xs');
+        margin: units('05') 0;
+      }
+    }
+
+    .leaflet-control-zoom {
+      margin-left: $site-summary-column-width + 10px;
+    }
+  }
+}

--- a/assets/src/styles/pages/_wdfn-site-search.scss
+++ b/assets/src/styles/pages/_wdfn-site-search.scss
@@ -126,6 +126,30 @@
     opacity: 0.5;
     fill-opacity: 0.3;
   }
+
+  .loading-modal {
+    display: none;
+  }
+
+  &[data-loading-state="loading"] {
+    .loading-modal {
+      background-color: rgba(120,120,190,.3); 
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      height: 350px;
+      width: 100%;
+      position: absolute;
+      z-index: 1200;
+    }
+
+    .loading {
+      background: white;
+      border: 1px solid color('base');
+      border-radius: units(2);
+      padding: units(2);
+    }
+  }
 }
 
 

--- a/assets/src/styles/pages/_wdfn-site-search.scss
+++ b/assets/src/styles/pages/_wdfn-site-search.scss
@@ -16,7 +16,7 @@
     list-style-type: none;
   }
 
-  h4 {
+  h4, label {
     margin-top: 0;
   }
 

--- a/assets/src/styles/pages/_wdfn-site-search.scss
+++ b/assets/src/styles/pages/_wdfn-site-search.scss
@@ -65,6 +65,16 @@
   .result-count {
     margin-right: 1rem;
   }
+
+  .explanation {
+    visibility: hidden;
+  }
+
+  &:hover {
+    button:disabled + .explanation {
+      visibility: visible;
+    }
+  }
 }
 
 .wdfn-map-container {

--- a/assets/src/styles/pages/_wdfn-site-search.scss
+++ b/assets/src/styles/pages/_wdfn-site-search.scss
@@ -104,10 +104,14 @@
         margin: units('05') 0;
       }
 
-      .site-id {
+      .site-id, .site-type {
         color: color('base');
         font-size: size('body', '2xs');
         margin: units('05') 0;
+      }
+
+      .site-type {
+        margin-top: units('105');
       }
     }
 

--- a/assets/src/styles/pages/_wdfn-site-search.scss
+++ b/assets/src/styles/pages/_wdfn-site-search.scss
@@ -119,4 +119,13 @@
       margin-left: $site-summary-column-width + 10px;
     }
   }
+
+  .site-marker {
+    fill: red;
+    stroke: #f03;
+    opacity: 0.5;
+    fill-opacity: 0.3;
+  }
 }
+
+

--- a/assets/src/styles/pages/_wdfn-site-search.scss
+++ b/assets/src/styles/pages/_wdfn-site-search.scss
@@ -66,6 +66,14 @@
   .result-count {
     margin-right: 1rem;
   }
+
+  .share-search {
+    margin-left: auto;
+  }
+  
+  .download:after {
+    content: '»';
+  }
 }
 
 .wdfn-map-container {

--- a/wdfn-server/waterdata/schema.py
+++ b/wdfn-server/waterdata/schema.py
@@ -183,7 +183,7 @@ class Query(ObjectType):
     Queries
     """
     monitoring_locations = Field(MonitoringLocations,
-                                 site_type=List(String),
+                                 siteType=List(String),
                                  providers=List(String),
                                  bBox=String(),
                                  startDateLo=String(),

--- a/wdfn-server/waterdata/templates/macros/components.html
+++ b/wdfn-server/waterdata/templates/macros/components.html
@@ -46,12 +46,6 @@
     </div>
 {%- endmacro %}
 
-{% macro USMapComponent(latitude, longitude, zoom) -%}
-  <div class="wdfn-component" data-component="us-map" data-latitude="{{ latitude }}" data-longitude="{{ longitude }}" data-zoom="{{zoom}}">
-        <div id="site-map"></div>
-  </div>
-{%- endmacro %}
-
 {% macro USWDSCheckbox(name, label, value) -%}
     <div class="usa-checkbox">
       <input type="checkbox" 

--- a/wdfn-server/waterdata/templates/wdfn.html
+++ b/wdfn-server/waterdata/templates/wdfn.html
@@ -184,6 +184,16 @@
                         >
                   Show results
                 </button>
+                <button class="usa-button share-search" 
+                        disabled
+                        >
+                  Share this search 
+                </button>
+                <button class="usa-button download" 
+                        disabled
+                        >
+                  Refine and download
+                </button>
               </div>
             </form>
         </div>

--- a/wdfn-server/waterdata/templates/wdfn.html
+++ b/wdfn-server/waterdata/templates/wdfn.html
@@ -15,6 +15,13 @@
       <h1>Explore USGS Water Data</h1>
         <div class="wdfn-component" data-component="wdfn-param-filters">
             <form action="" class="grid-row" id="monitoring-location-search">
+              <div class="alerts">
+                <div class="usa-alert usa-alert--info filter-instructions">
+                  <div class="usa-alert__body">
+                    <p class="usa-alert__text">Please select at least two filters</p>
+                  </div>
+                </div>
+              </div>
               <div class="grid-row">
                   <fieldset class="usa-fieldset tablet:grid-col-2" id="site-type-filters">
                       <legend class="usa-fieldset"><h3>Type of sites</h3></legend>
@@ -177,7 +184,6 @@
                         >
                   Show results
                 </button>
-                <p class="explanation">Please select at least two filters from the form above</p>
               </div>
             </form>
         </div>

--- a/wdfn-server/waterdata/templates/wdfn.html
+++ b/wdfn-server/waterdata/templates/wdfn.html
@@ -170,6 +170,24 @@
                                   </li>
                               </ul>
                           </div>
+                          <div class="filter-param-list grid-col">
+                            <label class="usa-label" for="all-parameters">All USGS Parameters</label>
+                            <div class="usa-combo-box"
+                              
+                              
+                            >
+                              <select
+                                class="usa-select"
+                                name="all-parameters"
+                                id="all-parameters"
+                                
+                                
+                              >
+                                <option value>Select a parameter</option>
+                                <option value="test">Just testing</option>
+                              </select>
+                              <p class="explanation">View a list of all parameters</p>
+                          </div>
                       </div>
                   </fieldset>
               </div>

--- a/wdfn-server/waterdata/templates/wdfn.html
+++ b/wdfn-server/waterdata/templates/wdfn.html
@@ -172,16 +172,11 @@
                           </div>
                           <div class="filter-param-list grid-col">
                             <label class="usa-label" for="all-parameters">All USGS Parameters</label>
-                            <div class="usa-combo-box"
-                              
-                              
-                            >
+                            <div class="usa-combo-box">
                               <select
                                 class="usa-select"
                                 name="all-parameters"
                                 id="all-parameters"
-                                
-                                
                               >
                                 <option value>Select a parameter</option>
                                 <option value="test">Just testing</option>

--- a/wdfn-server/waterdata/templates/wdfn.html
+++ b/wdfn-server/waterdata/templates/wdfn.html
@@ -170,7 +170,14 @@
                 <div id="result-count" class="result-count" aria-live="polite">
                     Number of matching sites: <span>0</span>
                 </div>
-                <button class="usa-button" type="submit">Show results</button>
+                <button class="usa-button" 
+                        type="submit" 
+                        id="wdfn-search-submit"
+                        class="wdfn-search-submit"
+                        >
+                  Show results
+                </button>
+                <p class="explanation">Please select at least two filters from the form above</p>
               </div>
             </form>
         </div>

--- a/wdfn-server/waterdata/templates/wdfn.html
+++ b/wdfn-server/waterdata/templates/wdfn.html
@@ -174,6 +174,14 @@
               </div>
             </form>
         </div>
-      {{ USMapComponent(latitude, longitude, zoom) }}
+        <div class="wdfn-component wdfn-map-container" 
+             id="wdfn-map-container"
+             data-component="site-summaries"
+             data-summaries-visible="false">
+          <div id="site-summaries" class="site-summaries">
+            <ul></ul>
+          </div>
+          {{ USMapComponent(latitude, longitude, zoom) }}
+        </div>
     </div>
 {% endblock content %}

--- a/wdfn-server/waterdata/templates/wdfn.html
+++ b/wdfn-server/waterdata/templates/wdfn.html
@@ -4,6 +4,12 @@
 
 {% import 'macros/components.html' as components %}
 
+{% macro USMapComponent(latitude, longitude, zoom) -%}
+  <div class="wdfn-component" data-component="us-map" data-latitude="{{ latitude }}" data-longitude="{{ longitude }}" data-zoom="{{zoom}}">
+        <div id="site-map"></div>
+  </div>
+{%- endmacro %}
+
 {% block content %}
     <div class="usa-width-one-whole">
       <h1>Explore USGS Water Data</h1>
@@ -168,6 +174,6 @@
               </div>
             </form>
         </div>
-      {{ components.USMapComponent(latitude, longitude, zoom) }}
+      {{ USMapComponent(latitude, longitude, zoom) }}
     </div>
 {% endblock content %}

--- a/wdfn-server/waterdata/templates/wdfn.html
+++ b/wdfn-server/waterdata/templates/wdfn.html
@@ -188,7 +188,10 @@
              data-loading-state="first-load"
              >
           <div id="loading-modal" class="loading-modal">
-            <div class="loading">Loading…</div>
+            <div class="loading">
+              <i class="fas fa-spinner fa-spin"></i>
+              Loading…
+            </div>
           </div>
           <div id="site-summaries" class="site-summaries">
             <ul></ul>

--- a/wdfn-server/waterdata/templates/wdfn.html
+++ b/wdfn-server/waterdata/templates/wdfn.html
@@ -177,7 +177,12 @@
         <div class="wdfn-component wdfn-map-container" 
              id="wdfn-map-container"
              data-component="site-summaries"
-             data-summaries-visible="false">
+             data-summaries-visible="false"
+             data-loading-state="first-load"
+             >
+          <div id="loading-modal" class="loading-modal">
+            <div class="loading">Loading…</div>
+          </div>
           <div id="site-summaries" class="site-summaries">
             <ul></ul>
           </div>


### PR DESCRIPTION
In anticipation of the next round of user research, this PR adds the following bits of functionality to the prototype:

* Add a sidebar to the search results map that has summary info for each of the monitoring locations returned from the API:
![search results](https://user-images.githubusercontent.com/6290/91491884-bb0ff880-e882-11ea-9552-10baca5107de.png)

* Show a loading overlay and spinner to give users visual feedback that the search is happening:
![loading](https://user-images.githubusercontent.com/6290/91492020-ea266a00-e882-11ea-8b18-458964ee558b.gif)

* Disable the search button when there are fewer than 2 filters applied (to avoid giant queries)
![filter-validation](https://user-images.githubusercontent.com/6290/91492099-07f3cf00-e883-11ea-836f-535cab287481.gif)


* Add some non-functional elements to the filter form that are necessary for testing. Wireframe for reference:
![Wireframe](https://user-images.githubusercontent.com/6290/91494685-3a073000-e887-11ea-80ea-98d479e14079.jpeg)

* Small changes to make this branch consistent with changes in 9d758c4