### PR TITLE
fix null select issue

### DIFF
--- a/assets/src/scripts/monitoring-location/components/daily-value-hydrograph/graph-brush.js
+++ b/assets/src/scripts/monitoring-location/components/daily-value-hydrograph/graph-brush.js
@@ -30,15 +30,11 @@ export const drawGraphBrush = function(container, store) {
         const CENTERING_DIVISOR_LARGE_SCREEN = 3;
         const CENTERING_DIVISOR_SMALL_SCREEN = 2.3;
 
-        // if the user clicks a point in the brush area without making an actual selection, remove the custom handles
-        if (event.selection == null) {
-            customHandle.attr('display', 'none');
-        }
         customHandle.attr('transform', function(d, index) {
             const yPositionForCustomHandle = mediaQuery(config.USWDS_LARGE_SCREEN) ?
                 -layoutHeight / CENTERING_DIVISOR_LARGE_SCREEN :
                 -layoutHeight / CENTERING_DIVISOR_SMALL_SCREEN;
-            return `translate(${event.selection[index]}, ${yPositionForCustomHandle})`;
+            return event.selection != null ? `translate(${event.selection[index]}, ${yPositionForCustomHandle})` : null;
         });
 
         if (!event.sourceEvent || event.sourceEvent.type === 'zoom') {

--- a/assets/src/scripts/monitoring-location/components/hydrograph/graph-brush.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/graph-brush.js
@@ -29,15 +29,11 @@ export const drawGraphBrush = function(container, store) {
         const CENTERING_DIVISOR_LARGE_SCREEN = 3.3;
         const CENTERING_DIVISOR_SMALL_SCREEN = 2.5;
 
-        // if the user clicks a point in the brush area without making an actual selection, remove the custom handles
-        if (event.selection == null) {
-            customHandle.attr('display', 'none');            
-        }
         customHandle.attr('transform', function(d, index) {
             const yPositionForCustomHandle = mediaQuery(config.USWDS_LARGE_SCREEN) ?
                 -layoutHeight / CENTERING_DIVISOR_LARGE_SCREEN :
                 -layoutHeight / CENTERING_DIVISOR_SMALL_SCREEN;
-            return `translate(${event.selection[index]}, ${yPositionForCustomHandle})`;
+            return event.selection != null ? `translate(${event.selection[index]}, ${yPositionForCustomHandle})` : null;
         });
 
         if (!event.sourceEvent || event.sourceEvent.type === 'zoom') {
@@ -117,7 +113,7 @@ export const drawGraphBrush = function(container, store) {
                 const y = layoutHeight / 2;
 
                 // Create the svg path using the standard SVG commands M, A, V etc. and substituted variables.
-                return `M ${.5 * x},${y} 
+                return `M ${.5 * x},${y}
                     A6,6 0 0 ${east} ${6.5 * x},${y + 6}
                     V${2 * y - 6}
                     A6,6 0 0 ${east} ${.5 * x},${2 * y}


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [ ] Update the changelog appropriately

Fix the Null Selection Issue with the Brush Area and Custom Handles
-----------
This returns the original functionality where, when the user clicks a 'null' selection in the brush area, the brush area reverts to the maximum extent of the brush area.

Description
-----------
This actually turned out to be a small bug in that the code didn't execute completely when a null selection event occurred. I had originally added code that removed the custom brush handles on a null selection event, which kinda covered up the problem, but this is an actual solution, which is always better :)

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
