### PR TITLE
Fix Issue with Custom Handle Not Being Clickable 

### DIFF
--- a/assets/src/scripts/monitoring-location/components/daily-value-hydrograph/graph-brush.js
+++ b/assets/src/scripts/monitoring-location/components/daily-value-hydrograph/graph-brush.js
@@ -98,7 +98,8 @@ export const drawGraphBrush = function(container, store) {
             svg.select('.brush').remove();
 
             const group = svg.append('g').attr('class', 'brush')
-                .attr('transform', `translate(${layout.margin.left},${layout.margin.top})`).call(graphBrush);
+                .attr('transform', `translate(${layout.margin.left},${layout.margin.top})`)
+                .call(graphBrush);
 
             /* Draws the custom brush handle using an SVG path. The path is drawn twice, once for the handle
             * on the left hand side, which in d3 brush terms is referred to as 'east' (data type 'e'), and then
@@ -128,8 +129,6 @@ export const drawGraphBrush = function(container, store) {
                 .enter().append('path')
                 .attr('class', 'handle--custom')
                 .attr('d', brushResizePath);
-
-
 
             // Add a class so the default handles can have styling that won't conflict with the slider handle
             svg.selectAll('.handle').classed('standard-brush-handle', true);

--- a/assets/src/scripts/monitoring-location/components/daily-value-hydrograph/graph-brush.js
+++ b/assets/src/scripts/monitoring-location/components/daily-value-hydrograph/graph-brush.js
@@ -91,15 +91,14 @@ export const drawGraphBrush = function(container, store) {
             layoutHeight = layout.height;
 
             const graphBrush = brushX()
+                .extent([[0, 0], [layout.width - layout.margin.right, layout.height - layout.margin.bottom - layout.margin.top]])
+                .handleSize([1]) // make default handle 1px wide
                 .on('brush end', brushed);
 
             svg.select('.brush').remove();
 
             const group = svg.append('g').attr('class', 'brush')
-                .attr('transform', `translate(${layout.margin.left},${layout.margin.top})`);
-
-            graphBrush.handleSize([1]); // make default handle 1px wide
-            graphBrush.extent([[0, 0], [layout.width - layout.margin.right, layout.height - layout.margin.bottom - layout.margin.top]]);
+                .attr('transform', `translate(${layout.margin.left},${layout.margin.top})`).call(graphBrush);
 
             /* Draws the custom brush handle using an SVG path. The path is drawn twice, once for the handle
             * on the left hand side, which in d3 brush terms is referred to as 'east' (data type 'e'), and then
@@ -130,8 +129,7 @@ export const drawGraphBrush = function(container, store) {
                 .attr('class', 'handle--custom')
                 .attr('d', brushResizePath);
 
-            // Creates the brush
-            group.call(graphBrush);
+
 
             // Add a class so the default handles can have styling that won't conflict with the slider handle
             svg.selectAll('.handle').classed('standard-brush-handle', true);

--- a/assets/src/scripts/monitoring-location/components/hydrograph/graph-brush.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/graph-brush.js
@@ -14,6 +14,7 @@ import {isVisible} from './selectors/time-series-data';
 import {drawDataLines} from './time-series-lines';
 import {mediaQuery} from '../../../utils';
 import config from '../../../config';
+import {getXAxis} from "../daily-value-hydrograph/selectors/axes";
 
 /*
  * Renders a brush element within container for the main graph
@@ -76,7 +77,7 @@ export const drawGraphBrush = function(container, store) {
                     getBrushLayout
                 ))
                 .call(link(store, appendXAxis, createStructuredSelector({
-                    xAxis: getBrushXAxis,
+                    xAxis: getXAxis('BRUSH'),
                     layout: getBrushLayout
                 })))
                 .call(link(store, drawDataLines, createStructuredSelector({
@@ -130,6 +131,7 @@ export const drawGraphBrush = function(container, store) {
                 .data([{type: 'w'}, {type: 'e'}])
                 .enter().append('path')
                 .attr('class', 'handle--custom')
+                .attr('cursor', 'ew-resize')
                 .attr('d', brushResizePath);
 
             // Creates the brush

--- a/assets/src/scripts/monitoring-location/components/hydrograph/graph-brush.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/graph-brush.js
@@ -14,7 +14,6 @@ import {isVisible} from './selectors/time-series-data';
 import {drawDataLines} from './time-series-lines';
 import {mediaQuery} from '../../../utils';
 import config from '../../../config';
-import {getXAxis} from "../daily-value-hydrograph/selectors/axes";
 
 /*
  * Renders a brush element within container for the main graph
@@ -77,7 +76,7 @@ export const drawGraphBrush = function(container, store) {
                     getBrushLayout
                 ))
                 .call(link(store, appendXAxis, createStructuredSelector({
-                    xAxis: getXAxis('BRUSH'),
+                    xAxis: getBrushXAxis,
                     layout: getBrushLayout
                 })))
                 .call(link(store, drawDataLines, createStructuredSelector({

--- a/assets/src/scripts/monitoring-location/components/hydrograph/graph-brush.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/graph-brush.js
@@ -93,15 +93,15 @@ export const drawGraphBrush = function(container, store) {
             layoutHeight = layout.height;
 
             const graphBrush = brushX()
+                .extent([[0, 0], [layout.width - layout.margin.right, layout.height - layout.margin.bottom - layout.margin.top]])
+                .handleSize([1]) // make default handle 1px wide
                 .on('brush end', brushed);
 
             svg.select('.brush').remove();
 
             const group = svg.append('g').attr('class', 'brush')
-                .attr('transform', `translate(${layout.margin.left}, ${layout.margin.top})`);
-
-            graphBrush.handleSize([1]); // make default handle 1px wide
-            graphBrush.extent([[0, 0], [layout.width - layout.margin.right, layout.height - layout.margin.bottom - layout.margin.top]]);
+                .attr('transform', `translate(${layout.margin.left}, ${layout.margin.top})`)
+                .call(graphBrush)
 
             /* Draws the custom brush handle using an SVG path. The path is drawn twice, once for the handle
             * on the left hand side, which in d3 brush terms is referred to as 'east' (data type 'e'), and then
@@ -130,11 +130,7 @@ export const drawGraphBrush = function(container, store) {
                 .data([{type: 'w'}, {type: 'e'}])
                 .enter().append('path')
                 .attr('class', 'handle--custom')
-                .attr('cursor', 'ew-resize')
                 .attr('d', brushResizePath);
-
-            // Creates the brush
-            group.call(graphBrush);
 
             // Add a class so the default handles can have styling that won't conflict with the slider handle
             svg.selectAll('.handle').classed('standard-brush-handle', true);

--- a/assets/src/styles/components/dv-hydrograph.scss
+++ b/assets/src/styles/components/dv-hydrograph.scss
@@ -215,6 +215,7 @@ svg {
 
   .handle--custom {
     stroke: color('black');
+    fill: color('white');
     cursor: 'ew-resize';
   }
   .standard-brush-handle {

--- a/assets/src/styles/components/hydrograph/_app.scss
+++ b/assets/src/styles/components/hydrograph/_app.scss
@@ -146,6 +146,7 @@
     .handle--custom {
       stroke: color('black');
       fill: color('white');
+      cursor: 'ew-resize';
     }
     .standard-brush-handle {
       fill: color('black');

--- a/assets/src/styles/components/hydrograph/_app.scss
+++ b/assets/src/styles/components/hydrograph/_app.scss
@@ -145,6 +145,7 @@
 
     .handle--custom {
       stroke: color('black');
+      fill: color('white');
       cursor: 'ew-resize';
     }
     .standard-brush-handle {

--- a/assets/src/styles/components/hydrograph/_app.scss
+++ b/assets/src/styles/components/hydrograph/_app.scss
@@ -146,7 +146,6 @@
     .handle--custom {
       stroke: color('black');
       fill: color('white');
-      cursor: 'ew-resize';
     }
     .standard-brush-handle {
       fill: color('black');


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [ ] Update the changelog appropriately

Fix Issue with Custom Handle Not Being Clickable 
-----------
Makes the custom handles clickable 

Description
-----------
Turns out the issue here was with SVG rendering order. The custom brush handle was being added to the SVG prior to the 'overlay' such that they were under the overlay but were visible through it. As such, the handles were clickable when on the edge (outside) of the brush area, but once moved into the brush area they were under the 'overlay' and were not accessible to clicks. Changing the rendering order fixed this issue (and made the code cleaner too!)

I also added a white fill to the handles to make them look a bit more polished. 

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
