### PR TITLE
Quick bugfix for testing sessions

### DIFF
--- a/assets/src/scripts/wdfn-home/wdfn-param-filters/index.js
+++ b/assets/src/scripts/wdfn-home/wdfn-param-filters/index.js
@@ -100,10 +100,7 @@ const WDFNParamFilters = (node, store) => {
   const fetchMatchingSites = (filters) => {
       if (Object.keys(filters).length === 0) return;
 
-      const hasSiteType = Object.values(filters.siteTypes).some(el => el);
-
-      if (hasSiteType)
-          store.dispatch(retrieveWdfnData(filters));
+      store.dispatch(retrieveWdfnData(filters));
   };
 
   const filterForm = document.getElementById('monitoring-location-search');


### PR DESCRIPTION
# Remove guard condition preventing queries from running when no site type is selected

One-line change to the filter form. Before implementing the functionality to disable submitting the form when <2 filters were applied, I had a guard in there to require a site type to be selected before running a query just to prevent running queries with no filters. This was just to keep from accidentally hammering the API during development. This validation is handled in the [`toggleSearchEnabled`](https://github.com/usgs/waterdataui/compare/18F...mh-new-wdfn-ui-for-user-research?expand=1#diff-8368f07754b89e3c69bfc225d0305f15L133) method now.