### PR TITLE
Add 'All' option to time period filter

### DIFF
--- a/assets/src/scripts/wdfn-home/store/wdfn-store.js
+++ b/assets/src/scripts/wdfn-home/store/wdfn-store.js
@@ -187,7 +187,7 @@ export const retrieveWdfnData = function ({ siteTypes, bBox, parameters, timePer
             variables.pCode = parameters;
         }
 
-        if (timePeriod) {
+        if (timePeriod && timePeriod !== 'all') {
           variables.startDateLo = timePeriod;
         }
 

--- a/assets/src/scripts/wdfn-home/wdfn-param-filters/index.js
+++ b/assets/src/scripts/wdfn-home/wdfn-param-filters/index.js
@@ -20,7 +20,8 @@ const getDateRanges = () => {
     '5': `${month}-${day}-${year - 5}`,
     '10': `${month}-${day}-${year - 10}`,
     '20': `${month}-${day}-${year - 20}`,
-    '50': `${month}-${day}-${year - 50}`
+    '50': `${month}-${day}-${year - 50}`,
+    'all': 'all'
   };
 };
 

--- a/wdfn-server/waterdata/templates/wdfn.html
+++ b/wdfn-server/waterdata/templates/wdfn.html
@@ -46,6 +46,7 @@
                       {{ components.USWDSRadio("period-10-years", "period", "10 years", "10") }}
                       {{ components.USWDSRadio("period-20-years", "period", "20 years", "20") }}
                       {{ components.USWDSRadio("period-50-years", "period", "50 years", "50") }}
+                      {{ components.USWDSRadio("period-all", "period", "166 years (all)", "all") }}
                   </fieldset>
                   <fieldset class="usa-fieldset tablet:grid-col-8" id="filter-site-params">
                       <legend>


### PR DESCRIPTION
The time period filter did not have an "all" option. This PR just adds one, so that users can go back to pulling data from all time periods without having to refresh the page & lose their place.
