### PR TITLE
WDFN-431_Brush_handles_dont_reposition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/usgs/waterdataui/compare/waterdataui-0.37.0...master)
+### Fixed
+- Custom brush handles now reposition when user clicks and holds
 
 ## [0.37.0](https://github.com/usgs/waterdataui/compare/waterdataui-0.36.0...waterdataui-0.37.0) - 2020-09-16
 ### Added

--- a/assets/src/scripts/monitoring-location/components/daily-value-hydrograph/graph-brush.js
+++ b/assets/src/scripts/monitoring-location/components/daily-value-hydrograph/graph-brush.js
@@ -93,7 +93,7 @@ export const drawGraphBrush = function(container, store) {
             const graphBrush = brushX()
                 .extent([[0, 0], [layout.width - layout.margin.right, layout.height - layout.margin.bottom - layout.margin.top]])
                 .handleSize([1]) // make default handle 1px wide
-                .on('brush end', brushed);
+                .on('start brush end', brushed);
 
             svg.select('.brush').remove();
 

--- a/assets/src/scripts/monitoring-location/components/daily-value-hydrograph/selectors/layout.js
+++ b/assets/src/scripts/monitoring-location/components/daily-value-hydrograph/selectors/layout.js
@@ -43,7 +43,7 @@ export const getLayout = memoize(kind => createSelector(
             height: height,
             windowWidth: windowWidth,
             margin: {
-                top: kind === 'BRUSH' ? 12 : margin.top,
+                top: kind === 'BRUSH' ? 13 : margin.top,
                 right: margin.right,
                 bottom: margin.bottom,
                 left: margin.left

--- a/assets/src/scripts/monitoring-location/components/hydrograph/graph-brush.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/graph-brush.js
@@ -95,13 +95,13 @@ export const drawGraphBrush = function(container, store) {
             const graphBrush = brushX()
                 .extent([[0, 0], [layout.width - layout.margin.right, layout.height - layout.margin.bottom - layout.margin.top]])
                 .handleSize([1]) // make default handle 1px wide
-                .on('brush end', brushed);
+                .on('start brush end', brushed);
 
             svg.select('.brush').remove();
 
             const group = svg.append('g').attr('class', 'brush')
                 .attr('transform', `translate(${layout.margin.left}, ${layout.margin.top})`)
-                .call(graphBrush)
+                .call(graphBrush);
 
             /* Draws the custom brush handle using an SVG path. The path is drawn twice, once for the handle
             * on the left hand side, which in d3 brush terms is referred to as 'east' (data type 'e'), and then

--- a/assets/src/scripts/monitoring-location/components/hydrograph/selectors/layout.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/selectors/layout.js
@@ -69,7 +69,7 @@ export const getLayout = memoize(kind => createSelector(
             windowWidth: windowWidth,
             margin: {
                 bottom: margin.bottom,
-                top: kind === 'BRUSH' ? 12 : margin.top,
+                top: kind === 'BRUSH' ? 13 : margin.top,
                 left: margin.left + approxLabelLength,
                 right: margin.right + (isTemperatureParameter ? approxLabelLength : 0)
             }


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [x] Update the changelog appropriately

WDFN-431_Brush_handles_dont_reposition
-----------
Make it so that when the user clicks and holds the mouse button the custom handles reposition in the same manner as the default handles

Description
-----------
Fix to the custom handle issue as mentioned above, but also adds one more pixel to the spacing of helper text since at some screen resolutions the text was overlapping the SVG border. 

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
