### PR TITLE
Wdfn 425 network monitoring page throws error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Changed the word 'Toggle' to 'Display' for the 'median' checkbox.
 - Moved the 'provisional data statement' to a separate page--added link below graph.
 
+### Fixed
+- Issue where networks/monitoring-locations/ caused an error
+
 ## [0.36.0](https://github.com/usgs/waterdataui/compare/waterdataui-0.35.0...waterdataui-0.36.0) - 2020-08-25
 ### Changed
 - Removed custom tooltips and replaced with USWDS tooltip component.

--- a/wdfn-server/waterdata/templates/macros/components.html
+++ b/wdfn-server/waterdata/templates/macros/components.html
@@ -46,13 +46,15 @@
                 <div>{{ narrative|safe }}</div>
             {% endif %}
 
-            {% if collection.properties.contactInformation.contactName and collection.properties.contactInformation.contactEmail %}
-            <label class="bold-label" for="contact-info">Network Contact</label><br>
-            <span id="contact-info">
-                <span id="contact-name">{{ collection.properties.contactInformation.contactName }}</span>
-                <span><a class="usa-link" href="mailto:{{ collection.properties.contactInformation.contactEmail }}"><i class="fas fa-envelope"></i></a>
-                <a id="contact-email" class="usa-link" href="mailto:{{ collection.properties.contactInformation.contactEmail }}">{{ collection.properties.contactInformation.contactEmail }}</a></span>
-            </span>
+            {% if collection.properties.contactInformation %} {# compensates for missing contactInformation attribute in JSON for networks/monitoring-locations #}
+                {% if collection.properties.contactInformation.contactName and collection.properties.contactInformation.contactEmail %}
+                <label class="bold-label" for="contact-info">Network Contact</label><br>
+                <span id="contact-info">
+                    <span id="contact-name">{{ collection.properties.contactInformation.contactName }}</span>
+                    <span><a class="usa-link" href="mailto:{{ collection.properties.contactInformation.contactEmail }}"><i class="fas fa-envelope"></i></a>
+                    <a id="contact-email" class="usa-link" href="mailto:{{ collection.properties.contactInformation.contactEmail }}">{{ collection.properties.contactInformation.contactEmail }}</a></span>
+                </span>
+                {% endif %}
             {% endif %}
 
             {% if collection.properties.cooperators %}

--- a/wdfn-server/waterdata/views.py
+++ b/wdfn-server/waterdata/views.py
@@ -215,7 +215,7 @@ def networks(network_cd):
     if network_cd:
         collection = network_data
         extent = network_data['extent']['spatial']['bbox'][0]
-        narrative = markdown(network_data['properties']['narrative']) if network_data['properties']['narrative'] else None
+        narrative = markdown(network_data['properties']['narrative']) if network_data['properties'].get('narrative') else None
     else:
         collection = network_data.get('collections')
         extent = None


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [x] Update the changelog appropriately

WDFN 425 network monitoring page throws error
-----------
Fix for error when attempting to reach networks/monitoring-locations

Description
-----------
The issue is caused by the code expecting the a JSON file with a values
	"properties": {
             "contactInformation": {
                 "contactName": "Internet of Water Product Owners",
		 "contactEmail": "GS-W-iow_product_owners@usgs.gov"
           }		
	}
But is receiving . . .
	"properties": {
		"contactName": "Internet of Water Product Owners",
		"contactEmail": "GS-W-iow_product_owners@usgs.gov"
	}

The code changes add some extra guardrails to ignore the unexpected JSON

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
