### PR TITLE
enable clip path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/usgs/waterdataui/compare/waterdataui-0.37.0...master)
+### Fixed
+- Stopped end of median line from showing outside of graph area
 
 ## [0.37.0](https://github.com/usgs/waterdataui/compare/waterdataui-0.36.0...waterdataui-0.37.0) - 2020-09-16
 ### Added

--- a/assets/src/scripts/monitoring-location/components/hydrograph/time-series-graph.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/time-series-graph.js
@@ -254,7 +254,8 @@ export const drawTimeSeriesGraph = function(elem, store, siteNo, showMLName, sho
             visible: isVisible('median'),
             xscale: getMainXScale('current'),
             yscale: getMainYScale,
-            seriesPoints: getCurrentVariableMedianStatPoints
+            seriesPoints: getCurrentVariableMedianStatPoints,
+            enableClip: () => true
         })))
        .call(link(store, plotAllFloodLevelPoints, createStructuredSelector({
             visible: isWaterwatchVisible,


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [x] Update the changelog appropriately

WDFN-337 Median Line Shows Outside of Graph Area
-----------
Median line no longer shows outside of graph area

Description
-----------
The fix for this issue was mainly a bit of troubleshooting. It turns out the the 'clip-path' was not turned on for the median line as it was for the other graph lines. So when 'brush' was used to zoom in, the median line ran off the graph. Using the clip-path that was already in place for the other data lines, fixed the issue. 

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
