### PR TITLE
Wdfn 428 repoint sifta logos to new service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/usgs/waterdataui/compare/waterdataui-0.37.0...master)
+### Changed
+- Now using the new SIFTA service
 
 ## [0.37.0](https://github.com/usgs/waterdataui/compare/waterdataui-0.36.0...waterdataui-0.37.0) - 2020-09-16
 ### Added

--- a/wdfn-server/config.py
+++ b/wdfn-server/config.py
@@ -73,8 +73,8 @@ ENABLE_USGS_GA = False
 # To use hashed assets, set this to the gulp-rev-all rev-manifest.json path
 ASSET_MANIFEST_PATH = None
 
-# For cooperator site service, current lookup service is temporary, constants may need reconfiguring for the new service
-COOPERATOR_SERVICE_PATTERN = 'https://water.usgs.gov/customer/stories/{site_no}/approved.json'
+# For SIFTA cooperator site service - gives us the information needed to show the cooperator logos
+COOPERATOR_SERVICE_PATTERN = 'https://water.usgs.gov/cgi-bin/customer/stories/?site={site_no}'
 
 # These messages below will be added to a dismissible panel below the main header. It is an array of strings. Markup
 # can be used to add things like links, bold text, etc.

--- a/wdfn-server/waterdata/services/sifta.py
+++ b/wdfn-server/waterdata/services/sifta.py
@@ -18,6 +18,8 @@ def get_cooperators(site_no, district_cd):
             district_cd not in app.config['COOPERATOR_LOOKUP_ENABLED']):
         return []
 
+    print(app.config['COOPERATOR_SERVICE_PATTERN'].format(site_no=site_no))
+
     url = app.config['COOPERATOR_SERVICE_PATTERN'].format(site_no=site_no)
     response = execute_get_request(url)
     if response.status_code != 200:

--- a/wdfn-server/waterdata/services/sifta.py
+++ b/wdfn-server/waterdata/services/sifta.py
@@ -18,8 +18,6 @@ def get_cooperators(site_no, district_cd):
             district_cd not in app.config['COOPERATOR_LOOKUP_ENABLED']):
         return []
 
-    print(app.config['COOPERATOR_SERVICE_PATTERN'].format(site_no=site_no))
-
     url = app.config['COOPERATOR_SERVICE_PATTERN'].format(site_no=site_no)
     response = execute_get_request(url)
     if response.status_code != 200:


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [x] Update the changelog appropriately

WDFN 428 Repoint SIFTA Logos to New Service
-----------
Changes URL of SIFTA site service

Description
-----------
I think these changes will do the job. The change does work for the location listed in the ticket, 08083230, but for most of locations in list of locations on our development server, those return an empty set from the service. I checked with Jim Kreft and he indicated that the new service would likely return a smaller set of results than the old service, so perhaps this is normal.

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
