### PR TITLE
Iow 495 - Discrete GW Levels are on the IV Graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/usgs/waterdataui/compare/waterdataui-0.40.0...master)
+### Added display of discrete ground water level data on the IV hydrograph.
 
 ## [0.40.0](https://github.com/usgs/waterdataui/compare/waterdataui-0.39.0...waterdataui-0.40.0) - 2021-01-06
 ### Added

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "waterdataui-assets",
-  "version": "0.40.0dev",
+  "version": "0.41.0dev",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/assets/src/scripts/d3-rendering/legend.js
+++ b/assets/src/scripts/d3-rendering/legend.js
@@ -79,7 +79,7 @@ export const drawSimpleLegend = function(div, {legendMarkerRows, layout}) {
                 width: RECTANGLE_MARKER_WIDTH,
                 height: RECTANGLE_MARKER_HEIGHT,
                 length: LINE_MARKER_WIDTH,
-                r: marker.r,
+                r: marker.radius,
                 fill: marker.fill
             };
 

--- a/assets/src/scripts/d3-rendering/legend.test.js
+++ b/assets/src/scripts/d3-rendering/legend.test.js
@@ -3,7 +3,7 @@ import {select} from 'd3-selection';
 import * as utils from 'ui/utils';
 
 import {drawSimpleLegend} from './legend';
-import {lineMarker, rectangleMarker, textOnlyMarker} from './markers';
+import {circleMarker, lineMarker, rectangleMarker, textOnlyMarker} from './markers';
 
 describe('Legend module', () => {
 
@@ -34,6 +34,12 @@ describe('Legend module', () => {
                 domId: null,
                 domClass: 'some-other-class',
                 text: 'Median Label'
+            }, {
+                type: circleMarker,
+                domId: null,
+                domClass: 'circle-marker-class',
+                text: 'Circle Marker label',
+                radius: 5
             }]
         ];
         const layout = {
@@ -70,7 +76,8 @@ describe('Legend module', () => {
             expect(container.select('svg').size()).toBe(1);
             expect(container.selectAll('line').size()).toBe(2);
             expect(container.selectAll('rect').size()).toBe(1);
-            expect(container.selectAll('text').size()).toBe(4);
+            expect(container.selectAll('text').size()).toBe(5);
+            expect(container.selectAll('circle').size()).toBe(1);
         });
     });
 });

