### PR TITLE
Wdfn 336 compare line is behind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Additional analytics tracking.
 - Added an inventory data menu on the monitoring location page which is context specific for the site.
 
+### Fixed
+- Now using 365 days for one year graph and comparison -- focus line syncs with both current and compare series.
+
 ## [0.39.0](https://github.com/usgs/waterdataui/compare/waterdataui-0.38.0...waterdataui-0.39.0) - 2020-12-09
 ### Added
 - Static image of the Instantaneous Values Hydrograph for users of Internet Explorer. 

--- a/assets/src/scripts/utils.js
+++ b/assets/src/scripts/utils.js
@@ -157,15 +157,16 @@ export const calcStartTime = function(period, endTime, ianaTimeZone) {
     const timePeriodCode = period !== null ? period.substr(period.length - 1) : null;
     const timePeriod = period !== null ? period.slice(1,-1) : null;
 
-    let startTime = new DateTime.fromMillis(endTime, {zone: ianaTimeZone});
+     let startTime = new DateTime.fromMillis(endTime, {zone: ianaTimeZone});
 
     if (timePeriodCode === 'D') {
         startTime = startTime.minus({days: timePeriod});
     } else if (timePeriodCode === 'Y') {
-        startTime = startTime.minus({years: timePeriod});
+        startTime = startTime.minus({hours: 8760});
     } else {
         console.log('No known period specified');
     }
+
     return startTime.valueOf();
 };
 

