### PR TITLE
Wdfn 410 change color of last year line on hydrograph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/usgs/waterdataui/compare/waterdataui-0.38.0...master)
+### Added
+- New colors for the compare line
 
 ## [0.38.0](https://github.com/usgs/waterdataui/compare/waterdataui-0.37.0...waerdataui-0.38.0) - 2020-10-30
 ### Added

--- a/assets/src/styles/components/hydrograph/_app.scss
+++ b/assets/src/styles/components/hydrograph/_app.scss
@@ -144,23 +144,30 @@
     pointer-events: none;
     position: absolute;
     background: rgba(255, 255, 255, 0.8);
-    color: $default-time-series;
     opacity: 1;
 
     .current-tooltip-text {
       font-weight: bold;
-    }
+      color: $default-time-series;
+      .approved {
+        color: $approved-time-series;
+      }
 
-    .approved {
-      color: $approved-time-series;
-    }
-
-    .estimated {
-      color: $estimated-time-series;
+      .estimated {
+        color: $estimated-time-series;
+      }
     }
 
     .compare-tooltip-text {
       font-weight: normal;
+      color: $default-time-series-compare;
+      .approved {
+        color: $approved-time-series-compare;
+      }
+
+      .estimated {
+        color: $estimated-time-series-compare;
+      }
     }
   }
   svg {

--- a/assets/src/styles/components/hydrograph/_app.scss
+++ b/assets/src/styles/components/hydrograph/_app.scss
@@ -149,11 +149,12 @@
     .current-tooltip-text {
       font-weight: bold;
       color: $default-time-series;
-      .approved {
+
+      &.approved {
         color: $approved-time-series;
       }
 
-      .estimated {
+      &.estimated {
         color: $estimated-time-series;
       }
     }
@@ -161,11 +162,12 @@
     .compare-tooltip-text {
       font-weight: normal;
       color: $default-time-series-compare;
-      .approved {
+
+      &.approved {
         color: $approved-time-series-compare;
       }
 
-      .estimated {
+      &.estimated {
         color: $estimated-time-series-compare;
       }
     }

--- a/assets/src/styles/components/hydrograph/_graph.scss
+++ b/assets/src/styles/components/hydrograph/_graph.scss
@@ -62,6 +62,15 @@ svg {
 
   .ts-compare {
     stroke-width: 1px;
+    stroke: $default-time-series-compare;
+
+    &.approved {
+      stroke: $approved-time-series-compare;
+    }
+
+    &.estimated {
+      stroke: $estimated-time-series-compare;
+    }
   }
 
   .axis {

--- a/assets/src/styles/components/hydrograph/_variables.scss
+++ b/assets/src/styles/components/hydrograph/_variables.scss
@@ -1,9 +1,9 @@
-$approved-time-series: #1b9e77;
-$approved-time-series-compare: #eecb19;
-$estimated-time-series: #7570b3;
-$estimated-time-series-compare: #3ee0d1;
-$default-time-series: #d95f02;
-$default-time-series-compare: #a9f38a;
+$approved-time-series: #003f5c;
+$approved-time-series-compare: #665191;
+$estimated-time-series: #d45087;
+$estimated-time-series-compare: #a05195;
+$default-time-series: #ffa600;
+$default-time-series-compare: #ff7c43;
 $not-current-method-opacity: 0.1;
 $selected: color('accent-cool-lighter');
 $highlight: color('gray-4');

--- a/assets/src/styles/components/hydrograph/_variables.scss
+++ b/assets/src/styles/components/hydrograph/_variables.scss
@@ -1,6 +1,9 @@
 $approved-time-series: #1b9e77;
+$approved-time-series-compare: #eecb19;
 $estimated-time-series: #7570b3;
+$estimated-time-series-compare: #3ee0d1;
 $default-time-series: #d95f02;
+$default-time-series-compare: #a9f38a;
 $not-current-method-opacity: 0.1;
 $selected: color('accent-cool-lighter');
 $highlight: color('gray-4');


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [x] Update the changelog appropriately

WDFN 410 Change color of "last year" line on hydrograph
-----------
Added new colors for the compare line

Description
-----------
It was difficult to find a second set of colors that were both distinct and coordinating with the current color set, so I researched Color Brewer and several other internet recourses to generate a larger unified pallet. I settled on https://learnui.design/tools/data-color-picker.html#palette to create the pallet. I created a ten color pallet and used six colors as I wanted the 'estimated' and 'provisional' data to skew toward 'warning' colors where the approved had more watery placid tones.  I also opted for greater distinction between colors verses a more linear and, perhaps, aesthetically pleasing pallet. The colors choices are added as mere suggestion and are easily changed. 

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
