### PR TITLE
Wdfn 426 brush axis missing tick marks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Moved the 'provisional data statement' to a separate page--added link below graph.
 
 ### Fixed
+- Issue that removed tick marks from main graph's brush area
 - Issue where networks/monitoring-locations/ caused an error
 
 ## [0.36.0](https://github.com/usgs/waterdataui/compare/waterdataui-0.35.0...waterdataui-0.36.0) - 2020-08-25

--- a/assets/src/scripts/d3-rendering/tick-marks.js
+++ b/assets/src/scripts/d3-rendering/tick-marks.js
@@ -87,7 +87,7 @@ export const generateTimeTicks = function(startMillis, endMillis, ianaTimeZone) 
 
     let result = {
         dates: [],
-        format: null
+        format: {}
     };
 
     if (dayCount <= 3) {

--- a/assets/src/scripts/monitoring-location/components/daily-value-hydrograph/graph-brush.spec.js
+++ b/assets/src/scripts/monitoring-location/components/daily-value-hydrograph/graph-brush.spec.js
@@ -70,6 +70,7 @@ describe ('monitoring-location/components/daily-value-hydrograph/graph-brush mod
             expect(div.select('.brush-text-hint').size()).toBe(1);
             expect(div.selectAll('.handle').size()).toBe(2);
             expect(div.selectAll('.handle--custom').size()).toBe(2);
+            expect(div.selectAll('.tick').size()).toBe(5);
         });
 
         it('Should create a DV line, and an x-axis', () => {

--- a/assets/src/scripts/monitoring-location/components/hydrograph/graph-brush.spec.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/graph-brush.spec.js
@@ -171,6 +171,7 @@ describe ('monitoring-location/components/hydrograph/graph-brush module', () => 
             expect(div.select('.brush-text-hint').size()).toBe(1);
             expect(div.selectAll('.handle').size()).toBe(2);
             expect(div.selectAll('.handle--custom').size()).toBe(2);
+            expect(div.selectAll('.tick').size()).toBe(7);
         });
 
         it('Should create a time-series-line, and an x-axis', () => {

--- a/assets/src/scripts/monitoring-location/components/hydrograph/selectors/axes.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/selectors/axes.js
@@ -15,6 +15,7 @@ import {getYLabel, getSecondaryYLabel, getTsTimeZone, TEMPERATURE_PARAMETERS} fr
 const createXAxis = function(xScale, ianaTimeZone) {
     const [startMillis, endMillis] = xScale.domain();
     const ticks = generateTimeTicks(startMillis, endMillis, ianaTimeZone);
+
     return axisBottom()
         .scale(xScale)
         .tickValues(ticks.dates)
@@ -77,7 +78,7 @@ export const getBrushXAxis = createSelector(
     getBrushXScale('current'),
     getTsTimeZone,
     getCurrentDateRangeKind,
-    (xScale, ianaTimeZone, period) => createXAxis(xScale, period, ianaTimeZone)
+    (xScale, ianaTimeZone, period) => createXAxis(xScale, ianaTimeZone, period)
 );
 
 /**

--- a/assets/src/scripts/monitoring-location/components/hydrograph/selectors/axes.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/selectors/axes.js
@@ -77,8 +77,7 @@ const createAxes = function(xScale, yScale, secondaryYScale, yTickDetails, yTick
 export const getBrushXAxis = createSelector(
     getBrushXScale('current'),
     getTsTimeZone,
-    getCurrentDateRangeKind,
-    (xScale, ianaTimeZone, period) => createXAxis(xScale, ianaTimeZone, period)
+    (xScale, ianaTimeZone) => createXAxis(xScale, ianaTimeZone)
 );
 
 /**

--- a/assets/src/scripts/monitoring-location/components/hydrograph/selectors/scales.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/selectors/scales.js
@@ -76,9 +76,9 @@ export const getXScale = memoize((kind, tsKey) => createSelector(
         state => state.ivTimeSeriesState.ivGraphBrushOffset,
     (layout, requestTimeRange, brushOffset) => {
         let timeRange;
-
         if (kind === 'BRUSH') {
             timeRange = requestTimeRange;
+
         } else {
             if (brushOffset && requestTimeRange) {
                 timeRange = {

--- a/assets/src/scripts/monitoring-location/components/hydrograph/selectors/scales.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/selectors/scales.js
@@ -80,7 +80,6 @@ export const getXScale = memoize((kind, tsKey) => createSelector(
         if (kind === 'BRUSH') {
             timeRange = requestTimeRange;
         } else {
-
             if (brushOffset && requestTimeRange) {
                 timeRange = {
                     'start': requestTimeRange.start + brushOffset.start,

--- a/assets/src/scripts/monitoring-location/components/hydrograph/selectors/scales.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/selectors/scales.js
@@ -76,9 +76,9 @@ export const getXScale = memoize((kind, tsKey) => createSelector(
         state => state.ivTimeSeriesState.ivGraphBrushOffset,
     (layout, requestTimeRange, brushOffset) => {
         let timeRange;
+        
         if (kind === 'BRUSH') {
             timeRange = requestTimeRange;
-
         } else {
             if (brushOffset && requestTimeRange) {
                 timeRange = {

--- a/assets/src/scripts/monitoring-location/components/hydrograph/selectors/scales.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/selectors/scales.js
@@ -76,7 +76,7 @@ export const getXScale = memoize((kind, tsKey) => createSelector(
         state => state.ivTimeSeriesState.ivGraphBrushOffset,
     (layout, requestTimeRange, brushOffset) => {
         let timeRange;
-        
+
         if (kind === 'BRUSH') {
             timeRange = requestTimeRange;
         } else {

--- a/assets/src/scripts/monitoring-location/components/hydrograph/selectors/scales.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/selectors/scales.js
@@ -35,8 +35,6 @@ export const createXScale = function (timeRange, xSize) {
     let scale = scaleLinear()
         .range([0, xSize]);
     if (timeRange) {
-        console.log('this should run with timeRange = ', timeRange)
-        console.log('in createXScale xSize', xSize)
         scale.domain([timeRange.start, timeRange.end]);
     }
     return scale;
@@ -78,9 +76,8 @@ export const getXScale = memoize((kind, tsKey) => createSelector(
         state => state.ivTimeSeriesState.ivGraphBrushOffset,
     (layout, requestTimeRange, brushOffset) => {
         let timeRange;
-        console.log('in getXScale')
+
         if (kind === 'BRUSH') {
-            console.log('this should have run and this is requestTimeRange ', requestTimeRange)
             timeRange = requestTimeRange;
         } else {
 

--- a/assets/src/scripts/monitoring-location/components/hydrograph/selectors/scales.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/selectors/scales.js
@@ -35,6 +35,8 @@ export const createXScale = function (timeRange, xSize) {
     let scale = scaleLinear()
         .range([0, xSize]);
     if (timeRange) {
+        console.log('this should run with timeRange = ', timeRange)
+        console.log('in createXScale xSize', xSize)
         scale.domain([timeRange.start, timeRange.end]);
     }
     return scale;
@@ -76,7 +78,9 @@ export const getXScale = memoize((kind, tsKey) => createSelector(
         state => state.ivTimeSeriesState.ivGraphBrushOffset,
     (layout, requestTimeRange, brushOffset) => {
         let timeRange;
+        console.log('in getXScale')
         if (kind === 'BRUSH') {
+            console.log('this should have run and this is requestTimeRange ', requestTimeRange)
             timeRange = requestTimeRange;
         } else {
 


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [x] Update the changelog appropriately

WDFN 426 Brush Axis Missing Tick Marks
-----------
Returns tick marks to brush axis

Description
-----------
The bug was caused by arguments being passed in the incorrect order. This caused the time zone received by the function to be the period code, which is, as might be imagined, not going to turn out well. Switching the order cleared up the issue. 

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