--- a/assets/src/scripts/d3-rendering/markers.js
+++ b/assets/src/scripts/d3-rendering/markers.js
@@ -126,9 +126,9 @@ export const textOnlyMarker = function(elem, {x, y, text, domId=null, domClass=n
 export const defineLineMarker = function(domId=null, domClass=null, text=null) {
     return {
         type: lineMarker,
-        domId: domId,
-        domClass: domClass,
-        text: text
+        domId,
+        domClass,
+        text
     };
 };
 
@@ -136,9 +136,9 @@ export const defineLineMarker = function(domId=null, domClass=null, text=null) {
 export const defineTextOnlyMarker = function(text, domId=null, domClass=null ) {
     return {
         type: textOnlyMarker,
-        domId: domId,
-        domClass: domClass,
-        text: text
+        domId,
+        domClass,
+        text
     };
 };
 
@@ -146,10 +146,21 @@ export const defineTextOnlyMarker = function(text, domId=null, domClass=null ) {
 export const defineRectangleMarker = function(domId=null, domClass=null, text=null, fill=null) {
     return {
         type: rectangleMarker,
-        domId: domId,
-        domClass: domClass,
-        text: text,
-        fill: fill
+        domId,
+        domClass,
+        text,
+        fill
+    };
+};
+
+export const defineCircleMarker = function(domId=null, domClass=null, radius=1, text=null, fill=null) {
+    return {
+        type: circleMarker,
+        domId,
+        domClass,
+        radius,
+        text,
+        fill
     };
 };
 

--- a/assets/src/scripts/mock-service-data.js
+++ b/assets/src/scripts/mock-service-data.js
@@ -3236,37 +3236,37 @@ export const MOCK_GWLEVEL_DATA =
               {
                 "value": "26.07",
                 "qualifiers": [],
-                "dateTime": "2020-01-23T09:06:00.000"
+                "dateTime": "2020-01-23T09:06:00.000-05:00"
               },
               {
                 "value": "27.27",
                 "qualifiers": [],
-                "dateTime": "2020-03-19T15:11:00.000"
+                "dateTime": "2020-03-19T15:11:00.000-06:00"
               },
               {
                 "value": "27.33",
                 "qualifiers": [],
-                "dateTime": "2020-05-13T11:47:00.000"
+                "dateTime": "2020-05-13T11:47:00.000-06:00"
               },
               {
                 "value": "29.19",
                 "qualifiers": [],
-                "dateTime": "2020-07-23T11:45:00.000"
+                "dateTime": "2020-07-23T11:45:00.000-06:00"
               },
               {
                 "value": "25.55",
                 "qualifiers": [],
-                "dateTime": "2020-08-24T16:04:00.000"
+                "dateTime": "2020-08-24T16:04:00.000-06:00"
               },
               {
                 "value": "25.03",
                 "qualifiers": [],
-                "dateTime": "2020-10-01T18:10:00.000"
+                "dateTime": "2020-10-01T18:10:00.000-06:00"
               },
               {
                 "value": "24.54",
                 "qualifiers": [],
-                "dateTime": "2020-11-17T12:57:00.000"
+                "dateTime": "2020-11-17T12:57:00.000-05:00"
               }
             ],
             "qualifier": [],

--- a/assets/src/scripts/mock-service-data.js
+++ b/assets/src/scripts/mock-service-data.js
@@ -3101,3 +3101,192 @@ export const MOCK_OBSERVATION_ITEM = `{
         }
     ]
 }`;
+
+export const MOCK_GWLEVEL_DATA =
+`{
+  "name": "ns1:timeSeriesResponseType",
+  "declaredType": "org.cuahsi.waterml.TimeSeriesResponseType",
+  "scope": "javax.xml.bind.JAXBElement$GlobalScope",
+  "value": {
+    "queryInfo": {
+      "queryURL": "http://waterservices.usgs.gov/nwis/gwlevels/format=json&sites=354133082042203&parameterCd=72019&startDT=2020-01-01&endDT=2020-11-17",
+      "criteria": {
+        "locationParam": "[ALL:354133082042203]",
+        "variableParam": "[72019]",
+        "timeParam": {
+          "beginDateTime": "2020-01-01T00:00:00.000",
+          "endDateTime": "2020-11-17T23:59:59.000"
+        },
+        "parameter": []
+      },
+      "note": [
+        {
+          "value": "[ALL:354133082042203]",
+          "title": "filter:sites"
+        },
+        {
+          "value": "[mode=RANGE, modifiedSince=null] interval={INTERVAL[2020-01-01T00:00:00.000-05:00/2020-11-17T23:59:59.000Z]}",
+          "title": "filter:timeRange"
+        },
+        {
+          "value": "methodIds=[ALL]",
+          "title": "filter:methodId"
+        },
+        {
+          "value": "2021-01-07T14:03:54.275Z",
+          "title": "requestDT"
+        },
+        {
+          "value": "2d53d020-50f1-11eb-be92-2cea7f58f5ca",
+          "title": "requestId"
+        },
+        {
+          "value": "Provisional data are subject to revision. Go to http://waterdata.usgs.gov/nwis/help/?provisional for more information.",
+          "title": "disclaimer"
+        },
+        {
+          "value": "vaas01",
+          "title": "server"
+        }
+      ]
+    },
+    "timeSeries": [
+      {
+        "sourceInfo": {
+          "siteName": "MC-109 NEAR PLEASANT GARDENS, NC (BEDROCK)",
+          "siteCode": [
+            {
+              "value": "354133082042203",
+              "network": "NWIS",
+              "agencyCode": "USGS"
+            }
+          ],
+          "timeZoneInfo": {
+            "defaultTimeZone": {
+              "zoneOffset": "-05:00",
+              "zoneAbbreviation": "EST"
+            },
+            "daylightSavingsTimeZone": {
+              "zoneOffset": "-04:00",
+              "zoneAbbreviation": "EDT"
+            },
+            "siteUsesDaylightSavingsTime": true
+          },
+          "geoLocation": {
+            "geogLocation": {
+              "srs": "EPSG:4326",
+              "latitude": 35.6926111,
+              "longitude": -82.0729444
+            },
+            "localSiteXY": []
+          },
+          "note": [],
+          "siteType": [],
+          "siteProperty": [
+            {
+              "value": "GW",
+              "name": "siteTypeCd"
+            },
+            {
+              "value": "03050101",
+              "name": "hucCd"
+            },
+            {
+              "value": "37",
+              "name": "stateCd"
+            },
+            {
+              "value": "37111",
+              "name": "countyCd"
+            }
+          ]
+        },
+        "variable": {
+          "variableCode": [
+            {
+              "value": "72019",
+              "network": "NWIS",
+              "vocabulary": "NWIS:UnitValues",
+              "variableID": 52331280,
+              "default": true
+            }
+          ],
+          "variableName": "Depth to water level, ft below land surface",
+          "variableDescription": "Depth to water level, feet below land surface",
+          "valueType": "Derived Value",
+          "unit": {
+            "unitCode": "ft"
+          },
+          "options": {
+            "option": [
+              {
+                "name": "Statistic",
+                "optionCode": "00000"
+              }
+            ]
+          },
+          "note": [],
+          "noDataValue": -999999.0,
+          "variableProperty": [],
+          "oid": "52331280"
+        },
+        "values": [
+          {
+            "value": [
+              {
+                "value": "26.07",
+                "qualifiers": [],
+                "dateTime": "2020-01-23T09:06:00.000"
+              },
+              {
+                "value": "27.27",
+                "qualifiers": [],
+                "dateTime": "2020-03-19T15:11:00.000"
+              },
+              {
+                "value": "27.33",
+                "qualifiers": [],
+                "dateTime": "2020-05-13T11:47:00.000"
+              },
+              {
+                "value": "29.19",
+                "qualifiers": [],
+                "dateTime": "2020-07-23T11:45:00.000"
+              },
+              {
+                "value": "25.55",
+                "qualifiers": [],
+                "dateTime": "2020-08-24T16:04:00.000"
+              },
+              {
+                "value": "25.03",
+                "qualifiers": [],
+                "dateTime": "2020-10-01T18:10:00.000"
+              },
+              {
+                "value": "24.54",
+                "qualifiers": [],
+                "dateTime": "2020-11-17T12:57:00.000"
+              }
+            ],
+            "qualifier": [],
+            "qualityControlLevel": [],
+            "method": [
+              {
+                "methodID": 1
+              }
+            ],
+            "source": [],
+            "offset": [],
+            "sample": [],
+            "censorCode": []
+          }
+        ],
+        "name": "USGS:354133082042203:72019:00000"
+      }
+    ]
+  },
+  "nil": false,
+  "globalScope": true,
+  "typeSubstituted": false
+}`;

--- a/assets/src/scripts/monitoring-location/components/hydrograph/discrete-data.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/discrete-data.js
@@ -7,9 +7,8 @@ export const drawGroundWaterLevels = function(svg, {levels, xScale, yScale}) {
 
     levels.forEach((level) => {
         group.append('circle')
-            .data(level)
             .attr('r', CIRCLE_RADIUS_SINGLE_PT)
-            .attr('cx', d => xScale(d.dateTime))
-            .attr('cy', d => yScale(d.value));
+            .attr('cx', xScale(level.dateTime))
+            .attr('cy', yScale(level.value));
     });
 };

--- a/assets/src/scripts/monitoring-location/components/hydrograph/discrete-data.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/discrete-data.js
@@ -1,14 +1,22 @@
-const CIRCLE_RADIUS_SINGLE_PT = 1;
+import {defineCircleMarker} from 'd3render/markers';
 
-export const drawGroundWaterLevels = function(svg, {levels, xScale, yScale}) {
+const GW_LEVEL_RADIUS = 5;
+const GW_LEVEL_CLASS = 'gw-level-point';
+
+export const drawGroundwaterLevels = function(svg, {levels, xScale, yScale}) {
     svg.selectAll('#iv-graph-gw-levels-group').remove();
     const group = svg.append('g')
         .attr('id', 'iv-graph-gw-levels-group');
 
     levels.forEach((level) => {
         group.append('circle')
-            .attr('r', CIRCLE_RADIUS_SINGLE_PT)
+            .attr('class', GW_LEVEL_CLASS)
+            .attr('r', GW_LEVEL_RADIUS)
             .attr('cx', xScale(level.dateTime))
             .attr('cy', yScale(level.value));
     });
+};
+
+export const getGroundwaterLevelsMarker = function() {
+    return defineCircleMarker(null, GW_LEVEL_CLASS, GW_LEVEL_RADIUS, 'Groundwater level');
 };

--- a/assets/src/scripts/monitoring-location/components/hydrograph/discrete-data.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/discrete-data.js
@@ -4,7 +4,7 @@ const GW_LEVEL_RADIUS = 5;
 const GW_LEVEL_CLASS = 'gw-level-point';
 
 /*
- * Render the ground water level symobls on the svg in their own group. If the group exists
+ * Render the ground water level symbols on the svg in their own group. If the group exists, remove
  * it before rendering again.
  * @param {D3 elem} svg (could also be a group)
  * @param {Array of Object} levels - each object, should have dateTime and value properties

--- a/assets/src/scripts/monitoring-location/components/hydrograph/discrete-data.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/discrete-data.js
@@ -1,0 +1,15 @@
+const CIRCLE_RADIUS_SINGLE_PT = 1;
+
+export const drawGroundWaterLevels = function(svg, {levels, xScale, yScale}) {
+    svg.selectAll('#iv-graph-gw-levels-group').remove();
+    const group = svg.append('g')
+        .attr('id', 'iv-graph-gw-levels-group');
+
+    levels.forEach((level) => {
+        group.append('circle')
+            .data(level)
+            .attr('r', CIRCLE_RADIUS_SINGLE_PT)
+            .attr('cx', d => xScale(d.dateTime))
+            .attr('cy', d => yScale(d.value));
+    });
+};

--- a/assets/src/scripts/monitoring-location/components/hydrograph/discrete-data.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/discrete-data.js
@@ -3,6 +3,14 @@ import {defineCircleMarker} from 'd3render/markers';
 const GW_LEVEL_RADIUS = 5;
 const GW_LEVEL_CLASS = 'gw-level-point';
 
+/*
+ * Render the ground water level symobls on the svg in their own group. If the group exists
+ * it before rendering again.
+ * @param {D3 elem} svg (could also be a group)
+ * @param {Array of Object} levels - each object, should have dateTime and value properties
+ * @param {D3 scale} xScale
+ * @param {D3 scale } yScale
+ */
 export const drawGroundwaterLevels = function(svg, {levels, xScale, yScale}) {
     svg.selectAll('#iv-graph-gw-levels-group').remove();
     const group = svg.append('g')
@@ -17,6 +25,10 @@ export const drawGroundwaterLevels = function(svg, {levels, xScale, yScale}) {
     });
 };
 
+/*
+ * Returns a circle marker that can be used to represent the groundwater level symbol in legends
+ * @return {Object} - see d3-rendering/markers module.
+ */
 export const getGroundwaterLevelsMarker = function() {
     return defineCircleMarker(null, GW_LEVEL_CLASS, GW_LEVEL_RADIUS, 'Groundwater level');
 };

--- a/assets/src/scripts/monitoring-location/components/hydrograph/discrete-data.test.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/discrete-data.test.js
@@ -1,0 +1,61 @@
+import {select} from 'd3-selection';
+import {scaleLinear} from 'd3-scale';
+
+import {circleMarker} from 'd3render/markers';
+import {drawGroundwaterLevels, getGroundwaterLevelsMarker} from './discrete-data';
+
+describe('monitoring-location/components/hydrograph/discrete-data', () => {
+    describe('drawGroundwaterLevels', () => {
+
+        let svg, gwLevels, xScale, yScale;
+
+        beforeEach(() => {
+            svg = select('body').append('svg');
+            gwLevels = [
+                {value: '14.0', dateTime: 1491055200000},
+                {value: '14.5', dateTime: 1490882400000},
+                {value: '13.0', dateTime: 1490536800000},
+                {value: '12.0', dateTime: 1489672800000}
+            ];
+            xScale = scaleLinear()
+                .domain([0, 100])
+                .range([1489000000000, 1500000000000]);
+            yScale = scaleLinear()
+                .domain([0, 100])
+                .range([11.0, 15.0]);
+        });
+
+        afterEach(() => {
+            svg.remove();
+        });
+
+        it('Renders 4 circles for each gw level', () => {
+            drawGroundwaterLevels(svg, {
+                levels: gwLevels,
+                xScale: xScale,
+                yScale: yScale
+            });
+            expect(svg.selectAll('circle').size()).toBe(4);
+        });
+
+        it('A second call to render with no gw levels renders no circles', () => {
+            drawGroundwaterLevels(svg, {
+                levels: gwLevels,
+                xScale: xScale,
+                yScale: yScale
+            });
+            drawGroundwaterLevels(svg, {
+                levels: [],
+                xScale: xScale,
+                yScale: yScale
+            });
+            expect(svg.selectAll('circle').size()).toBe(0);
+        });
+
+        describe('getGroundwaterLevelsMarker', () => {
+            it('Expects to return a circle marker', () => {
+                expect(getGroundwaterLevelsMarker().type).toBe(circleMarker);
+            });
+        });
+    });
+});

--- a/assets/src/scripts/monitoring-location/components/hydrograph/legend.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/legend.js
@@ -1,6 +1,6 @@
 import {createStructuredSelector} from 'reselect';
 
-import {drawSimpleLegend} from 'd3render//legend';
+import {drawSimpleLegend} from 'd3render/legend';
 import {link} from 'ui/lib/d3-redux';
 
 import {getMainLayout} from './selectors/layout';

--- a/assets/src/scripts/monitoring-location/components/hydrograph/selectors/discrete-data.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/selectors/discrete-data.js
@@ -1,0 +1,25 @@
+import {createSelector} from 'reselect';
+
+import {getIVCurrentVariableGroundwaterLevels} from 'ml/selectors/discrete-data-selector';
+import {getRequestTimeRange} from 'ml/selectors/time-series-selector';
+
+/*
+ * Returns a selector function that returns the groundwater levels that will be visible
+ * on the hydrograpnh
+ * @return {Function} which returns an array of groundwater level object with properties:
+ *      @prop {String} value
+ *      @prop {Array of String} qualifiers
+ *      @prop {Number} dateTime
+ */
+export const getVisibleGroundWaterLevels = createSelector(
+    getRequestTimeRange('current'),
+    getIVCurrentVariableGroundwaterLevels,
+    (timeRange, gwLevels) => {
+        if (!timeRange || !gwLevels.values) {
+            return [];
+        }
+        return gwLevels.values.filter((data) => {
+            return data.dateTime > timeRange.start && data.dateTime < timeRange.end;
+        });
+    }
+);

--- a/assets/src/scripts/monitoring-location/components/hydrograph/selectors/discrete-data.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/selectors/discrete-data.js
@@ -6,7 +6,7 @@ import {getRequestTimeRange} from 'ml/selectors/time-series-selector';
 /*
  * Returns a selector function that returns the groundwater levels that will be visible
  * on the hydrograpnh
- * @return {Function} which returns an array of groundwater level object with properties:
+ * @return {Function} which returns an {Array} of groundwater level object with properties:
  *      @prop {String} value
  *      @prop {Array of String} qualifiers
  *      @prop {Number} dateTime
@@ -22,4 +22,14 @@ export const getVisibleGroundWaterLevels = createSelector(
             return data.dateTime > timeRange.start && data.dateTime < timeRange.end;
         });
     }
+);
+
+/*
+ * Returns a selector function that returns true if any ground water
+ * levels are visible.
+ * @return {Function} which returns {Boolean}
+ */
+export const anyVisibleGroundWaterLevels = createSelector(
+    getVisibleGroundWaterLevels,
+    (gwLevels) => gwLevels.length != 0
 );

--- a/assets/src/scripts/monitoring-location/components/hydrograph/selectors/discrete-data.test.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/selectors/discrete-data.test.js
@@ -1,0 +1,84 @@
+import {getVisibleGroundWaterLevels} from './discrete-data';
+
+describe('monitoring-location/components/hydrograph/selectors/discrete-data', () => {
+
+    describe('getVisibleGroundWaterLevels', () => {
+        const TEST_STATE = {
+            ianaTimeZone: 'America/Chicago',
+            ivTimeSeriesData: {
+                queryInfo: {
+                    'current:P7D': {
+                        notes: {
+                            requestDT: 1490936400000,
+                            'filter:timeRange': {
+                                mode: 'PERIOD',
+                                periodDays: 7,
+                                modifiedSince: null
+                            }
+                        }
+                    }
+                },
+                variables: {
+                    '45807042': {
+                        variableCode: {
+                            'value': '72019'
+                        }
+                    },
+                    '45807041': {
+                        variableCode: {
+                            'value': '00060'
+                        }
+                    }
+                }
+            },
+            ivTimeSeriesState: {
+                currentIVDateRange: 'P7D',
+                currentIVVariableID: '45807042'
+            },
+            discreteData: {
+                groundwaterLevels: {
+                    '72019': {
+                        variable: {
+                            variableCode: {
+                                value: '72019',
+                                variableID: 45807042
+                            }
+                        },
+                        values: [
+                            {value: '14.0', dateTime: 1491055200000},
+                            {value: '14.5', dateTime: 1490882400000},
+                            {value: '13.0', dateTime: 1490536800000},
+                            {value: '12.0', dateTime: 1489672800000}
+                        ]
+                    }
+                }
+            }
+        };
+
+        it('Return empty array if no groundwater levels are defined', () => {
+            const testData = {
+                ...TEST_STATE,
+                discreteData: {
+                    groundwaterLevels: null
+                }
+            };
+            expect(getVisibleGroundWaterLevels(testData)).toHaveLength(0);
+        });
+
+        it('Return an empty array if the current variable does not have ground water data', () => {
+            const testData = {
+                ...TEST_STATE,
+                ivTimeSeriesState: {
+                    ...TEST_STATE.ivTimeSeriesState,
+                    currentIVVariableID: '45807041'
+                }
+            };
+            expect(getVisibleGroundWaterLevels(testData)).toHaveLength(0);
+        });
+
+        it('Return the ground water levels that are in the 7 day period', () => {
+            const result = getVisibleGroundWaterLevels(TEST_STATE);
+            expect(result).toHaveLength(2);
+        });
+    });
+});

--- a/assets/src/scripts/monitoring-location/components/hydrograph/selectors/discrete-data.test.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/selectors/discrete-data.test.js
@@ -1,9 +1,8 @@
-import {getVisibleGroundWaterLevels} from './discrete-data';
+import {getVisibleGroundWaterLevels, anyVisibleGroundWaterLevels} from './discrete-data';
 
 describe('monitoring-location/components/hydrograph/selectors/discrete-data', () => {
 
-    describe('getVisibleGroundWaterLevels', () => {
-        const TEST_STATE = {
+    const TEST_STATE = {
             ianaTimeZone: 'America/Chicago',
             ivTimeSeriesData: {
                 queryInfo: {
@@ -55,6 +54,8 @@ describe('monitoring-location/components/hydrograph/selectors/discrete-data', ()
             }
         };
 
+    describe('getVisibleGroundWaterLevels', () => {
+
         it('Return empty array if no groundwater levels are defined', () => {
             const testData = {
                 ...TEST_STATE,
@@ -79,6 +80,22 @@ describe('monitoring-location/components/hydrograph/selectors/discrete-data', ()
         it('Return the ground water levels that are in the 7 day period', () => {
             const result = getVisibleGroundWaterLevels(TEST_STATE);
             expect(result).toHaveLength(2);
+        });
+    });
+
+    describe('anyVisibleGroundWaterLevels', () => {
+        it('Return false if no visible ground water levels', () => {
+            const testData = {
+                ...TEST_STATE,
+                discreteData: {
+                    groundwaterLevels: null
+                }
+            };
+            expect(anyVisibleGroundWaterLevels(testData)).toBe(false);
+        });
+
+        it('Return true if visible ground water levels', () => {
+            expect(anyVisibleGroundWaterLevels(TEST_STATE)).toBe(true);
         });
     });
 });

--- a/assets/src/scripts/monitoring-location/components/hydrograph/selectors/legend-data.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/selectors/legend-data.js
@@ -7,6 +7,8 @@ import {getWaterwatchFloodLevels, isWaterwatchVisible} from 'ml/selectors/flood-
 import {getCurrentVariableMedianMetadata} from 'ml/selectors/median-statistics-selector';
 
 import {getCurrentVariableLineSegments, HASH_ID, MASK_DESC} from './drawing-data';
+import {anyVisibleGroundWaterLevels} from './discrete-data';
+import {getGroundwaterLevelsMarker} from '../discrete-data';
 
 const TS_LABEL = {
     'current': 'Current: ',
@@ -52,12 +54,14 @@ const getLegendDisplay = createSelector(
     getUniqueClasses('compare'),
     isWaterwatchVisible,
     getWaterwatchFloodLevels,
-    (showSeries, medianSeries, currentClasses, compareClasses, showWaterWatch, floodLevels) => {
+    anyVisibleGroundWaterLevels,
+    (showSeries, medianSeries, currentClasses, compareClasses, showWaterWatch, floodLevels, showGroundWaterLevels) => {
         return {
             current: showSeries.current ? currentClasses : undefined,
             compare: showSeries.compare ? compareClasses : undefined,
             median: showSeries.median ? medianSeries : undefined,
-            floodLevels: showWaterWatch ? floodLevels : undefined
+            floodLevels: showWaterWatch ? floodLevels : undefined,
+            groundwaterLevels: showGroundWaterLevels
         };
     }
 );
@@ -143,6 +147,8 @@ const getFloodLevelMarkers = function(floodLevels) {
 };
 
 
+
+
 /*
  * Factory function  that returns an array of array of markers to be used for the
  * time series graph legend
@@ -152,11 +158,19 @@ export const getLegendMarkerRows = createSelector(
     getLegendDisplay,
     (displayItems) => {
         const markerRows = [];
-        const currentTsMarkerRow = displayItems.current ? getTsMarkers('current', displayItems.current) : undefined;
+        let currentTsMarkerRow = displayItems.current ? getTsMarkers('current', displayItems.current) : undefined;
         const compareTsMarkerRow = displayItems.compare ? getTsMarkers('compare', displayItems.compare) : undefined;
         const medianMarkerRows = displayItems.median ? getMedianMarkers(displayItems.median) : [];
         const floodMarkerRows = displayItems.floodLevels ? getFloodLevelMarkers(displayItems.floodLevels) : [];
-
+        /* Add groundwater marker to current row */
+        if (displayItems.groundwaterLevels) {
+            const gwLevelMarker = getGroundwaterLevelsMarker();
+            if (currentTsMarkerRow) {
+                currentTsMarkerRow.push(gwLevelMarker);
+            } else {
+                currentTsMarkerRow = [gwLevelMarker];
+            }
+        }
         if (currentTsMarkerRow) {
             markerRows.push(currentTsMarkerRow);
         }

--- a/assets/src/scripts/monitoring-location/components/hydrograph/selectors/legend-data.test.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/selectors/legend-data.test.js
@@ -1,12 +1,24 @@
-import {lineMarker, rectangleMarker, textOnlyMarker} from 'd3render/markers';
+import {lineMarker, rectangleMarker, textOnlyMarker, circleMarker} from 'd3render/markers';
 
 import {getLegendMarkerRows} from './legend-data';
 
 describe('monitoring-location/components/hydrograph/selectors/legend-data', () => {
     const TEST_DATA = {
         ivTimeSeriesData: {
+            queryInfo: {
+                    'current:P7D': {
+                        notes: {
+                            requestDT: 1520339792000,
+                            'filter:timeRange': {
+                                mode: 'PERIOD',
+                                periodDays: 7,
+                                modifiedSince: null
+                            }
+                        }
+                    }
+                },
             timeSeries: {
-                '00060:current': {
+                '72019:current:P7D': {
                     tsKey: 'current:P7D',
                     startTime: new Date('2018-03-06T15:45:00.000Z'),
                     endTime: new Date('2018-03-13T13:45:00.000Z'),
@@ -29,10 +41,10 @@ describe('monitoring-location/components/hydrograph/selectors/legend-data', () =
                     }]
                 },
 
-                '00060:compare': {
+                '72019:compare': {
                     tsKey: 'compare:P7D',
                     startTime: new Date('2018-03-06T15:45:00.000Z'),
-                    endTime: new Date('2018-03-06T15:45:00.000Z'),
+                    endTime: new Date('2018-03-18T15:45:00.000Z'),
                     variable: '45807202',
                     points: [{
                         value: 1,
@@ -54,9 +66,9 @@ describe('monitoring-location/components/hydrograph/selectors/legend-data', () =
             },
             variables: {
                 '45807197': {
-                    variableCode: {value: '00060'},
-                    variableName: 'Streamflow',
-                    variableDescription: 'Discharge, cubic feet per second',
+                    variableCode: {value: '72019'},
+                    variableName: 'Groundwater Levels',
+                    variableDescription: 'Depth to water level, ft below land surface',
                     oid: '45807197'
                 },
                 '45807202': {
@@ -68,7 +80,7 @@ describe('monitoring-location/components/hydrograph/selectors/legend-data', () =
         },
         statisticsData: {
             median: {
-                '00060': {
+                '72019': {
                     '1': [{
                         month_nu: '2',
                         day_nu: '25',
@@ -87,6 +99,24 @@ describe('monitoring-location/components/hydrograph/selectors/legend-data', () =
                 current: true,
                 compare: true,
                 median: true
+            }
+        },
+        discreteData: {
+            groundwaterLevels: {
+                '72019': {
+                    variable: {
+                        variableCode: {
+                            value: '72019',
+                            variableID: 45807197
+                        }
+                    },
+                    values: [
+                        {value: '14.0', dateTime: 1519942619200},
+                        {value: '14.5', dateTime: 1490882400000},
+                        {value: '13.0', dateTime: 1490536800000},
+                        {value: '12.0', dateTime: 1489672800000}
+                    ]
+                }
             }
         },
         floodData: {
@@ -110,7 +140,8 @@ describe('monitoring-location/components/hydrograph/selectors/legend-data', () =
                     timeSeries: {}
                 },
                 statisticsData: {},
-                floodState: {}
+                floodState: {},
+                discreteData: {}
             };
 
             expect(getLegendMarkerRows(newData)).toEqual([]);
@@ -120,11 +151,12 @@ describe('monitoring-location/components/hydrograph/selectors/legend-data', () =
             const result = getLegendMarkerRows(TEST_DATA);
 
             expect(result).toHaveLength(2);
-            expect(result[0]).toHaveLength(4);
+            expect(result[0]).toHaveLength(5);
             expect(result[0][0].type).toEqual(textOnlyMarker);
             expect(result[0][1].type).toEqual(lineMarker);
             expect(result[0][2].type).toEqual(rectangleMarker);
             expect(result[0][3].type).toEqual(rectangleMarker);
+            expect(result[0][4].type).toEqual(circleMarker);
             expect(result[1]).toHaveLength(2);
             expect(result[1][0].type).toEqual(textOnlyMarker);
             expect(result[1][1].type).toEqual(lineMarker);
@@ -163,11 +195,13 @@ describe('monitoring-location/components/hydrograph/selectors/legend-data', () =
             const result = getLegendMarkerRows(newData);
 
             expect(result).toHaveLength(1);
-            expect(result[0]).toHaveLength(4);
+            expect(result[0]).toHaveLength(5);
             expect(result[0][0].type).toEqual(textOnlyMarker);
             expect(result[0][1].type).toEqual(lineMarker);
             expect(result[0][2].type).toEqual(rectangleMarker);
             expect(result[0][3].type).toEqual(rectangleMarker);
+            expect(result[0][4].type).toEqual(circleMarker);
+
         });
     });
 });

--- a/assets/src/scripts/monitoring-location/components/hydrograph/time-series-graph.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/time-series-graph.js
@@ -24,7 +24,7 @@ import {getMainLayout} from './selectors/layout';
 import {getMainXScale, getMainYScale, getBrushXScale} from './selectors/scales';
 import {getDescription, isVisible, getTitle} from './selectors/time-series-data';
 
-import {drawGroundWaterLevels} from './discrete-data';
+import {drawGroundwaterLevels} from './discrete-data';
 import {drawDataLines} from './time-series-lines';
 import {drawTooltipFocus, drawTooltipText}  from './tooltip';
 
@@ -271,7 +271,7 @@ export const drawTimeSeriesGraph = function(elem, store, siteNo, showMLName, sho
             seriesPoints: getCurrentVariableMedianStatPoints,
             enableClip: () => true
         })))
-        .call(link(store, drawGroundWaterLevels, createStructuredSelector({
+        .call(link(store, drawGroundwaterLevels, createStructuredSelector({
             levels: getVisibleGroundWaterLevels,
             xScale: getMainXScale('current'),
             yScale: getMainYScale

--- a/assets/src/scripts/monitoring-location/components/hydrograph/time-series-graph.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/time-series-graph.js
@@ -14,6 +14,7 @@ import {getAgencyCode, getMonitoringLocationName, getCurrentVariable} from 'ml/s
 import {isWaterwatchVisible, getWaterwatchFloodLevels} from 'ml/selectors/flood-data-selector';
 
 import {getAxes}  from './selectors/axes';
+import {getVisibleGroundWaterLevels} from './selectors/discrete-data';
 import {
     getCurrentVariableLineSegments,
     getCurrentVariableMedianStatPoints,
@@ -23,6 +24,7 @@ import {getMainLayout} from './selectors/layout';
 import {getMainXScale, getMainYScale, getBrushXScale} from './selectors/scales';
 import {getDescription, isVisible, getTitle} from './selectors/time-series-data';
 
+import {drawGroundWaterLevels} from './discrete-data';
 import {drawDataLines} from './time-series-lines';
 import {drawTooltipFocus, drawTooltipText}  from './tooltip';
 
@@ -269,12 +271,18 @@ export const drawTimeSeriesGraph = function(elem, store, siteNo, showMLName, sho
             seriesPoints: getCurrentVariableMedianStatPoints,
             enableClip: () => true
         })))
+        .call(link(store, drawGroundWaterLevels, createStructuredSelector({
+            levels: getVisibleGroundWaterLevels,
+            xScale: getMainXScale('current'),
+            yScale: getMainYScale
+        })))
         .call(link(store, plotAllFloodLevelPoints, createStructuredSelector({
             visible: isWaterwatchVisible,
             xscale: getBrushXScale('current'),
             yscale: getMainYScale,
             seriesPoints: getWaterwatchFloodLevels
         })));
+
     if (showTooltip) {
         dataGroup.call(drawTooltipFocus, store);
     }

--- a/assets/src/scripts/monitoring-location/index.js
+++ b/assets/src/scripts/monitoring-location/index.js
@@ -32,11 +32,13 @@ const loadAllGroundWaterData = function(nodes, store) {
     }
 
     const siteno = nodesWithGroundWaterLevels[0].dataset.siteno;
-    Object.keys(config.gwPeriodOfRecord).forEach(function(parameterCode) {
-        const periodOfRecord = config.gwPeriodOfRecord[parameterCode];
-        store.dispatch(
-            retrieveGroundwaterLevels(siteno, parameterCode, periodOfRecord.begin_date, periodOfRecord.end_date));
-    });
+    if (config.gwPeriodOfRecord) {
+        Object.keys(config.gwPeriodOfRecord).forEach(function (parameterCode) {
+            const periodOfRecord = config.gwPeriodOfRecord[parameterCode];
+            store.dispatch(
+                retrieveGroundwaterLevels(siteno, parameterCode, periodOfRecord.begin_date, periodOfRecord.end_date));
+        });
+    }
 };
 
 const load = function() {

--- a/assets/src/scripts/monitoring-location/selectors/discrete-data-selector.js
+++ b/assets/src/scripts/monitoring-location/selectors/discrete-data-selector.js
@@ -20,7 +20,6 @@ export const getIVCurrentVariableGroundwaterLevels = createSelector(
     getAllGroundwaterLevels,
     getCurrentParmCd,
     (gwLevels, parameterCode) => {
-
         return gwLevels && parameterCode && gwLevels[parameterCode] ? gwLevels[parameterCode] : {};
     }
 );

--- a/assets/src/scripts/monitoring-location/selectors/discrete-data-selector.js
+++ b/assets/src/scripts/monitoring-location/selectors/discrete-data-selector.js
@@ -1,0 +1,26 @@
+import {createSelector} from 'reselect';
+
+import {getCurrentParmCd} from './time-series-selector';
+
+/*
+ * Returns selector function which returns all of the groundwater levels.
+ * @return {Function} - The function returns an Object containing all of the groundwater levels. The
+ * object's keys represent parameter codes.
+ */
+export const getAllGroundwaterLevels =
+    (state) => state.discreteData.groundwaterLevels ? state.discreteData.groundwaterLevels : null;
+
+/*
+ * Returns selector function which returns the groundwater levels for the current IV variable
+ * @return {Function} - The function returns an Object with the following properties:
+ *      @prop {Object} variable
+ *      @prop {Object} values
+ */
+export const getIVCurrentVariableGroundwaterLevels = createSelector(
+    getAllGroundwaterLevels,
+    getCurrentParmCd,
+    (gwLevels, parameterCode) => {
+
+        return gwLevels && parameterCode && gwLevels[parameterCode] ? gwLevels[parameterCode] : {};
+    }
+);

--- a/assets/src/scripts/monitoring-location/selectors/discrete-data-selector.test.js
+++ b/assets/src/scripts/monitoring-location/selectors/discrete-data-selector.test.js
@@ -1,0 +1,132 @@
+import {getAllGroundwaterLevels, getIVCurrentVariableGroundwaterLevels} from './discrete-data-selector';
+
+describe('monitoring-location/selectors/discrete-data-selector', () => {
+    describe('getAllGroundwaterLevels', () => {
+        it('Return null if no groundwater levels are available', () => {
+            expect(getAllGroundwaterLevels({
+                discreteData: {}
+            })).toBeNull();
+            expect(getAllGroundwaterLevels({
+                discreteData: {
+                    groundwaterLevels: null
+                }
+            })).toBeNull();
+        });
+
+        it('Return all groundwater levels', () => {
+            const TEST_DATA = {
+                '72019': {
+                    variables: {variableID: 1111},
+                    values: [
+                        {value: '11.5', qualifiers: [], date: 1586354400000}
+                    ]
+                },
+                '65443': {
+                    variables: {variableID: 1111},
+                    values: [
+                        {value: '15.5', qualifiers: [], date: 1586354400000},
+                        {value: '24.3', qualifiers: [], date: 1588946400000}
+                    ]
+                }
+            };
+            expect(getAllGroundwaterLevels({
+                discreteData: {
+                    groundwaterLevels: TEST_DATA
+                }
+            })).toEqual(TEST_DATA);
+        });
+    });
+
+    describe('getIVCurrentVariableGroundwaterLevels', () => {
+        const TEST_IV_TIME_SERIES_DATA = {
+            ivTimeSeriesData: {
+                variables: {
+                    '45807042': {
+                        variableCode: {
+                            'value': '72019'
+                        }
+                    },
+                    '450807142': {
+                        variableCode: {
+                            'value': '00010'
+                        }
+                    }
+                }
+            }
+        };
+        const TEST_IV_TIME_SERIES_STATE = {
+            ivTimeSeriesState: {
+                currentIVVariableID: '45807042'
+            }
+        };
+
+        const TEST_GROUNDWATER_LEVELS = {
+            discreteData : {
+                groundwaterLevels : {
+                    '72019': {
+                        variable: {
+                            variableCode: {
+                                value: '72019',
+                                variableID: '45807042'
+                            }
+                        },
+                        values: [
+                            {
+                                value: '34.5',
+                                qualifiers: [],
+                                dateTime: 1604775600000
+                            },
+                            {
+                                value: '40.2',
+                                qualifiers: [],
+                                datetime: 1607972400000
+                            }
+                        ]
+                    }
+                }
+            }
+        };
+
+        it('Return empty object if no groundwater levels and current IV variable is not defined', () => {
+            expect(getIVCurrentVariableGroundwaterLevels({
+                discreteData: {groundwaterLevels: null},
+                ivTimeSeriesState: {},
+                ivTimeSeriesData: {}
+            })).toEqual({});
+        });
+
+        it('Return empty object if no groundwater levels but current IV variable is defined', () => {
+            expect(getIVCurrentVariableGroundwaterLevels({
+                discreteData: {groundwaterLevels: null},
+                ...TEST_IV_TIME_SERIES_DATA,
+                ...TEST_IV_TIME_SERIES_STATE
+            })).toEqual({});
+        });
+
+        it('Return empty object if groundwater levels exist but no current IV variable is defined', () => {
+            expect(getIVCurrentVariableGroundwaterLevels({
+                ivTimeSeriesState: {},
+                ...TEST_IV_TIME_SERIES_DATA,
+                ...TEST_GROUNDWATER_LEVELS
+            })).toEqual({});
+        });
+
+        it('Should return an empty object if no groundwater levels exist for selected IV variable', () => {
+            expect(getIVCurrentVariableGroundwaterLevels({
+                ivTimeSeriesState: {
+                   currenteIVVariableID: 450807142
+                },
+                ...TEST_IV_TIME_SERIES_DATA,
+                ...TEST_GROUNDWATER_LEVELS
+            })).toEqual({});
+        });
+
+        it('Should return the groundwater levels for selected IV variable', () => {
+            expect(getIVCurrentVariableGroundwaterLevels({
+                ...TEST_IV_TIME_SERIES_DATA,
+                ...TEST_IV_TIME_SERIES_STATE,
+                ...TEST_GROUNDWATER_LEVELS
+            })).toEqual(TEST_GROUNDWATER_LEVELS.discreteData.groundwaterLevels['72019']);
+        });
+    });
+});

--- a/assets/src/scripts/monitoring-location/selectors/time-series-selector.js
+++ b/assets/src/scripts/monitoring-location/selectors/time-series-selector.js
@@ -88,7 +88,6 @@ export const getCurrentVariable = createSelector(
 export const getCurrentParmCd = createSelector(
     getCurrentVariable,
     (currentVar) => {
-
         return currentVar && currentVar.variableCode ? currentVar.variableCode.value : null;
     }
 );

--- a/assets/src/scripts/monitoring-location/store/discrete-data.js
+++ b/assets/src/scripts/monitoring-location/store/discrete-data.js
@@ -1,0 +1,96 @@
+import {DateTime} from 'luxon';
+
+import {fetchGroundwaterLevels} from 'ui/web-services/groundwater-levels';
+
+const INITIAL_DATA = {
+    groundwaterLevels : {}
+};
+
+/*
+ * Synchronous Redux actions to add the ground water level data for the variable.
+ * @param {String} parameterCode -
+ * @param {Object} data - Each object has properties
+ *      @prop {Object} variable - contains detailed information about the parameter
+ *      @prop {Array of Object} values - contains the following properties
+ *        @prop {String} value
+ *        @prop {Array of String} qualifiers
+ *        @prop {Number} dateTime - Unix epoch time
+ */
+export const addGroundwaterLevels = function(parameterCode, data) {
+    return {
+        type: 'ADD_GROUNDWATER_LEVELS',
+        parameterCode,
+        data
+    };
+};
+
+/*
+ * Redux asynchronous action to retrieve the groundwater levels for a monitoring location and parameterCode
+ * over the time period
+ * @param {String} monitoringLocationId
+ * @param {String} parameterCode
+ * @param {String} startDT - ISO-8601 date format
+ * @param {String} endDT - ISO-8601 date format
+ */
+export const retrieveGroundwaterLevels = function(monitoringLocationId, parameterCode, startDT, endDT) {
+    return function(dispatch, getState) {
+        const state = getState();
+        if (state.discreteData.groundWaterLevels && parameterCode in state.discreteData.groundWaterLevels) {
+            return Promise.resolve();
+        }
+        return fetchGroundwaterLevels({
+            site: monitoringLocationId,
+            parameterCode: parameterCode,
+            startDT: startDT,
+            endDT: endDT
+        })
+            .then(
+                (data) => {
+                    if (!data.value || !data.value.timeSeries || !data.value.timeSeries.length) {
+                        dispatch(addGroundwaterLevels(parameterCode, {}));
+                    } else {
+                        let values;
+                        const timeSeries = data.value.timeSeries;
+                        if (!timeSeries[0].values.length || !timeSeries[0].values[0].value.length) {
+                            values = [];
+                        } else {
+                            values = timeSeries[0].values[0].value.map((v) => {
+                                const dateTime = DateTime.fromISO(v.dateTime, {zone: 'utc'}).toMillis();
+                                return {
+                                    value: v.value,
+                                    qualifiers: v.qualifiers,
+                                    dateTime: dateTime
+                                };
+
+                            });
+                        }
+                        dispatch(addGroundwaterLevels(parameterCode, {
+                            variable: timeSeries[0].variable,
+                            values: values
+                        }));
+                    }
+                },
+                () => {
+                    console.error(`Unable to retrieve ground water levels for site, 
+                    ${monitoringLocationId} and parameterCode, ${parameterCode}`);
+                });
+    };
+};
+
+export const discreteDataReducer = function(discreteData = INITIAL_DATA, action) {
+    switch(action.type) {
+        case 'ADD_GROUNDWATER_LEVELS': {
+            let newData = {};
+            newData[action.parameterCode] = action.data;
+            return Object.assign(
+                {},
+                discreteData,
+                {
+                    groundwaterLevels: Object.assign({}, discreteData.groundwaterLevels, newData)
+                }
+            );
+        }
+        default:
+            return discreteData;
+    }
+};

--- a/assets/src/scripts/monitoring-location/store/discrete-data.js
+++ b/assets/src/scripts/monitoring-location/store/discrete-data.js
@@ -3,7 +3,7 @@ import {DateTime} from 'luxon';
 import {fetchGroundwaterLevels} from 'ui/web-services/groundwater-levels';
 
 const INITIAL_DATA = {
-    groundwaterLevels : {}
+    groundwaterLevels : null
 };
 
 /*

--- a/assets/src/scripts/monitoring-location/store/discrete-data.test.js
+++ b/assets/src/scripts/monitoring-location/store/discrete-data.test.js
@@ -123,7 +123,7 @@ describe('monitoring-location/store/discrete-data', () => {
                 expect(state.discreteData.groundwaterLevels['72019'].values[0]).toEqual({
                     value: '26.07',
                     qualifiers: [],
-                    dateTime: 1579770360000
+                    dateTime: 1579788360000
                 });
             });
         });

--- a/assets/src/scripts/monitoring-location/store/discrete-data.test.js
+++ b/assets/src/scripts/monitoring-location/store/discrete-data.test.js
@@ -1,0 +1,162 @@
+import mockConsole from 'jest-mock-console';
+import {applyMiddleware,  combineReducers, createStore} from 'redux';
+import {default as thunk} from 'redux-thunk';
+import sinon from 'sinon';
+
+import {MOCK_GWLEVEL_DATA} from 'ui/mock-service-data';
+import {addGroundwaterLevels, retrieveGroundwaterLevels, discreteDataReducer} from './discrete-data';
+
+describe('monitoring-location/store/discrete-data', () => {
+    let store;
+    let fakeServer;
+    let restoreConsole;
+
+    beforeEach(() => {
+        store = createStore(
+            combineReducers({
+                discreteData: discreteDataReducer
+            }),
+            {
+                discreteData: {}
+            },
+            applyMiddleware(thunk)
+        );
+        fakeServer = sinon.createFakeServer();
+        restoreConsole = mockConsole();
+    });
+
+    afterEach(() => {
+        fakeServer.restore();
+        restoreConsole();
+    });
+
+    describe('addGroundwaterLevels action', () => {
+        const TEST_DATA = {
+            variable: {
+                variableCode: {
+                    value: '72019',
+                    variableID: '12345'
+                }
+            },
+            values: [
+                {
+                    value: '34.5',
+                    qualifiers: [],
+                    dateTime: 1604775600000
+                },
+                {
+                    value: '40.2',
+                    qualifiers: [],
+                    datetime: 1607972400000
+                }
+            ]
+        };
+        it('adds the groundwater levels to the store', () => {
+            store.dispatch(addGroundwaterLevels('72019', TEST_DATA));
+            const state = store.getState();
+
+            expect(state.discreteData.groundwaterLevels['72019']).toEqual(TEST_DATA);
+        });
+
+        it('add the groundwater levels for the parameter code to the store while retaining data from other parameter codes', () => {
+            const testDataOne = {
+                variable: {
+                    variableCode: {
+                        value: '60123',
+                        variableID: '55555'
+                    }
+                },
+                values: [
+                    {
+                        value: '12.5',
+                        qualifiers: [],
+                        dateTime: 1597431600000
+                    },
+                    {
+                        value: '10.2',
+                        qualifiers: [],
+                        datetime: 1600110000000
+                    }
+                ]
+            };
+            store.dispatch(addGroundwaterLevels('60123', testDataOne));
+            store.dispatch(addGroundwaterLevels('72019', TEST_DATA));
+            const state = store.getState();
+
+            expect(state.discreteData.groundwaterLevels['60123']).toEqual(testDataOne);
+            expect(state.discreteData.groundwaterLevels['72019']).toEqual(TEST_DATA);
+        });
+
+        it('replace the existing data for the parameter code', () => {
+            const changedTestData = {
+                ...TEST_DATA,
+                values: [{
+                    value: '14.5',
+                    qualifiers: [],
+                    dateTime: 1604775600000
+                },
+                {
+                    value: '4.2',
+                    qualifiers: [],
+                    datetime: 1607972400000
+                }]
+            };
+            store.dispatch(addGroundwaterLevels('72019', TEST_DATA));
+            store.dispatch(addGroundwaterLevels('72019', changedTestData));
+            const state = store.getState();
+            
+            expect(state.discreteData.groundwaterLevels['72019']).toEqual(changedTestData);
+        });
+    });
+
+    describe('asynchronous action retrieveGroundwaterLevels', () => {
+        it('Fetches groundwater levels and updates the store while converting the dateTimes to epoch', () => {
+            fakeServer.respondWith([200, {'Content-Type': 'application/json'}, MOCK_GWLEVEL_DATA]);
+            const dispatchPromise = store.dispatch(retrieveGroundwaterLevels('12345678', '72019', '2020-01-01', '2020-11-17)'));
+            fakeServer.respond();
+            return dispatchPromise.then(() => {
+                const state = store.getState();
+
+                expect(state.discreteData.groundwaterLevels['72019']).toBeDefined();
+                expect(state.discreteData.groundwaterLevels['72019'].variable.variableCode[0].value).toEqual('72019');
+                expect(state.discreteData.groundwaterLevels['72019'].values).toHaveLength(7);
+                expect(state.discreteData.groundwaterLevels['72019'].values[0]).toEqual({
+                    value: '26.07',
+                    qualifiers: [],
+                    dateTime: 1579770360000
+                });
+            });
+        });
+
+        it('Fetches groundwater levels with no levels and updates state', () => {
+            const MOCK_DATA = {
+                value: {
+                    timeSeries: [
+                        {
+                            variable: {variableId: 11112222},
+                            values: [{value: []}]
+                        }
+                    ]
+                }
+            };
+            fakeServer.respondWith([200, {'Content-Type': 'application/json'}, JSON.stringify(MOCK_DATA)]);
+            const dispatchPromise = store.dispatch(retrieveGroundwaterLevels('12345678', '72019', '2020-01-01', '2020-11-17)'));
+            fakeServer.respond();
+            return dispatchPromise.then(() => {
+                const state = store.getState();
+                expect(state.discreteData.groundwaterLevels['72019'].values).toHaveLength(0);
+            });
+        });
+
+        it('Bad fetch updates groundwater level with empty object', () => {
+            fakeServer.respondWith([500, {}, 'Internal server error']);
+            const dispatchPromise = store.dispatch(retrieveGroundwaterLevels('12345678', '72019', '2020-01-01', '2020-11-17)'));
+            fakeServer.respond();
+            return dispatchPromise.then(() => {
+                const state = store.getState();
+
+                expect(state.discreteData.groundwaterLevels['72019']).toEqual({});
+            });
+        });
+    });
+});

--- a/assets/src/scripts/monitoring-location/store/index.js
+++ b/assets/src/scripts/monitoring-location/store/index.js
@@ -7,6 +7,7 @@ import {
 import {nldiDataReducer as nldiData} from './nldi-data';
 import {dailyValueTimeSeriesDataReducer as dailyValueTimeSeriesData} from './daily-value-time-series';
 import {dailyValueTimeSeriesStateReducer as dailyValueTimeSeriesState} from './daily-value-time-series';
+import {discreteDataReducer as discreteData} from './discrete-data';
 import {ivTimeSeriesDataReducer as ivTimeSeriesData} from './instantaneous-value-time-series-data';
 import {ivTimeSeriesStateReducer as ivTimeSeriesState} from './instantaneous-value-time-series-state';
 import {networkDataReducer as networkData} from './network';
@@ -21,6 +22,7 @@ const appReducer = combineReducers({
     statisticsData,
     floodData,
     nldiData,
+    discreteData,
     ivTimeSeriesState,
     dailyValueTimeSeriesState,
     floodState,
@@ -36,6 +38,7 @@ export const configureStore = function(initialState) {
         ivTimeSeriesData: {},
         ianaTimeZone: null,
         dailyValueTimeSeriesData: {},
+        discreteData: {},
         floodData: {
             stages: [],
             extent: {},

--- a/assets/src/scripts/monitoring-location/store/instantaneous-value-time-series-state.js
+++ b/assets/src/scripts/monitoring-location/store/instantaneous-value-time-series-state.js
@@ -6,7 +6,7 @@
  */
 
 /*
- * Synchronous action to toggle the visibility of specific time series (i.e. current, compare, median)
+ * Synchronous action to toggle the visibility of specific time series (i.e. current, compare, median, gwlevels)
  * @param {String} key
  * @param {Boolean} show
  * @return {Object} - Redux action

--- a/assets/src/scripts/web-services/flood-data.test.js
+++ b/assets/src/scripts/web-services/flood-data.test.js
@@ -6,7 +6,7 @@ import {fetchFIMPublicStatus, fetchFloodExtent, fetchFloodFeatures,
     fetchWaterwatchFloodLevels} from './flood-data';
 
 
-describe('flood_data module', () => {
+describe('web-services/flood-data', () => {
     let fakeServer;
     beforeEach(() => {
         fakeServer = sinon.createFakeServer();
@@ -16,7 +16,7 @@ describe('flood_data module', () => {
         fakeServer.restore();
     });
 
-    describe('web-services/fetchFIMPublicStatus', () => {
+    describe('fetchFIMPublicStatus', () => {
         const siteno = '12345678';
         describe('with valid response', () => {
             let promise;

--- a/assets/src/scripts/web-services/groundwater-levels.js
+++ b/assets/src/scripts/web-services/groundwater-levels.js
@@ -1,0 +1,23 @@
+
+import {get} from 'ui/ajax';
+import config from 'ui/config';
+
+/**
+ * Fetch the groundwater levels for site, parameterCode, and period
+ * @param {String} sites
+ * @param {String} parameterCode
+ * @param {String} startDT - ISO-8601 date format
+ * @param {String} endDT - ISO-8601 date format
+ * @return {Promise} resolves to Object that is retrieved with ground water levels
+ */
+export const fetchGroundwaterLevels = function({site, parameterCode, startDT, endDT}) {
+    const queryParams = `sites=${site}&parameterCd=${parameterCode}&startDT=${startDT}&endDT=${endDT}`;
+    const url = `${config.GROUNDWATER_LEVELS_ENDPOINT}?${queryParams}&format=json`;
+
+    return get(url)
+        .then(response => JSON.parse(response))
+        .catch(reason => {
+            console.error(reason);
+            return {};
+        });
+};

--- a/assets/src/scripts/web-services/groundwater-levels.test.js
+++ b/assets/src/scripts/web-services/groundwater-levels.test.js
@@ -1,0 +1,61 @@
+import mockConsole from 'jest-mock-console';
+import sinon from 'sinon';
+
+import {MOCK_GWLEVEL_DATA} from 'ui/mock-service-data';
+
+import {fetchGroundwaterLevels} from './groundwater-levels';
+
+describe('web-services/groundwater-levels', () => {
+    let fakeServer;
+    let restoreConsole;
+
+    beforeEach(() => {
+        fakeServer = sinon.createFakeServer();
+        restoreConsole = mockConsole();
+
+    });
+
+    afterEach(() => {
+        fakeServer.restore();
+        restoreConsole();
+    });
+
+    describe('fetchGroundwaterLevels', () => {
+        let fetchPromise;
+        const fetchParameters = {
+            site: '354133082042203',
+            parameterCode: '72019',
+            startDT: '2020-01-01',
+            endDt: '2020-11-17'
+        };
+
+        it('expects properly formated query parameters in service request', () => {
+            fetchGroundwaterLevels(fetchParameters);
+            const url = fakeServer.requests[0].url;
+
+            expect(url).toContain(`sites=${fetchParameters.site}`);
+            expect(url).toContain(`parameterCd=${fetchParameters.parameterCode}`);
+            expect(url).toContain(`startDT=${fetchParameters.startDT}`);
+            expect(url).toContain(`endDT=${fetchParameters.endDT}`);
+            expect(url).toContain('format=json');
+        });
+
+        it('Successful fetch returns a JSON object with ground water levels', () => {
+            fakeServer.respondWith([200, {'Content-type': 'application/json'}, MOCK_GWLEVEL_DATA]);
+            fetchPromise = fetchGroundwaterLevels(fetchParameters);
+            fakeServer.respond();
+            return fetchPromise.then((resp) => {
+                expect(resp).toEqual(JSON.parse(MOCK_GWLEVEL_DATA));
+            });
+        });
+
+        it('Bad fetch returns an empty object', () => {
+            fakeServer.respondWith([500, {}, 'Internal server error']);
+            fetchPromise = fetchGroundwaterLevels(fetchParameters);
+            fakeServer.respond();
+            return fetchPromise.then((resp) => {
+                expect(resp).toEqual({});
+            });
+        });
+    });
+});

--- a/assets/src/scripts/web-services/observations.test.js
+++ b/assets/src/scripts/web-services/observations.test.js
@@ -1,6 +1,5 @@
 import sinon from 'sinon';
 
-import config from 'ui/config';
 import {MOCK_OBSERVATION_ITEM} from 'ui/mock-service-data';
 
 import {fetchAvailableDVTimeSeries, fetchDVTimeSeries, fetchNetworkMonitoringLocations,

--- a/assets/src/styles/components/hydrograph/_graph.scss
+++ b/assets/src/styles/components/hydrograph/_graph.scss
@@ -184,6 +184,11 @@ svg {
       stroke-width: 2px;
     }
   }
+  .gw-level-point {
+    stroke: red;
+    stroke-width: 2px;
+    fill: none;
+  }
 
   .waterwatch-data-series {
     fill: none;

--- a/wdfn-server/config.py
+++ b/wdfn-server/config.py
@@ -36,6 +36,7 @@ NWIS_ENDPOINTS = {
 WEATHER_SERVICE_ROOT = 'https://api.weather.gov'
 
 OBSERVATIONS_ENDPOINT = 'https://labs.waterdata.usgs.gov/api/observations/'
+GROUNDWATER_LEVELS_ENDPOINT = 'https://waterservices.usgs.gov/nwis/gwlevels/'
 
 FIM_GIS_ENDPOINT = 'https://gis.wim.usgs.gov/arcgis/rest/services/FIMMapper/'
 FIM_ENDPOINT = 'https://fim.wim.usgs.gov/fim/'

--- a/wdfn-server/config.py
+++ b/wdfn-server/config.py
@@ -23,7 +23,7 @@ MONITORING_CAMERA_ENABLED = True
 MONITORING_CAMERA_PATH = os.path.join(PROJECT_HOME, 'data/monitoring_camera_data.json')
 DAILY_VALUE_HYDROGRAPH_ENABLED = True
 SET_COOKIE_TO_HIDE_BANNER_NOTICES = True  # set cookie set to hide banner messages for the life of the cookie
-
+GROUNDWATER_LEVELS_ENABLED = True
 DEBUG = False
 
 SERVER_SERVICE_ROOT = 'https://waterservices.usgs.gov'  # Used for webserver calls to waterservices.

--- a/wdfn-server/waterdata/templates/base_plain.html
+++ b/wdfn-server/waterdata/templates/base_plain.html
@@ -26,6 +26,7 @@
                 'PAST_SERVICE_ROOT': '{{ config.PAST_SERVICE_ROOT }}/nwis',
                 'NWIS_INVENTORY_ENDPOINT': '{{ config.NWIS_ENDPOINTS.INVENTORY }}',
                 'OBSERVATIONS_ENDPOINT': '{{ config.OBSERVATIONS_ENDPOINT }}',
+                'GROUNDWATER_LEVELS_ENDPOINT': '{{ config.GROUNDWATER_LEVELS_ENDPOINT }}',
                 'HYDRO_ENDPOINT': '{{ config.HYDRO_ENDPOINT }}',
                 'TNM_USGS_TOPO_ENDPOINT' : '{{ config.TNM_USGS_TOPO_ENDPOINT }}',
                 'TNM_USGS_IMAGERY_ONLY_ENDPOINT': '{{ config.TNM_USGS_IMAGERY_ONLY_ENDPOINT }}',

--- a/wdfn-server/waterdata/templates/monitoring_location.html
+++ b/wdfn-server/waterdata/templates/monitoring_location.html
@@ -33,9 +33,18 @@
     {% if uv_period_of_record %}
         <script type="application/javascript">
             CONFIG.uvPeriodOfRecord = {{ uv_period_of_record | tojson }};
-            CONFIG.gwPeriodOfRecord = {{ gw_period_of_record | tojson }};
         </script>
     {% endif %}
+    {% if gw_period_of_record %}
+        <script type="application/javascript">
+            CONFIG.gwPeriodOfRecord = {{ gw_period_of_record | tojson }};
+        </script>
+    {% else %}
+        <script type="application/javascript">
+           CONFIG.gwPeriodOfRecord = null;
+        </script>
+    {% endif %}
+
     <script src="{{ 'bundle.js' | asset_url }}"></script>
     {% if json_ld %}
         <script type="application/ld+json">

--- a/wdfn-server/waterdata/templates/monitoring_location.html
+++ b/wdfn-server/waterdata/templates/monitoring_location.html
@@ -33,6 +33,7 @@
     {% if uv_period_of_record %}
         <script type="application/javascript">
             CONFIG.uvPeriodOfRecord = {{ uv_period_of_record | tojson }};
+            CONFIG.gwPeriodOfRecord = {{ gw_period_of_record | tojson }};
         </script>
     {% endif %}
     <script src="{{ 'bundle.js' | asset_url }}"></script>

--- a/wdfn-server/waterdata/views.py
+++ b/wdfn-server/waterdata/views.py
@@ -132,7 +132,8 @@ def monitoring_location(site_no):
                 'json_ld': Markup(json.dumps(json_ld, indent=4)),
                 'available_data_types': available_data_types,
                 'uv_period_of_record': get_period_of_record_by_parm_cd(parameter_data),
-                'gw_period_of_record': get_period_of_record_by_parm_cd(parameter_data, 'gw'),
+                'gw_period_of_record': get_period_of_record_by_parm_cd(parameter_data, 'gw')
+                    if app.config['GROUNDWATER_LEVELS_ENABLED'] else None,
                 'parm_grp_summary': grouped_dataseries,
                 'questions_link': questions_link,
                 'cooperators': cooperators

--- a/wdfn-server/waterdata/views.py
+++ b/wdfn-server/waterdata/views.py
@@ -132,6 +132,7 @@ def monitoring_location(site_no):
                 'json_ld': Markup(json.dumps(json_ld, indent=4)),
                 'available_data_types': available_data_types,
                 'uv_period_of_record': get_period_of_record_by_parm_cd(parameter_data),
+                'gw_period_of_record': get_period_of_record_by_parm_cd(parameter_data, 'gw'),
                 'parm_grp_summary': grouped_dataseries,
                 'questions_link': questions_link,
                 'cooperators': cooperators

--- a/wdfn-server/waterdata/views.py
+++ b/wdfn-server/waterdata/views.py
@@ -123,7 +123,6 @@ def monitoring_location(site_no):
                 }
                 questions_link = construct_url('https://water.usgs.gov', 'contact/gsanswers', questions_link_params)
 
-
             context = {
                 'status_code': status,
                 'stations': site_data_list,
@@ -132,8 +131,8 @@ def monitoring_location(site_no):
                 'json_ld': Markup(json.dumps(json_ld, indent=4)),
                 'available_data_types': available_data_types,
                 'uv_period_of_record': get_period_of_record_by_parm_cd(parameter_data),
-                'gw_period_of_record': get_period_of_record_by_parm_cd(parameter_data, 'gw')
-                    if app.config['GROUNDWATER_LEVELS_ENABLED'] else None,
+                'gw_period_of_record': get_period_of_record_by_parm_cd(parameter_data, 'gw') if app.config[
+                    'GROUNDWATER_LEVELS_ENABLED'] else None,
                 'parm_grp_summary': grouped_dataseries,
                 'questions_link': questions_link,
                 'cooperators': cooperators


### PR DESCRIPTION
Before making a pull request
----------------------------

- [ ] Make sure all tests run
- [ ] Update the changelog appropriately

Title
-----------
Discrete GW Levels are on the IV Graph

Description
-----------
The ground water levels are loaded outside of the components. I did this in preparation for the following on ticket to this to add ground water levels to the dv hydrograph. Since the data will be needed in two places, the component specific module seems to be the wrong place. 

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the JIRA ticket
- [ ] Assign someone to review unless the change is trivial