--- a/assets/src/scripts/utils.js
+++ b/assets/src/scripts/utils.js
@@ -156,13 +156,14 @@ export const mediaQuery = function(minWidth) {
 export const calcStartTime = function(period, endTime, ianaTimeZone) {
     const timePeriodCode = period !== null ? period.substr(period.length - 1) : null;
     const timePeriod = period !== null ? period.slice(1,-1) : null;
+    const hoursInOneYear = 8760;
 
     let startTime = new DateTime.fromMillis(endTime, {zone: ianaTimeZone});
 
     if (timePeriodCode === 'D') {
         startTime = startTime.minus({days: timePeriod});
     } else if (timePeriodCode === 'Y') {
-        startTime = startTime.minus({hours: 8760 * timePeriod}); // there are 8760 hours in 365 days
+        startTime = startTime.minus({hours: hoursInOneYear * timePeriod});
     } else {
         console.log('No known period specified');
     }

--- a/assets/src/scripts/utils.js
+++ b/assets/src/scripts/utils.js
@@ -158,7 +158,7 @@ export const calcStartTime = function(period, endTime, ianaTimeZone) {
     const timePeriod = period !== null ? period.slice(1,-1) : null;
     const hoursInOneYear = 8760;
 
-    let startTime = new DateTime.fromMillis(endTime, {zone: ianaTimeZone});
+    let startTime = DateTime.fromMillis(endTime, {zone: ianaTimeZone});
 
     if (timePeriodCode === 'D') {
         startTime = startTime.minus({days: timePeriod});

--- a/assets/src/scripts/utils.js
+++ b/assets/src/scripts/utils.js
@@ -162,7 +162,7 @@ export const calcStartTime = function(period, endTime, ianaTimeZone) {
     if (timePeriodCode === 'D') {
         startTime = startTime.minus({days: timePeriod});
     } else if (timePeriodCode === 'Y') {
-        startTime = startTime.minus({hours: 8760});
+        startTime = startTime.minus({hours: 8760 * timePeriod}); // there are 8760 hours in 365 days
     } else {
         console.log('No known period specified');
     }

--- a/assets/src/scripts/utils.js
+++ b/assets/src/scripts/utils.js
@@ -157,7 +157,7 @@ export const calcStartTime = function(period, endTime, ianaTimeZone) {
     const timePeriodCode = period !== null ? period.substr(period.length - 1) : null;
     const timePeriod = period !== null ? period.slice(1,-1) : null;
 
-     let startTime = new DateTime.fromMillis(endTime, {zone: ianaTimeZone});
+    let startTime = new DateTime.fromMillis(endTime, {zone: ianaTimeZone});
 
     if (timePeriodCode === 'D') {
         startTime = startTime.minus({days: timePeriod});

--- a/assets/src/scripts/web-services/models.js
+++ b/assets/src/scripts/web-services/models.js
@@ -57,9 +57,7 @@ export const getTimeSeries = function({sites, params=null, startDate=null, endDa
         serviceRoot = tsServiceRoot(startDate);
     }
     let paramCds = params !== null ? `&parameterCd=${params.join(',')}` : '';
-
     let url = `${serviceRoot}/iv/?sites=${sites.join(',')}${paramCds}&${timeParams}&siteStatus=all&format=json`;
-
 
     return get(url)
         .then(response => JSON.parse(response))

--- a/assets/src/scripts/web-services/models.js
+++ b/assets/src/scripts/web-services/models.js
@@ -68,9 +68,10 @@ export const getTimeSeries = function({sites, params=null, startDate=null, endDa
 };
 
 export const getPreviousYearTimeSeries = function({site, startTime, endTime, parameterCode}) {
+    const hoursInOneYear = 8760;
     parameterCode = parameterCode ? [parameterCode] : null;
-    let lastYearStartTime = new DateTime.fromMillis(startTime).minus({hours: 8760});
-    let lastYearEndTime = new DateTime.fromMillis(endTime).minus({hours: 8760});
+    const lastYearStartTime = new DateTime.fromMillis(startTime).minus({hours: hoursInOneYear});
+    const lastYearEndTime = new DateTime.fromMillis(endTime).minus({hours: hoursInOneYear});
 
     return getTimeSeries({sites: [site], startDate: lastYearStartTime, endDate: lastYearEndTime, params: parameterCode});
 };

--- a/assets/src/scripts/web-services/models.js
+++ b/assets/src/scripts/web-services/models.js
@@ -59,6 +59,8 @@ export const getTimeSeries = function({sites, params=null, startDate=null, endDa
     let paramCds = params !== null ? `&parameterCd=${params.join(',')}` : '';
 
     let url = `${serviceRoot}/iv/?sites=${sites.join(',')}${paramCds}&${timeParams}&siteStatus=all&format=json`;
+
+
     return get(url)
         .then(response => JSON.parse(response))
         .catch(reason => {
@@ -69,8 +71,17 @@ export const getTimeSeries = function({sites, params=null, startDate=null, endDa
 
 export const getPreviousYearTimeSeries = function({site, startTime, endTime, parameterCode}) {
     parameterCode = parameterCode ? [parameterCode] : null;
-    let lastYearStartTime = new DateTime.fromMillis(startTime).minus({hours: 8760});
-    let lastYearEndTime = new DateTime.fromMillis(endTime).minus({hours: 8760});
+    console.log('startTime ', startTime)
+    console.log('endTime ', endTime)
+
+    let lastYearStartTime = new DateTime.fromMillis(startTime);
+    let lastYearEndTime = new DateTime.fromMillis(endTime);
+    console.log('lastYearStartTime ', lastYearStartTime.toISODate())
+    console.log('lastYearEndTime ', lastYearEndTime.toISODate())
+    lastYearStartTime = lastYearStartTime.minus({hours: 8760});
+    lastYearEndTime = lastYearEndTime.minus({hours: 8760});
+    console.log('lastYearStartTime after ', lastYearStartTime.toISODate())
+    console.log('lastYearEndTime after', lastYearEndTime.toISODate())
 
     return getTimeSeries({sites: [site], startDate: lastYearStartTime, endDate: lastYearEndTime, params: parameterCode});
 };

--- a/assets/src/scripts/web-services/models.js
+++ b/assets/src/scripts/web-services/models.js
@@ -1,5 +1,7 @@
 import {utcFormat} from 'd3-time-format';
 
+import {DateTime} from 'luxon';
+
 import {get} from 'ui/ajax';
 import config from 'ui/config';
 
@@ -67,12 +69,9 @@ export const getTimeSeries = function({sites, params=null, startDate=null, endDa
 
 export const getPreviousYearTimeSeries = function({site, startTime, endTime, parameterCode}) {
     parameterCode = parameterCode ? [parameterCode] : null;
+    let lastYearStartTime = new DateTime.fromMillis(startTime).minus({hours: 8760});
+    let lastYearEndTime = new DateTime.fromMillis(endTime).minus({hours: 8760});
 
-    let lastYearStartTime = new Date(startTime);
-    let lastYearEndTime = new Date(endTime);
-
-    lastYearStartTime.setFullYear(lastYearStartTime.getFullYear() - 1);
-    lastYearEndTime.setFullYear(lastYearEndTime.getFullYear() - 1);
     return getTimeSeries({sites: [site], startDate: lastYearStartTime, endDate: lastYearEndTime, params: parameterCode});
 };
 

--- a/assets/src/scripts/web-services/models.js
+++ b/assets/src/scripts/web-services/models.js
@@ -70,8 +70,8 @@ export const getTimeSeries = function({sites, params=null, startDate=null, endDa
 export const getPreviousYearTimeSeries = function({site, startTime, endTime, parameterCode}) {
     const hoursInOneYear = 8760;
     parameterCode = parameterCode ? [parameterCode] : null;
-    const lastYearStartTime = new DateTime.fromMillis(startTime).minus({hours: hoursInOneYear});
-    const lastYearEndTime = new DateTime.fromMillis(endTime).minus({hours: hoursInOneYear});
+    const lastYearStartTime = DateTime.fromMillis(startTime).minus({hours: hoursInOneYear});
+    const lastYearEndTime = DateTime.fromMillis(endTime).minus({hours: hoursInOneYear});
 
     return getTimeSeries({sites: [site], startDate: lastYearStartTime, endDate: lastYearEndTime, params: parameterCode});
 };

--- a/assets/src/scripts/web-services/models.js
+++ b/assets/src/scripts/web-services/models.js
@@ -71,17 +71,8 @@ export const getTimeSeries = function({sites, params=null, startDate=null, endDa
 
 export const getPreviousYearTimeSeries = function({site, startTime, endTime, parameterCode}) {
     parameterCode = parameterCode ? [parameterCode] : null;
-    console.log('startTime ', startTime)
-    console.log('endTime ', endTime)
-
-    let lastYearStartTime = new DateTime.fromMillis(startTime);
-    let lastYearEndTime = new DateTime.fromMillis(endTime);
-    console.log('lastYearStartTime ', lastYearStartTime.toISODate())
-    console.log('lastYearEndTime ', lastYearEndTime.toISODate())
-    lastYearStartTime = lastYearStartTime.minus({hours: 8760});
-    lastYearEndTime = lastYearEndTime.minus({hours: 8760});
-    console.log('lastYearStartTime after ', lastYearStartTime.toISODate())
-    console.log('lastYearEndTime after', lastYearEndTime.toISODate())
+    let lastYearStartTime = new DateTime.fromMillis(startTime).minus({hours: 8760});
+    let lastYearEndTime = new DateTime.fromMillis(endTime).minus({hours: 8760});
 
     return getTimeSeries({sites: [site], startDate: lastYearStartTime, endDate: lastYearEndTime, params: parameterCode});
 };

--- a/assets/src/scripts/web-services/models.spec.js
+++ b/assets/src/scripts/web-services/models.spec.js
@@ -109,8 +109,8 @@ describe('Models module', () => {
 
     describe('getPreviousYearTimeSeries', () => {
         const siteID = '05413500';
-        const startDate = 1514872800000;
-        const endDate = 1546408800000;
+        const startDate = 1514872800000; // milliSecond version of 01/02/2018
+        const endDate = 1546408800000; // milliSecond version of 01/02/2019
 
         it('Retrieves data using the startDT and endDT parameters', () => {
             getPreviousYearTimeSeries({site: siteID, startTime: startDate, endTime: endDate});

--- a/assets/src/scripts/web-services/models.spec.js
+++ b/assets/src/scripts/web-services/models.spec.js
@@ -1,5 +1,7 @@
 import {utcFormat} from 'd3-time-format';
 
+import {DateTime} from 'luxon';
+
 import {getPreviousYearTimeSeries, getTimeSeries, queryWeatherService} from './models';
 
 
@@ -107,16 +109,15 @@ describe('Models module', () => {
 
     describe('getPreviousYearTimeSeries', () => {
         const siteID = '05413500';
+        const startDate = 1514872800000;
+        const endDate = 1546408800000;
 
-        const startDate = new Date('2018-01-02T15:00:00.000-06:00');
-        const endDate = new Date('2018-01-02T16:45:00.000-06:00');
-
-        it('Retrieves data using the startDT and endDT parameters', () => {
+        fit('Retrieves data using the startDT and endDT parameters', () => {
             getPreviousYearTimeSeries({site: siteID, startTime: startDate, endTime: endDate});
             let request = jasmine.Ajax.requests.mostRecent();
 
-            expect(request.url).toContain('startDT=2017-01-02T21:00');
-            expect(request.url).toContain('endDT=2017-01-02T22:45');
+            expect(request.url).toContain('startDT=2017-01-02T06:00Z');
+            expect(request.url).toContain('endDT=2018-01-02T06:00Z');
         });
 
         it('Parses valid data', () => {

--- a/assets/src/scripts/web-services/models.spec.js
+++ b/assets/src/scripts/web-services/models.spec.js
@@ -120,7 +120,7 @@ describe('Models module', () => {
             expect(request.url).toContain('endDT=2018-01-02T06:00Z');
         });
 
-        fit('The difference between start and end dates for normal "compare" year will be 365 days ', () => {
+        it('The difference between start and end dates for normal "compare" year will be 365 days ', () => {
             getPreviousYearTimeSeries({site: siteID, startTime: startDate, endTime: endDate});
             const request = jasmine.Ajax.requests.mostRecent();
 
@@ -132,13 +132,16 @@ describe('Models module', () => {
         });
 
         it('The difference between start and end dates for leap "compare" year will still be 365 days ', () => {
+            const startDateLeapYearTest = 1483362000000; // milliSecond version of 01/02/2017 (year before a leap year, because we compare to the previous year)
+            const endDateLeapYearTest = 1514898000000; // milliSecond version of 01/02/2018
+            getPreviousYearTimeSeries({site: siteID, startTime: startDateLeapYearTest, endTime: endDateLeapYearTest});
             const request = jasmine.Ajax.requests.mostRecent();
-            const startDate = DateTime.fromISO('2016-01-02T06:00Z');
-            const endDate = DateTime.fromISO('2017-01-02T06:00Z');
 
-            let timeSpanInDays = startDate.diff(endDate, 'days');
+            const urlStartDate = DateTime.fromISO(request.url.slice(68, 85));
+            const urlEndDate = DateTime.fromISO(request.url.slice(92, 109));
+            const timeSpanInDays = urlEndDate.diff(urlStartDate, 'days');
 
-            expect(timeSpanInDays).toEqual('P-365D');
+            expect(timeSpanInDays.toObject()).toEqual({days: 365});
         });
 
         it('Parses valid data', () => {

--- a/assets/src/scripts/web-services/models.spec.js
+++ b/assets/src/scripts/web-services/models.spec.js
@@ -112,7 +112,7 @@ describe('Models module', () => {
         const startDate = 1514872800000;
         const endDate = 1546408800000;
 
-        fit('Retrieves data using the startDT and endDT parameters', () => {
+        it('Retrieves data using the startDT and endDT parameters', () => {
             getPreviousYearTimeSeries({site: siteID, startTime: startDate, endTime: endDate});
             let request = jasmine.Ajax.requests.mostRecent();
 

--- a/assets/src/scripts/web-services/models.spec.js
+++ b/assets/src/scripts/web-services/models.spec.js
@@ -120,7 +120,7 @@ describe('Models module', () => {
             expect(request.url).toContain('endDT=2018-01-02T06:00Z');
         });
 
-        it('The difference between start and end dates for normal "compare" year will be 365 days ', () => {
+        it('Expects the difference between start and end dates for normal "compare" year will be 365 days ', () => {
             getPreviousYearTimeSeries({site: siteID, startTime: startDate, endTime: endDate});
             const request = jasmine.Ajax.requests.mostRecent();
 
@@ -131,7 +131,7 @@ describe('Models module', () => {
             expect(timeSpanInDays.toObject()).toEqual({days: 365});
         });
 
-        it('The difference between start and end dates for leap "compare" year will still be 365 days ', () => {
+        it('Expects the difference between start and end dates for leap "compare" year will still be 365 days ', () => {
             const startDateLeapYearTest = 1483362000000; // milliSecond version of 01/02/2017 (year before a leap year, because we compare to the previous year)
             const endDateLeapYearTest = 1514898000000; // milliSecond version of 01/02/2018
             getPreviousYearTimeSeries({site: siteID, startTime: startDateLeapYearTest, endTime: endDateLeapYearTest});

--- a/assets/src/scripts/web-services/models.spec.js
+++ b/assets/src/scripts/web-services/models.spec.js
@@ -114,10 +114,31 @@ describe('Models module', () => {
 
         it('Retrieves data using the startDT and endDT parameters', () => {
             getPreviousYearTimeSeries({site: siteID, startTime: startDate, endTime: endDate});
-            let request = jasmine.Ajax.requests.mostRecent();
+            const request = jasmine.Ajax.requests.mostRecent();
 
             expect(request.url).toContain('startDT=2017-01-02T06:00Z');
             expect(request.url).toContain('endDT=2018-01-02T06:00Z');
+        });
+
+        fit('The difference between start and end dates for normal "compare" year will be 365 days ', () => {
+            getPreviousYearTimeSeries({site: siteID, startTime: startDate, endTime: endDate});
+            const request = jasmine.Ajax.requests.mostRecent();
+
+            const urlStartDate = DateTime.fromISO(request.url.slice(68, 85));
+            const urlEndDate = DateTime.fromISO(request.url.slice(92, 109));
+            const timeSpanInDays = urlEndDate.diff(urlStartDate, 'days');
+
+            expect(timeSpanInDays.toObject()).toEqual({days: 365});
+        });
+
+        it('The difference between start and end dates for leap "compare" year will still be 365 days ', () => {
+            const request = jasmine.Ajax.requests.mostRecent();
+            const startDate = DateTime.fromISO('2016-01-02T06:00Z');
+            const endDate = DateTime.fromISO('2017-01-02T06:00Z');
+
+            let timeSpanInDays = startDate.diff(endDate, 'days');
+
+            expect(timeSpanInDays).toEqual('P-365D');
         });
 
         it('Parses valid data', () => {


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [x] Update the changelog appropriately

WDFN 336 Compare Line is Behind on One Year Graphs
-----------

Changes to use 'time math' instead of 'calendar math' for calculation of the year to compare so that leap years mesh with normal years. 

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
