### PR TITLE
Iow 820 - allow for selecting parameters that are only 'field visit' groundwater levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Camera metadata is now fetched and the client is using html5 video when video format is supported, otherwise the most recent image is shown.
-- The parameter selection list now show parameters that are groundwater field visits only in addition to parameters that have IV data.
+- The parameter selection list now shows parameters that are groundwater field visits only in addition to parameters that have IV data.
 
 ## [0.40.0](https://github.com/usgs/waterdataui/compare/waterdataui-0.39.0...waterdataui-0.40.0) - 2021-01-06
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Camera metadata is now fetched and the client is using html5 video when video format is supported, otherwise the most recent image is shown.
+- The parameter selection list now show parameters that are groundwater field visits only in addition to parameters that have IV data.
 
 ## [0.40.0](https://github.com/usgs/waterdataui/compare/waterdataui-0.39.0...waterdataui-0.40.0) - 2021-01-06
 ### Added

--- a/assets/src/scripts/monitoring-location/components/hydrograph/date-controls.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/date-controls.js
@@ -5,8 +5,10 @@ import components from 'uswds/src/js/components';
 
 import config from 'ui/config';
 import {link} from 'ui/lib/d3-redux';
+
 import {drawLoadingIndicator} from 'd3render/loading-indicator';
 
+import {getAllGroundwaterLevels} from 'ml/selectors/discrete-data-selector';
 import {
     isLoadingTS,
     hasAnyTimeSeries,
@@ -15,6 +17,7 @@ import {
     getCurrentParmCd
 } from 'ml/selectors/time-series-selector';
 import {getIanaTimeZone} from 'ml/selectors/time-zone-selector';
+
 import {Actions as ivTimeSeriesDataActions} from 'ml/store/instantaneous-value-time-series-data';
 import {Actions as ivTimeSeriesStateActions} from 'ml/store/instantaneous-value-time-series-state';
 
@@ -57,7 +60,9 @@ export const drawDateRangeControls = function(elem, store, siteno) {
         .attr('aria-label', 'Time interval select')
         .call(link(store,function(container, showControls) {
             container.attr('hidden', showControls ? null : true);
-        }, hasAnyTimeSeries));
+        }, (state) => {
+            return hasAnyTimeSeries(state) || getAllGroundwaterLevels(state);
+        }));
 
     // Add a container that holds the custom selection radio buttons and the form fields
     const containerRadioGroupAndFormButtons = elem.insert('div', ':nth-child(3)')

--- a/assets/src/scripts/monitoring-location/components/hydrograph/index.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/index.js
@@ -45,7 +45,9 @@ import {getTimeSeriesScalesByParmCd} from './selectors/scales';
  * @param {Redux store} store
  * @param {DOM node} node
  * @param {Object} - string properties to set initial state information. The property siteno is required
- */
+ * @param {Promise} loadPromise - will resolve when any data needed by this module
+ *                                that is fetched by the caller has been fetched
+ * */
 export const attachToNode = function(store,
                                      node,
                                      {

--- a/assets/src/scripts/monitoring-location/components/hydrograph/index.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/index.js
@@ -125,7 +125,7 @@ export const attachToNode = function(store,
             drawInfoAlert(nodeElem, {body: 'No time series data available for this site'});
             if (!showOnlyGraph) {
                 document.getElementById('classic-page-link')
-                    .setAttribute('href', `${config.NWIS_INVENTORY_ENDPOINT}?site_no=${siteno}`);
+                    .setAttribute('href', `${config.NWIS_INVENTORY_PAGE_URL}?site_no=${siteno}`);
             }
         } else {
             //Update time series state

--- a/assets/src/scripts/monitoring-location/components/hydrograph/index.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/index.js
@@ -139,7 +139,6 @@ export const attachToNode = function(store,
                 //Sort variables and use the first one as the current variable
                 const sortedVars = sortedParameters(getVariables(state));
                 if (sortedVars.length) {
-                    console.log('Setting current variable ' + sortedVars[0].oid);
                     store.dispatch(ivTimeSeriesStateActions.setCurrentIVVariable(sortedVars[0].oid));
                 }
             }

--- a/assets/src/scripts/monitoring-location/components/hydrograph/index.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/index.js
@@ -15,7 +15,7 @@ import {drawLoadingIndicator} from 'd3render/loading-indicator';
 import {isPeriodWithinAcceptableRange, isPeriodCustom} from 'ml/iv-data-utils';
 import {renderTimeSeriesUrlParams} from 'ml/url-params';
 
-import {hasAnyVariables, getCurrentParmCd, getVariables} from 'ml/selectors/time-series-selector';
+import {hasAnyVariables, getCurrentVariableID, getCurrentParmCd, getVariables} from 'ml/selectors/time-series-selector';
 
 import {Actions as ivTimeSeriesDataActions} from 'ml/store/instantaneous-value-time-series-data';
 import {Actions as ivTimeSeriesStateActions} from 'ml/store/instantaneous-value-time-series-state';
@@ -129,11 +129,15 @@ export const attachToNode = function(store,
                     return variable.variableCode.value === parameterCode;
                 };
                 const thisVariable = Object.values(getVariables(state)).find(isThisParamCode);
-                store.dispatch(ivTimeSeriesStateActions.setCurrentIVVariable(thisVariable.oid));
-            } else {
+                if (thisVariable) {
+                    store.dispatch(ivTimeSeriesStateActions.setCurrentIVVariable(thisVariable.oid));
+                }
+            }
+            if (!getCurrentVariableID(state)) {
                 //Sort variables and use the first one as the current variable
                 const sortedVars = sortedParameters(getVariables(state));
                 if (sortedVars.length) {
+                    console.log('Setting current variable ' + sortedVars[0].oid);
                     store.dispatch(ivTimeSeriesStateActions.setCurrentIVVariable(sortedVars[0].oid));
                 }
             }

--- a/assets/src/scripts/monitoring-location/components/hydrograph/index.test.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/index.test.js
@@ -473,7 +473,7 @@ describe('monitoring-location/components/hydrograph module', () => {
 
     describe('graphNode contains the expected elements when no IV time series has been retrieved and showOnlyGraph is false', () => {
         let store;
-        config.NWIS_INVENTORY_ENDPOINT = 'https://fakenwis.usgs.gov/inventory';
+        config.NWIS_INVENTORY_PAGE_URL = 'https://fakenwis.usgs.gov/inventory';
         beforeEach(() => {
             jest.spyOn(floodDataActions, 'retrieveWaterwatchData').mockReturnValue(function() {
                 return Promise.resolve({});

--- a/assets/src/scripts/monitoring-location/components/hydrograph/index.test.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/index.test.js
@@ -192,6 +192,7 @@ describe('monitoring-location/components/hydrograph module', () => {
 
     let graphNode;
     let fakeServer;
+    let loadPromise = new Promise(() => null);
 
     beforeEach(() => {
         let body = select('body');
@@ -217,7 +218,7 @@ describe('monitoring-location/components/hydrograph module', () => {
     });
 
     it('expect alert if no siteno defined', () => {
-        attachToNode({}, graphNode, {});
+        attachToNode({}, graphNode, {}, loadPromise);
         expect(graphNode.innerHTML).toContain('No data is available');
     });
 
@@ -235,7 +236,7 @@ describe('monitoring-location/components/hydrograph module', () => {
         it('loading-indicator is shown until initial data has been retrieved', () => {
             attachToNode(store, graphNode, {
                 siteno: '12345678'
-            });
+            }, loadPromise);
 
             expect(select(graphNode).select('.loading-indicator').size()).toBe(1);
         });
@@ -244,7 +245,7 @@ describe('monitoring-location/components/hydrograph module', () => {
             jest.spyOn(timeZoneActions, 'retrieveIanaTimeZone');
             attachToNode(store, graphNode, {
                 siteno: '12345678'
-            });
+            }, loadPromise);
 
             expect(timeZoneActions.retrieveIanaTimeZone).toHaveBeenCalled();
         });
@@ -260,7 +261,7 @@ describe('monitoring-location/components/hydrograph module', () => {
                 attachToNode(store, graphNode, {
                     siteno: '12345678',
                     parameterCode: '00065'
-                });
+                }, loadPromise);
 
                 expect(ivTimeSeriesDataActions.retrieveIVTimeSeries).toHaveBeenCalledWith('12345678');
                 expect(statisticsDataActions.retrieveMedianStatistics).toHaveBeenCalledWith('12345678');
@@ -271,7 +272,7 @@ describe('monitoring-location/components/hydrograph module', () => {
                     siteno: '12345678',
                     parameterCode: '00065',
                     period: 'P30D'
-                });
+                }, loadPromise);
 
                 expect(ivTimeSeriesDataActions.retrieveIVTimeSeries).toHaveBeenCalledWith('12345678');
                 expect(statisticsDataActions.retrieveMedianStatistics).toHaveBeenCalledWith('12345678');
@@ -283,7 +284,7 @@ describe('monitoring-location/components/hydrograph module', () => {
                     parameterCode: '00065',
                     startDT: '2010-01-01',
                     endDT: '2010-03-01'
-                });
+                }, loadPromise);
 
                 expect(ivTimeSeriesDataActions.retrieveIVTimeSeries).toHaveBeenCalledWith('12345678');
                 expect(statisticsDataActions.retrieveMedianStatistics).toHaveBeenCalledWith('12345678');
@@ -307,7 +308,7 @@ describe('monitoring-location/components/hydrograph module', () => {
                 attachToNode(store, graphNode, {
                     siteno: '12345678',
                     parameterCode: '00065'
-                });
+                }, loadPromise);
 
                 return new Promise(resolve => {
                     window.requestAnimationFrame(() => {
@@ -322,7 +323,7 @@ describe('monitoring-location/components/hydrograph module', () => {
                     siteno: '12345678',
                     parameterCode: '00065',
                     period: 'P30D'
-                });
+                }, loadPromise);
 
                 return new Promise(resolve => {
                     window.requestAnimationFrame(() => {
@@ -339,7 +340,7 @@ describe('monitoring-location/components/hydrograph module', () => {
                     parameterCode: '00065',
                     startDT: '2010-01-01',
                     endDT: '2010-03-01'
-                });
+                }, loadPromise);
 
                 return new Promise(resolve => {
                     window.requestAnimationFrame(() => {
@@ -359,7 +360,7 @@ describe('monitoring-location/components/hydrograph module', () => {
                     parameterCode: '00065',
                     startDT: '2010-01-01',
                     endDT: '2010-03-01'
-                });
+                }, loadPromise);
 
                 return new Promise(resolve => {
                     window.requestAnimationFrame(() => {
@@ -399,7 +400,7 @@ describe('monitoring-location/components/hydrograph module', () => {
                 parameterCode: '00065',
                 period: 'P20D',
                 showOnlyGraph: true
-            });
+            }, loadPromise);
 
             return new Promise(resolve => {
                 window.requestAnimationFrame(() => {
@@ -419,7 +420,7 @@ describe('monitoring-location/components/hydrograph module', () => {
                 startDT: '2010-01-01',
                 endDT: '2010-03-01',
                 showOnlyGraph: true
-            });
+            }, loadPromise);
 
             return new Promise(resolve => {
                 window.requestAnimationFrame(() => {
@@ -441,7 +442,7 @@ describe('monitoring-location/components/hydrograph module', () => {
                 startDT: '2010-01-01',
                 endDT: '2010-03-01',
                 showOnlyGraph: true
-            });
+            }, loadPromise);
 
             return new Promise(resolve => {
                 window.requestAnimationFrame(() => {
@@ -458,7 +459,7 @@ describe('monitoring-location/components/hydrograph module', () => {
                 siteno: '12345678',
                 parameterCode: '00065',
                 showOnlyGraph: true
-            });
+            }, loadPromise);
 
             return new Promise(resolve => {
                 window.requestAnimationFrame(() => {
@@ -474,6 +475,7 @@ describe('monitoring-location/components/hydrograph module', () => {
     describe('graphNode contains the expected elements when no IV time series has been retrieved and showOnlyGraph is false', () => {
         let store;
         config.NWIS_INVENTORY_PAGE_URL = 'https://fakenwis.usgs.gov/inventory';
+        let resolvedLoadPromise = Promise.resolve();
         beforeEach(() => {
             jest.spyOn(floodDataActions, 'retrieveWaterwatchData').mockReturnValue(function() {
                 return Promise.resolve({});
@@ -495,7 +497,7 @@ describe('monitoring-location/components/hydrograph module', () => {
                     width: 400
                 }
             });
-            attachToNode(store, graphNode, {siteno: '12345678'});
+            attachToNode(store, graphNode, {siteno: '12345678'}, resolvedLoadPromise);
             return new Promise(resolve => {
                 window.requestAnimationFrame(() => {
                     resolve();
@@ -515,6 +517,7 @@ describe('monitoring-location/components/hydrograph module', () => {
     describe('graphNode contains the expected elements when showOnlyGraph is false', () => {
         /* eslint no-use-before-define: 0 */
         let store;
+        let resolvedLoadPromise = Promise.resolve();
         beforeEach(() => {
             jest.spyOn(floodDataActions, 'retrieveWaterwatchData').mockReturnValue(function() {
                 return Promise.resolve({});
@@ -567,7 +570,7 @@ describe('monitoring-location/components/hydrograph module', () => {
                 }
             });
 
-            attachToNode(store, graphNode, {siteno: '12345678'});
+            attachToNode(store, graphNode, {siteno: '12345678'}, resolvedLoadPromise);
             return new Promise(resolve => {
                 window.requestAnimationFrame(() => {
                     resolve();
@@ -663,6 +666,7 @@ describe('monitoring-location/components/hydrograph module', () => {
 
     describe('hide elements when showOnlyGraph is set to true', () => {
         let store;
+        let resolvedLoadPromise = Promise.resolve();
         beforeEach(() => {
             jest.spyOn(ivTimeSeriesDataActions, 'retrieveIVTimeSeries').mockReturnValue(function() {
                 return Promise.resolve({});
@@ -709,7 +713,7 @@ describe('monitoring-location/components/hydrograph module', () => {
 
             });
 
-            attachToNode(store, graphNode, {siteno: '123456788', showOnlyGraph: true});
+            attachToNode(store, graphNode, {siteno: '123456788', showOnlyGraph: true}, resolvedLoadPromise);
         });
 
         it('should not have brush element for the hydrograph', () => {

--- a/assets/src/scripts/monitoring-location/components/hydrograph/parameters.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/parameters.js
@@ -134,35 +134,35 @@ export const plotSeriesSelectTable = function(elem,
         .selectAll('tr')
         .data(availableParameterCodes)
         .enter().append('tr')
-        .attr('id', param => `time-series-select-table-row-${param.parameterCode}`)
+        .attr('id', d => `time-series-select-table-row-${d.parameterCode}`)
         .attr('ga-on', 'click')
         .attr('ga-event-category', 'selectTimeSeries')
-        .attr('ga-event-action', (param) => `time-series-parmcd-${param.parameterCode}`)
+        .attr('ga-event-action', (d) => `time-series-parmcd-${d.parameterCode}`)
         .attr('role', 'option')
-        .classed('selected', param => param.selected)
-        .attr('aria-selected', param => param.selected)
-        .on('click', function(event, param) {
-            if (!param.selected) {
-                store.dispatch(Actions.updateIVCurrentVariableAndRetrieveTimeSeries(siteno, param.variableID));
+        .classed('selected', d => d.selected)
+        .attr('aria-selected', d => d.selected)
+        .on('click', function(event, d) {
+            if (!d.selected) {
+                store.dispatch(Actions.updateIVCurrentVariableAndRetrieveTimeSeries(siteno, d.variableID));
             }
         })
         .call(tr => {
             const paramSelectCol = tr.append('td');
             paramSelectCol.append('input')
-                .attr('id', param => `time-series-select-radio-button-${param.parameterCode}`)
+                .attr('id', d => `time-series-select-radio-button-${d.parameterCode}`)
                 .attr('type', 'radio')
                 .attr('name', 'param-select-radio-input')
                 .attr('class', 'usa-radio__input')
-                .attr('value', param => `${param.variableID}`)
-                .property('checked', param => param.selected ? true : null);
+                .attr('value', d => `${d.variableID}`)
+                .property('checked', d => d.selected ? true : null);
             paramSelectCol.append('label')
                .attr('class', 'usa-radio__label');
             const paramCdCol = tr.append('th')
                 .attr('scope', 'row');
             paramCdCol.append('span')
-                .text(param => param.description)
-                .each(function(datum) {
-                    appendInfoTooltip(select(this), `Parameter code: ${datum.parameterCode}`);
+                .text(d => d.description)
+                .each(function(d) {
+                    appendInfoTooltip(select(this), `Parameter code: ${d.parameterCode}`);
                 });
             tr.append('td')
                 .append('svg')
@@ -172,8 +172,8 @@ export const plotSeriesSelectTable = function(elem,
                 .text(param => param.timeSeriesCount);
             tr.append('td')
                 .style('white-space', 'nowrap')
-                .text(param => `${config.uvPeriodOfRecord[param.parameterCode.replace(config.CALCULATED_TEMPERATURE_VARIABLE_CODE, '')].begin_date} 
-                        to ${config.uvPeriodOfRecord[param.parameterCode.replace(config.CALCULATED_TEMPERATURE_VARIABLE_CODE, '')].end_date}`);
+                .text(d => d.periodOfRecord ?
+                    `${d.periodOfRecord.begin_date} - ${d.periodOfRecord.end_date}` : '');
             tr.append('td')
                 .append('div')
                 .attr('class', 'wateralert-link');
@@ -181,30 +181,20 @@ export const plotSeriesSelectTable = function(elem,
 
     // WaterAlert does not support every parameter code, so lets take that into account when adding the links
     table.selectAll('.wateralert-link').each(function(d) {
-
-        // Allow the converted temperature codes to have a link to the non-converted Wateralert form
-        const allTemperatureParameters = config.TEMPERATURE_PARAMETERS.celsius.concat(config.TEMPERATURE_PARAMETERS.fahrenheit);
-        const convertedTemperatureCodes = allTemperatureParameters.map(function(code) {
-            return code.replace(`${code}`, `${code}${config.CALCULATED_TEMPERATURE_VARIABLE_CODE}`);
-        });
-
         let selection = select(this);
 
-        if (config.WATER_ALERT_PARAMETER_CODES.includes(d.parameterCode.replace(config.CALCULATED_TEMPERATURE_VARIABLE_CODE, ''))) {
-            const waterAlertLink = selection.append('a')
-                .attr('href', `${config.WATERALERT_SUBSCRIPTION}/?site_no=${siteno}&parm=${d.parameterCode.replace(config.CALCULATED_TEMPERATURE_VARIABLE_CODE, '')}`)
-                .attr('class', 'usa-tooltip usa-link wateralert-available')
-                .attr('data-position', 'left')
-                .attr('data-classes', 'width-full tablet:width-auto')
-                .attr('title', 'Subscribe to text or email alerts based on thresholds that you set')
-                .text(convertedTemperatureCodes.includes(d.parameterCode) ? 'Alerts in C' : 'Subscribe');
+        let waterAlertCell;
+        if (d.waterAlert.hasWaterAlert) {
+            waterAlertCell = selection.append('a')
+                .attr('href', `${config.WATERALERT_SUBSCRIPTION}/?site_no=${siteno}&parm=${d.waterAlert.subscriptionParameterCode}`);
         } else {
-            selection.attr('class', 'usa-tooltip wateralert-unavailable')
-                .attr('data-position', 'left')
-                .attr('data-classes', 'width-full tablet:width-auto')
-                .attr('title', `Sorry, there are no WaterAlerts for this parameter (${d.parameterCode})`)
-                .text('N/A');
+            waterAlertCell = selection;
         }
+        waterAlertCell.attr('class', 'water-alert-cell usa-tooltip')
+            .attr('data-position', 'left')
+            .attr('data-classes', 'width-full tablet:width-auto')
+            .attr('title', d.waterAlert.tooltipText)
+            .text(d.waterAlert.displayText);
     });
 
     // Activate the USWDS toolTips for WaterAlert subscriptions

--- a/assets/src/scripts/monitoring-location/components/hydrograph/parameters.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/parameters.js
@@ -82,6 +82,7 @@ export const addSparkLine = function(svgSelection, {seriesLineSegments, scales})
     }
 };
 
+
 /**
  * Draws a table with clickable rows of time series parameter codes. Selecting
  * a row changes the active parameter code.

--- a/assets/src/scripts/monitoring-location/components/hydrograph/parameters.test.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/parameters.test.js
@@ -1,32 +1,12 @@
 import {scaleLinear} from 'd3-scale';
 import {select} from 'd3-selection';
 
-import config from 'ui/config';
 import {configureStore} from 'ml/store';
 
 import {addSparkLine, plotSeriesSelectTable} from './parameters';
 
 describe('monitoring-location/components/hydrograph/parameters module', () => {
-    config.uvPeriodOfRecord = {
-        '00010': {
-            begin_date: '01-02-2001',
-            end_date: '10-15-2015'
-        },
-        '00060': {
-            begin_date: '04-01-1991',
-            end_date: '10-15-2007'
-        },
-        '00093': {
-            begin_date: '11-25-2001',
-            end_date: '03-01-2020'
-        },
-        '00067': {
-            begin_date: '04-01-1990',
-            end_date: '10-15-2006'
-        }
-    };
-
-     describe('plotSeriesSelectTable', () => {
+    describe('plotSeriesSelectTable', () => {
         let tableDivSelection;
 
         const data = [12, 13, 14, 15, 16].map(day => {
@@ -38,10 +18,74 @@ describe('monitoring-location/components/hydrograph/parameters module', () => {
         });
 
         const availableParameterCodes = [
-            {variableID: '00010ID', parameterCode: '00010', description: 'Temperature', selected: true, timeSeriesCount: 1},
-            {variableID: '00010IDF', parameterCode: '00010F', description: 'Temperature in F', selected: false, timeSeriesCount: 1},
-            {variableID: '00067ID', parameterCode: '00067', description: 'Ruthenium (VI) Fluoride', selected: false, timeSeriesCount: 1},
-            {variableID: '00093ID', parameterCode: '00093', description: 'Uranium (V) Oxide', selected: false, timeSeriesCount: 1}
+            {
+                variableID: '00010ID',
+                parameterCode: '00010',
+                description: 'Temperature in C',
+                selected: true,
+                timeSeriesCount: 1,
+                periodOfRecord: {
+                    begin_date: '01-02-2001',
+                    end_date: '10-15-2015'
+                },
+                waterAlert: {
+                    hasWaterAlert: true,
+                    subscriptionParameterCode: '00010',
+                    displayText: '00010 Display Text',
+                    tooltipText: '00010 Tooltip Text'
+                }
+            },
+            {
+                variableID: '00010IDF',
+                parameterCode: '00010F',
+                description: 'Temperature in F',
+                selected: false,
+                timeSeriesCount: 1,
+                periodOfRecord: {
+                    begin_date: '01-02-2001',
+                    end_date: '10-15-2015'
+                },
+                waterAlert: {
+                    hasWaterAlert: true,
+                    subscriptionParameterCode: '00010',
+                    displayText: '00010F Display Text',
+                    tooltipText: '00010F Tooltip Text'
+                }
+            },
+            {
+                variableID: '00067ID',
+                parameterCode: '00067',
+                description: 'Ruthenium (VI) Fluoride',
+                selected: false,
+                timeSeriesCount: 1,
+                periodOfRecord: {
+                    begin_date: '04-01-1990',
+                    end_date: '10-15-2006'
+                },
+                waterAlert: {
+                    hasWaterAlert: false,
+                    subscriptionParameterCode: '',
+                    displayText: '00067 Display Text',
+                    tooltipText: '00067 Tooltip Text'
+                }
+            },
+            {
+                variableID: '00093ID',
+                parameterCode: '00093',
+                description: 'Uranium (V) Oxide',
+                selected: false,
+                timeSeriesCount: 1,
+                periodOfRecord: {
+                    begin_date: '11-25-2001',
+                    end_date: '03-01-2020'
+                },
+                waterAlert: {
+                    hasWaterAlert: false,
+                    subscriptionParameterCode: '',
+                    displayText: '00093 Display Text',
+                    tooltipText: '00093 Tooltip Text'
+                }
+            }
         ];
 
         const lineSegmentsByParmCd = {
@@ -98,15 +142,11 @@ describe('monitoring-location/components/hydrograph/parameters module', () => {
             expect(tableDivSelection.selectAll('input').size()).toEqual(4);
         });
 
-         it('creates a WaterAlert subscribe link each parameter in the table supported by WaterAlert', () => {
-             plotSeriesSelectTable(tableDivSelection, testArgsWithData, store);
-             expect(tableDivSelection.selectAll('.wateralert-available').size()).toEqual(2);
-         });
-
-         it('creates WaterAlert not available text for each parameter in the table NOT supported by WaterAlert', () => {
-             plotSeriesSelectTable(tableDivSelection, testArgsWithData, store);
-             expect(tableDivSelection.selectAll('.wateralert-unavailable').size()).toEqual(2);
-         });
+        it('creates a WaterAlert subscribe link each parameter in the table supported by WaterAlert as appropriate', () => {
+            plotSeriesSelectTable(tableDivSelection, testArgsWithData, store);
+            expect(tableDivSelection.selectAll('.water-alert-cell').size()).toEqual(4);
+            expect(tableDivSelection.selectAll('a').size()).toEqual(2);
+        });
 
         it('updates the radio button input checked property for the corresponding selected parameter', () => {
             plotSeriesSelectTable(tableDivSelection, testArgsWithData, store);
@@ -116,9 +156,7 @@ describe('monitoring-location/components/hydrograph/parameters module', () => {
             let selectedParamRowInput = selectedParamTD.select('input');
             expect(selectedParamRowInput.property('checked')).toBeTruthy();
         });
-
     });
-
 
     describe('addSparkline', () => {
         let svg;
@@ -275,4 +313,5 @@ describe('monitoring-location/components/hydrograph/parameters module', () => {
             expect(svg.selectAll('path').size()).toEqual(2);
         });
     });
-});
+})
+;

--- a/assets/src/scripts/monitoring-location/components/hydrograph/selectors/cursor.test.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/selectors/cursor.test.js
@@ -203,7 +203,8 @@ const TEST_STATE_THREE_VARS = {
     ui: {
         windowWidth: 1024,
         width: 800
-    }
+    },
+    discreteData: {}
 };
 
 const TEST_STATE_ONE_VAR = {
@@ -327,7 +328,8 @@ const TEST_STATE_ONE_VAR = {
     ui: {
         windowWidth: 1024,
         width: 800
-    }
+    },
+    discreteData: {}
 };
 
 describe('monitoring-location/components/hydrograph/cursor module', () => {

--- a/assets/src/scripts/monitoring-location/components/hydrograph/selectors/discrete-data.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/selectors/discrete-data.js
@@ -7,20 +7,27 @@ import {getRequestTimeRange} from 'ml/selectors/time-series-selector';
  * Returns a selector function that returns the groundwater levels that will be visible
  * on the hydrograpnh
  * @return {Function} which returns an {Array} of groundwater level object with properties:
- *      @prop {String} value
+ *      @prop {Float} value
  *      @prop {Array of String} qualifiers
  *      @prop {Number} dateTime
  */
-export const getVisibleGroundWaterLevels = createSelector(
+export const getVisibleGroundWaterLevelPoints = createSelector(
     getRequestTimeRange('current'),
     getIVCurrentVariableGroundwaterLevels,
     (timeRange, gwLevels) => {
         if (!timeRange || !gwLevels.values) {
             return [];
         }
-        return gwLevels.values.filter((data) => {
-            return data.dateTime > timeRange.start && data.dateTime < timeRange.end;
-        });
+        return gwLevels.values
+            .filter((data) => {
+                return data.dateTime > timeRange.start && data.dateTime < timeRange.end;
+            })
+            .map((data) => {
+                return {
+                    ...data,
+                    value: parseFloat(data.value)
+                };
+            });
     }
 );
 
@@ -30,6 +37,6 @@ export const getVisibleGroundWaterLevels = createSelector(
  * @return {Function} which returns {Boolean}
  */
 export const anyVisibleGroundWaterLevels = createSelector(
-    getVisibleGroundWaterLevels,
-    (gwLevels) => gwLevels.length != 0
+    getVisibleGroundWaterLevelPoints,
+    (gwLevels) => gwLevels.length !== 0
 );

--- a/assets/src/scripts/monitoring-location/components/hydrograph/selectors/discrete-data.test.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/selectors/discrete-data.test.js
@@ -1,4 +1,4 @@
-import {getVisibleGroundWaterLevels, anyVisibleGroundWaterLevels} from './discrete-data';
+import {getVisibleGroundWaterLevelPoints, anyVisibleGroundWaterLevels} from './discrete-data';
 
 describe('monitoring-location/components/hydrograph/selectors/discrete-data', () => {
 
@@ -54,7 +54,7 @@ describe('monitoring-location/components/hydrograph/selectors/discrete-data', ()
             }
         };
 
-    describe('getVisibleGroundWaterLevels', () => {
+    describe('getVisibleGroundWaterLevelPoints', () => {
 
         it('Return empty array if no groundwater levels are defined', () => {
             const testData = {
@@ -63,7 +63,7 @@ describe('monitoring-location/components/hydrograph/selectors/discrete-data', ()
                     groundwaterLevels: null
                 }
             };
-            expect(getVisibleGroundWaterLevels(testData)).toHaveLength(0);
+            expect(getVisibleGroundWaterLevelPoints(testData)).toHaveLength(0);
         });
 
         it('Return an empty array if the current variable does not have ground water data', () => {
@@ -74,11 +74,11 @@ describe('monitoring-location/components/hydrograph/selectors/discrete-data', ()
                     currentIVVariableID: '45807041'
                 }
             };
-            expect(getVisibleGroundWaterLevels(testData)).toHaveLength(0);
+            expect(getVisibleGroundWaterLevelPoints(testData)).toHaveLength(0);
         });
 
         it('Return the ground water levels that are in the 7 day period', () => {
-            const result = getVisibleGroundWaterLevels(TEST_STATE);
+            const result = getVisibleGroundWaterLevelPoints(TEST_STATE);
             expect(result).toHaveLength(2);
         });
     });

--- a/assets/src/scripts/monitoring-location/components/hydrograph/selectors/discrete-data.test.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/selectors/discrete-data.test.js
@@ -36,12 +36,12 @@ describe('monitoring-location/components/hydrograph/selectors/discrete-data', ()
             },
             discreteData: {
                 groundwaterLevels: {
-                    '72019': {
+                    '45807042': {
                         variable: {
-                            variableCode: {
-                                value: '72019',
-                                variableID: 45807042
-                            }
+                            variableCode: [{
+                                value: '72019'
+                            }],
+                            oid: '45807042'
                         },
                         values: [
                             {value: '14.0', dateTime: 1491055200000},

--- a/assets/src/scripts/monitoring-location/components/hydrograph/selectors/discrete-data.test.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/selectors/discrete-data.test.js
@@ -38,9 +38,9 @@ describe('monitoring-location/components/hydrograph/selectors/discrete-data', ()
                 groundwaterLevels: {
                     '45807042': {
                         variable: {
-                            variableCode: [{
+                            variableCode: {
                                 value: '72019'
-                            }],
+                            },
                             oid: '45807042'
                         },
                         values: [

--- a/assets/src/scripts/monitoring-location/components/hydrograph/selectors/drawing-data.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/selectors/drawing-data.js
@@ -17,7 +17,7 @@ import {
 } from 'ml/selectors/time-series-selector';
 import {getIanaTimeZone} from 'ml/selectors/time-zone-selector';
 
-import {getVisibleGroundWaterLevels} from './discrete-data';
+import {getVisibleGroundWaterLevelPoints} from './discrete-data';
 
 export const MASK_DESC = {
     ice: 'Ice Affected',
@@ -225,7 +225,7 @@ export const getVisiblePoints = createSelector(
     getCurrentVariablePoints('current'), // array of array of points
     getCurrentVariablePoints('compare'), // array of array of points
     getCurrentVariableMedianStatPoints, // array of array of points
-    getVisibleGroundWaterLevels, // array of points
+    getVisibleGroundWaterLevelPoints, // array of points
     (state) => state.ivTimeSeriesState.showIVTimeSeries,
     (current, compare, median, gwLevels, showSeries) => {
         const pointArray = [];

--- a/assets/src/scripts/monitoring-location/components/hydrograph/selectors/drawing-data.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/selectors/drawing-data.js
@@ -228,7 +228,10 @@ export const getVisiblePoints = createSelector(
     getVisibleGroundWaterLevels,
     (state) => state.ivTimeSeriesState.showIVTimeSeries,
     (current, compare, median, gwLevels, showSeries) => {
-        const pointArray = [gwLevels];
+        const pointArray = [];
+        if (gwLevels.length) {
+            pointArray.push(gwLevels);
+        }
         if (showSeries['current']) {
             Array.prototype.push.apply(pointArray, current);
 

--- a/assets/src/scripts/monitoring-location/components/hydrograph/selectors/drawing-data.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/selectors/drawing-data.js
@@ -222,10 +222,10 @@ export const getCurrentVariableMedianStatPoints = createSelector(
  * @return {Array}            Array of point arrays.
  */
 export const getVisiblePoints = createSelector(
-    getCurrentVariablePoints('current'),
-    getCurrentVariablePoints('compare'),
-    getCurrentVariableMedianStatPoints,
-    getVisibleGroundWaterLevels,
+    getCurrentVariablePoints('current'), // array of array of points
+    getCurrentVariablePoints('compare'), // array of array of points
+    getCurrentVariableMedianStatPoints, // array of array of points
+    getVisibleGroundWaterLevels, // array of points
     (state) => state.ivTimeSeriesState.showIVTimeSeries,
     (current, compare, median, gwLevels, showSeries) => {
         const pointArray = [];

--- a/assets/src/scripts/monitoring-location/components/hydrograph/selectors/drawing-data.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/selectors/drawing-data.js
@@ -17,6 +17,8 @@ import {
 } from 'ml/selectors/time-series-selector';
 import {getIanaTimeZone} from 'ml/selectors/time-zone-selector';
 
+import {getVisibleGroundWaterLevels} from './discrete-data';
+
 export const MASK_DESC = {
     ice: 'Ice Affected',
     fld: 'Flood',
@@ -223,9 +225,10 @@ export const getVisiblePoints = createSelector(
     getCurrentVariablePoints('current'),
     getCurrentVariablePoints('compare'),
     getCurrentVariableMedianStatPoints,
+    getVisibleGroundWaterLevels,
     (state) => state.ivTimeSeriesState.showIVTimeSeries,
-    (current, compare, median, showSeries) => {
-        const pointArray = [];
+    (current, compare, median, gwLevels, showSeries) => {
+        const pointArray = [gwLevels];
         if (showSeries['current']) {
             Array.prototype.push.apply(pointArray, current);
 

--- a/assets/src/scripts/monitoring-location/components/hydrograph/selectors/drawing-data.test.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/selectors/drawing-data.test.js
@@ -198,7 +198,8 @@ const TEST_DATA = {
         currentIVVariableID: '45807197',
         currentIVDateRange: 'P7D',
         currentIVMethodID: 69928
-    }
+    },
+    discreteData: {}
 };
 
 describe('monitoring-location/components/hydrograph/drawingData module', () => {
@@ -885,6 +886,30 @@ describe('monitoring-location/components/hydrograph/drawingData module', () => {
             };
 
             expect(getVisiblePoints(newTestData)).toHaveLength(0);
+        });
+
+        it('Expects three arrays if groundwater levels are visible', () => {
+            const newTestData = {
+                ...testData,
+                discreteData: {
+                    groundwaterLevels: {
+                        '45807197': {
+                            variable: {
+                                variableCode: {value: '00060'},
+                                variableName: 'Streamflow',
+                                variableDescription: 'Discharge, cubic feet per second',
+                                oid: '45807197'
+                            },
+                            values: [{
+                                value: 11,
+                                qualifiers: ['A'],
+                                dateTime: 1488083700000
+                            }]
+                        }
+                    }
+                }
+            };
+            expect(getVisiblePoints(newTestData)).toHaveLength(3);
         });
     });
 

--- a/assets/src/scripts/monitoring-location/components/hydrograph/selectors/legend-data.test.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/selectors/legend-data.test.js
@@ -105,9 +105,9 @@ describe('monitoring-location/components/hydrograph/selectors/legend-data', () =
             groundwaterLevels: {
                 '45807197': {
                     variable: {
-                        variableCode: [{
+                        variableCode: {
                             value: '72019'
-                        }],
+                        },
                         oid: '45807197'
                     },
                     values: [

--- a/assets/src/scripts/monitoring-location/components/hydrograph/selectors/legend-data.test.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/selectors/legend-data.test.js
@@ -103,12 +103,12 @@ describe('monitoring-location/components/hydrograph/selectors/legend-data', () =
         },
         discreteData: {
             groundwaterLevels: {
-                '72019': {
+                '45807197': {
                     variable: {
-                        variableCode: {
-                            value: '72019',
-                            variableID: 45807197
-                        }
+                        variableCode: [{
+                            value: '72019'
+                        }],
+                        oid: '45807197'
                     },
                     values: [
                         {value: '14.0', dateTime: 1519942619200},

--- a/assets/src/scripts/monitoring-location/components/hydrograph/selectors/parameter-data.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/selectors/parameter-data.js
@@ -1,6 +1,10 @@
+import unionBy from 'lodash/unionBy';
 import {createSelector} from 'reselect';
 
+import config from 'ui/config';
 import {sortedParameters} from 'ui/utils';
+
+import {getAllGroundwaterLevelVariables} from 'ml/selectors/discrete-data-selector';
 import {getCurrentVariableID, getTimeSeries, getVariables} from 'ml/selectors/time-series-selector';
 
 /**
@@ -15,25 +19,50 @@ import {getCurrentVariableID, getTimeSeries, getVariables} from 'ml/selectors/ti
 export const getAvailableParameterCodes = createSelector(
     getVariables,
     getTimeSeries,
+    getAllGroundwaterLevelVariables,
     getCurrentVariableID,
-    (variables, timeSeries, currentVariableID) => {
-        if (!variables) {
+    (ivVariables, timeSeries, gwLevelVariables, currentVariableID) => {
+        if (!ivVariables && !gwLevelVariables) {
             return [];
         }
-
+        const allVariables =
+            unionBy(ivVariables ? Object.values(ivVariables) : [], gwLevelVariables, (variable) => variable.oid);
         const seriesList = Object.values(timeSeries);
-        const availableVariableIds = seriesList.map(x => x.variable);
-        return sortedParameters(variables)
-            .filter(variable => availableVariableIds.includes(variable.oid))
+
+        return sortedParameters(allVariables)
             .map((variable) => {
+                const parameterCode = variable.variableCode.value;
+                const measuredParameterCode = parameterCode.replace(config.CALCULATED_TEMPERATURE_VARIABLE_CODE, '');
+                const hasWaterAlert = config.WATER_ALERT_PARAMETER_CODES.includes(measuredParameterCode);
+                let waterAlertDisplayText;
+                if (hasWaterAlert) {
+                    if (measuredParameterCode === parameterCode) {
+                        waterAlertDisplayText = 'Subscribe';
+                    } else {
+                        waterAlertDisplayText = 'Alerts in C';
+                    }
+                } else {
+                    waterAlertDisplayText = 'N/A';
+                }
+
                 return {
                     variableID: variable.oid,
-                    parameterCode: variable.variableCode.value,
+                    parameterCode: parameterCode,
                     description: variable.variableDescription,
                     selected: currentVariableID === variable.oid,
                     timeSeriesCount: seriesList.filter(ts => {
                         return ts.tsKey === 'current:P7D' && ts.variable === variable.oid;
-                    }).length
+                    }).length,
+                    periodOfRecord: config.uvPeriodOfRecord && measuredParameterCode in config.uvPeriodOfRecord ?
+                        config.uvPeriodOfRecord[measuredParameterCode] : null,
+                    waterAlert: {
+                        hasWaterAlert,
+                        subscriptionParameterCode: hasWaterAlert ? measuredParameterCode : '',
+                        displayText: waterAlertDisplayText,
+                        tooltipText: hasWaterAlert ? 'Subscribe to text or email alerts based on thresholds that you set' :
+                            `Sorry, there are no WaterAlerts for this parameter (${parameterCode})`
+                    }
+
                 };
             });
     }

--- a/assets/src/scripts/monitoring-location/components/hydrograph/selectors/parameter-data.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/selectors/parameter-data.js
@@ -1,10 +1,8 @@
-import unionBy from 'lodash/unionBy';
 import {createSelector} from 'reselect';
 
 import config from 'ui/config';
 import {sortedParameters} from 'ui/utils';
 
-import {getAllGroundwaterLevelVariables} from 'ml/selectors/discrete-data-selector';
 import {getCurrentVariableID, getTimeSeries, getVariables} from 'ml/selectors/time-series-selector';
 
 /**
@@ -19,14 +17,11 @@ import {getCurrentVariableID, getTimeSeries, getVariables} from 'ml/selectors/ti
 export const getAvailableParameterCodes = createSelector(
     getVariables,
     getTimeSeries,
-    getAllGroundwaterLevelVariables,
     getCurrentVariableID,
-    (ivVariables, timeSeries, gwLevelVariables, currentVariableID) => {
-        if (!ivVariables && !gwLevelVariables) {
+    (allVariables, timeSeries, currentVariableID) => {
+        if (!allVariables) {
             return [];
         }
-        const allVariables =
-            unionBy(ivVariables ? Object.values(ivVariables) : [], gwLevelVariables, (variable) => variable.oid);
         const seriesList = Object.values(timeSeries);
 
         return sortedParameters(allVariables)

--- a/assets/src/scripts/monitoring-location/components/hydrograph/selectors/parameter-data.test.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/selectors/parameter-data.test.js
@@ -1,112 +1,317 @@
+import config from 'ui/config';
 
 import {getAvailableParameterCodes} from './parameter-data';
 
 describe('monitoring-location/components/hydrograph/selectors/parameter-data', () => {
-    describe('getAvailableParameterCodes', () => {
-        it('sets attributes correctly when all series have data points', () => {
-            const available = getAvailableParameterCodes({
-                ivTimeSeriesData: {
-                    timeSeries: {
-                        'current:00060': {description: '00060', tsKey: 'current:P7D', variable: 'code0', points: [{x: 1, y: 2}]},
-                        'current:00061': {description: '00061', tsKey: 'current:P7D', variable: 'code1', points: [{x: 2, y: 3}]},
-                        'current:00062': {description: '00062', tsKey: 'current:P7D', variable: 'code2', points: [{x: 3, y: 4}]},
-                        'compare:00060': {description: '00060', tsKey: 'compare:P7D', variable: 'code0', points: [{x: 3, y: 46}]},
-                        'compare:00061': {description: '00061', tsKey: 'compare:P7D', variable: 'code1', points: [{x: 1, y: 17}]},
-                        'compare:00062': {description: '00062', tsKey: 'compare:P7D', variable: 'code2', points: [{x: 2, y: 18}]}
-                    },
-                    variables: {
-                        'code0': {
-                            oid: 'code0',
-                            variableDescription: 'code0 desc',
-                            variableCode: {
-                                value: '00060'
-                            }
-                        },
-                        'code1': {
-                            oid: 'code1',
-                            variableDescription: 'code1 desc',
-                            variableCode: {
-                                value: '00061'
-                            }
-                        },
-                        'code2': {
-                            oid: 'code2',
-                            variableDescription: 'code2 desc',
-                            variableCode: {
-                                value: '00062'
-                            }
-                        },
-                        'code3': {
-                            oid: 'code3',
-                            variableDescription: 'code3 desc',
-                            variableCode: {
-                                value: '00063'
-                            }
-                        }
+    config.uvPeriodOfRecord = {
+        '00060': {
+            begin_date: '01-01-1980',
+            end_date: '01-01-2020'
+        },
+        '00061': {
+            begin_date: '02-01-1980',
+            end_date: '02-01-2020'
+        },
+        '00010': {
+            begin_date: '03-01-1980',
+            end_date: '03-01-2020'
+        },
+        '72019': {
+            begin_date: '04-01-1980',
+            end_date: '04-01-2020'
+        }
+
+    };
+    const TEST_STATE = {
+        ivTimeSeriesData: {
+            timeSeries: {
+                '12345:current:00060': {
+                    description: '00060',
+                    tsKey: 'current:P7D',
+                    variable: 'code0',
+                    points: [{x: 1, y: 2}]
+                },
+                '13456:current:00061': {
+                    description: '00061',
+                    tsKey: 'current:P7D',
+                    variable: 'code1',
+                    points: [{x: 2, y: 3}]
+                },
+                '13457:current:00061': {
+                    description: '00061',
+                    tsKey: 'current:P7D',
+                    variable: 'code1',
+                    points: [{x: 4, y: 6}]
+                },
+                'current:00010': {
+                    description: '00010',
+                    tsKey: 'current:P7D',
+                    variable: '52331281',
+                    points: [{value: 4}]
+                },
+                'current:00010F': {
+                    description: '00010',
+                    tsKey: 'current:P7D',
+                    variable: '52331281F',
+                    points: [{value: 4}]
+                },
+                'current:72019': {
+                    description: '72019',
+                    tsKey: 'current:P7D',
+                    variable: '52331280',
+                    points: [{x: 3, y: 4}]
+                }
+            },
+            variables: {
+                'code0': {
+                    oid: 'code0',
+                    variableDescription: 'code0 desc',
+                    variableCode: {
+                        value: '00060'
                     }
                 },
-                ivTimeSeriesState: {
-                    currentIVVariableID: 'code0'
+                'code1': {
+                    oid: 'code1',
+                    variableDescription: 'code1 desc',
+                    variableCode: {
+                        value: '00061'
+                    }
+                },
+                '52331281': {
+                    oid:'52331281',
+                    variableDescription: 'Temperature C',
+                    variableCode: {
+                        value: '00010'
+                    }
+                },
+                '52331281F': {
+                    oid:'52331281F',
+                    variableDescription: 'Temperature F',
+                    variableCode: {
+                        value: '00010F'
+                    }
+                },
+                '52331280': {
+                    oid: '52331280',
+                    variableDescription: 'code2 desc',
+                    variableCode: {
+                        value: '72019'
+                    }
                 }
-            });
-            // Series are ordered by parameter code and have expected values.
-            expect(available).toEqual([
-                {variableID: 'code0', parameterCode: '00060', description: 'code0 desc', selected: true, timeSeriesCount: 1},
-                {variableID: 'code1', parameterCode: '00061', description: 'code1 desc', selected: false, timeSeriesCount: 1},
-                {variableID: 'code2', parameterCode: '00062', description: 'code2 desc', selected: false, timeSeriesCount: 1}
-            ]);
+            }
+        },
+        ivTimeSeriesState: {
+            currentIVVariableID: 'code0'
+        },
+        discreteData: {
+            groundwaterLevels: {
+                '52331280': {
+                    variable: {
+                        variableCode: {
+                            value: '72019',
+                            variableID: 52331280
+                        },
+                        variableName: 'Depth to water level, ft below land surface',
+                        variableDescription: 'code2 desc',
+                        unit: {
+                            unitCode: 'ft'
+                        },
+                        oid: '52331280'
+                    },
+                    values: [
+                        {
+                            value: '16.98',
+                            qualifiers: [
+                                '1'
+                            ],
+                            dateTime: 1479320640000
+                        }]
+                }
+            }
+        }
+    };
+
+    describe('getAvailableParameterCodes', () => {
+        it('Return an empty array if no variables for IV or discrete data groundwater levels are defined', () => {
+            expect(getAvailableParameterCodes({
+                ivTimeSeriesData: {},
+                ivTimeSeriesState: {},
+                discreteData: {}
+            })).toHaveLength(0);
         });
 
-        it('sets attributes correctly when not all series have data points', () => {
-            const available = getAvailableParameterCodes({
-                ivTimeSeriesData: {
-                    timeSeries: {
-                        'current:00060': {description: '00060', tsKey: 'current:P7D', variable: 'code0', points: [{x: 1, y: 2}]},
-                        'current:00061': {description: '00061', tsKey: 'current:P7D', variable: 'code1', points: []},
-                        'current:00062': {description: '00062', tsKey: 'current:P7D', variable: 'code2', points: [{x: 3, y: 4}]}
-                    },
-                    variables: {
-                        'code0': {
-                            oid: 'code0',
-                            variableDescription: 'code0 desc',
-                            variableCode: {
-                                value: '00060'
-                            }
-                        },
-                        'code1': {
-                            oid: 'code1',
-                            variableDescription: 'code1 desc',
-                            variableCode: {
-                                value: '00061'
-                            }
-                        },
-                        'code2': {
-                            oid: 'code2',
-                            variableDescription: 'code2 desc',
-                            variableCode: {
-                                value: '00062'
-                            }
-                        },
-                        'code3': {
-                            oid: 'code3',
-                            variableDescription: 'code3 desc',
-                            variableCode: {
-                                value: '00063'
-                            }
-                        }
-                    }
-                },
+        it('Return the IV variables when no discreteData in the correct order', () => {
+            const result = getAvailableParameterCodes({
+                ...TEST_STATE,
+                discreteData: {}
+            });
+            expect(result).toHaveLength(5);
+            expect(result[0]).toEqual(expect.objectContaining({
+                variableID: 'code0',
+                parameterCode: '00060',
+                description:'code0 desc',
+                selected: true,
+                timeSeriesCount: 1,
+                periodOfRecord: {
+                    begin_date: '01-01-1980',
+                    end_date: '01-01-2020'
+                }
+            }));
+            expect(result[0].waterAlert.hasWaterAlert).toBe(true);
+            expect(result[0].waterAlert.subscriptionParameterCode).toEqual('00060');
+
+            expect(result[1]).toEqual(expect.objectContaining({
+                variableID: '52331280',
+                parameterCode: '72019',
+                description: 'code2 desc',
+                selected: false,
+                timeSeriesCount: 1,
+                periodOfRecord: {
+                    begin_date: '04-01-1980',
+                    end_date: '04-01-2020'
+                }
+            }));
+            expect(result[1].waterAlert.hasWaterAlert).toBe(true);
+            expect(result[1].waterAlert.subscriptionParameterCode).toEqual('72019');
+
+
+            expect(result[2]).toEqual(expect.objectContaining({
+                variableID: 'code1',
+                parameterCode: '00061',
+                description:'code1 desc',
+                selected: false,
+                timeSeriesCount: 2,
+                periodOfRecord: {
+                    begin_date: '02-01-1980',
+                    end_date: '02-01-2020'
+                }
+            }));
+            expect(result[2].waterAlert.hasWaterAlert).toBe(false);
+
+            expect(result[3]).toEqual(expect.objectContaining({
+                variableID: '52331281',
+                parameterCode: '00010',
+                description:'Temperature C',
+                selected: false,
+                timeSeriesCount: 1,
+                periodOfRecord: {
+                    begin_date: '03-01-1980',
+                    end_date: '03-01-2020'
+                }
+            }));
+            expect(result[3].waterAlert.hasWaterAlert).toBe(true);
+            expect(result[3].waterAlert.subscriptionParameterCode).toEqual('00010');
+
+            expect(result[4]).toEqual(expect.objectContaining({
+                variableID: '52331281F',
+                parameterCode: '00010F',
+                description:'Temperature F',
+                selected: false,
+                timeSeriesCount: 1,
+                periodOfRecord: {
+                    begin_date: '03-01-1980',
+                    end_date: '03-01-2020'
+                }
+            }));
+            expect(result[4].waterAlert.hasWaterAlert).toBe(true);
+            expect(result[4].waterAlert.subscriptionParameterCode).toEqual('00010');
+        });
+
+        it('Returns the groundwater variables if no IV time series are available', () => {
+            const result = getAvailableParameterCodes({
+                ...TEST_STATE,
+                ivTimeSeriesData: {},
                 ivTimeSeriesState: {
-                    currentIVVariableID: 'code0'
+                    currentIVVariableID: '52331280'
                 }
             });
-            // Series are ordered by parameter code and have expected values.
-            expect(available).toEqual([
-                {variableID: 'code0', parameterCode: '00060', description: 'code0 desc', selected: true, timeSeriesCount: 1},
-                {variableID: 'code1', parameterCode: '00061', description: 'code1 desc', selected: false, timeSeriesCount: 1},
-                {variableID: 'code2', parameterCode: '00062', description: 'code2 desc', selected: false, timeSeriesCount: 1}
-            ]);
+            expect(result).toHaveLength(1);
+            expect(result[0]).toEqual(expect.objectContaining({
+                variableID: '52331280',
+                parameterCode: '72019',
+                description: 'code2 desc',
+                selected: true,
+                timeSeriesCount: 0,
+                periodOfRecord: {
+                    begin_date: '04-01-1980',
+                    end_date: '04-01-2020'
+                }
+            }));
+            expect(result[0].waterAlert.hasWaterAlert).toBe(true);
+            expect(result[0].waterAlert.subscriptionParameterCode).toEqual('72019');
+        });
+
+        it('Returns the merged variables if both IV and groundwater levels are available', () => {
+            const result = getAvailableParameterCodes(TEST_STATE);
+            expect(result[0]).toEqual(expect.objectContaining({
+                variableID: 'code0',
+                parameterCode: '00060',
+                description:'code0 desc',
+                selected: true,
+                timeSeriesCount: 1,
+                periodOfRecord: {
+                    begin_date: '01-01-1980',
+                    end_date: '01-01-2020'
+                }
+            }));
+            expect(result[0].waterAlert.hasWaterAlert).toBe(true);
+            expect(result[0].waterAlert.subscriptionParameterCode).toEqual('00060');
+
+            expect(result[1]).toEqual(expect.objectContaining({
+                variableID: '52331280',
+                parameterCode: '72019',
+                description: 'code2 desc',
+                selected: false,
+                timeSeriesCount: 1,
+                periodOfRecord: {
+                    begin_date: '04-01-1980',
+                    end_date: '04-01-2020'
+                }
+            }));
+            expect(result[1].waterAlert.hasWaterAlert).toBe(true);
+            expect(result[1].waterAlert.subscriptionParameterCode).toEqual('72019');
+
+
+            expect(result[2]).toEqual(expect.objectContaining({
+                variableID: 'code1',
+                parameterCode: '00061',
+                description:'code1 desc',
+                selected: false,
+                timeSeriesCount: 2,
+                periodOfRecord: {
+                    begin_date: '02-01-1980',
+                    end_date: '02-01-2020'
+                }
+            }));
+            expect(result[2].waterAlert.hasWaterAlert).toBe(false);
+
+            expect(result[3]).toEqual(expect.objectContaining({
+                variableID: '52331281',
+                parameterCode: '00010',
+                description:'Temperature C',
+                selected: false,
+                timeSeriesCount: 1,
+                periodOfRecord: {
+                    begin_date: '03-01-1980',
+                    end_date: '03-01-2020'
+                }
+            }));
+            expect(result[3].waterAlert.hasWaterAlert).toBe(true);
+            expect(result[3].waterAlert.subscriptionParameterCode).toEqual('00010');
+
+            expect(result[4]).toEqual(expect.objectContaining({
+                variableID: '52331281F',
+                parameterCode: '00010F',
+                description:'Temperature F',
+                selected: false,
+                timeSeriesCount: 1,
+                periodOfRecord: {
+                    begin_date: '03-01-1980',
+                    end_date: '03-01-2020'
+                }
+            }));
+            expect(result[4].waterAlert.hasWaterAlert).toBe(true);
+            expect(result[4].waterAlert.subscriptionParameterCode).toEqual('00010');
         });
     });
-
 });

--- a/assets/src/scripts/monitoring-location/components/hydrograph/selectors/parameter-data.test.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/selectors/parameter-data.test.js
@@ -220,7 +220,17 @@ describe('monitoring-location/components/hydrograph/selectors/parameter-data', (
         it('Returns the groundwater variables if no IV time series are available', () => {
             const result = getAvailableParameterCodes({
                 ...TEST_STATE,
-                ivTimeSeriesData: {},
+                ivTimeSeriesData: {
+                    variables: {
+                        '52331280': {
+                            oid: '52331280',
+                            variableDescription: 'code2 desc',
+                            variableCode: {
+                                value: '72019'
+                            }
+                        }
+                    }
+                },
                 ivTimeSeriesState: {
                     currentIVVariableID: '52331280'
                 }

--- a/assets/src/scripts/monitoring-location/components/hydrograph/selectors/scales.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/selectors/scales.js
@@ -2,8 +2,6 @@ import {scaleLinear, scaleSymlog} from 'd3-scale';
 import memoize from 'fast-memoize';
 import {createSelector} from 'reselect';
 
-import {convertCelsiusToFahrenheit, convertFahrenheitToCelsius} from 'ui/utils';
-
 import {getVariables, getCurrentParmCd, getRequestTimeRange, getTimeSeriesForTsKey} from 'ml/selectors/time-series-selector';
 
 import {getYDomain, getYDomainForVisiblePoints, SYMLOG_PARMS} from './domain';

--- a/assets/src/scripts/monitoring-location/components/hydrograph/selectors/scales.test.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/selectors/scales.test.js
@@ -121,7 +121,8 @@ describe('monitoring-location/components/hydrograph/scales', () => {
                 ui: {
                     width: 200,
                     windowWidth: 600
-                }
+                },
+                discreteData: {}
             };
             expect(getMainYScale(STATE).name).toBe('scale');
             expect(getBrushYScale(STATE).name).toBe('scale');
@@ -155,7 +156,8 @@ describe('monitoring-location/components/hydrograph/scales', () => {
                 ui: {
                     width: 200,
                     windowWidth: 600
-                }
+                },
+                discreteData: {}
             };
             expect(getMainYScale(STATE).name).toBe('scale');
             expect(getBrushYScale(STATE).name).toBe('scale');

--- a/assets/src/scripts/monitoring-location/components/hydrograph/time-series-graph.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/time-series-graph.js
@@ -14,7 +14,7 @@ import {getAgencyCode, getMonitoringLocationName, getCurrentVariable} from 'ml/s
 import {isWaterwatchVisible, getWaterwatchFloodLevels} from 'ml/selectors/flood-data-selector';
 
 import {getAxes}  from './selectors/axes';
-import {getVisibleGroundWaterLevels} from './selectors/discrete-data';
+import {getVisibleGroundWaterLevelPoints} from './selectors/discrete-data';
 import {
     getCurrentVariableLineSegments,
     getCurrentVariableMedianStatPoints,
@@ -272,7 +272,7 @@ export const drawTimeSeriesGraph = function(elem, store, siteNo, showMLName, sho
             enableClip: () => true
         })))
         .call(link(store, drawGroundwaterLevels, createStructuredSelector({
-            levels: getVisibleGroundWaterLevels,
+            levels: getVisibleGroundWaterLevelPoints,
             xScale: getMainXScale('current'),
             yScale: getMainYScale
         })))

--- a/assets/src/scripts/monitoring-location/index.js
+++ b/assets/src/scripts/monitoring-location/index.js
@@ -39,11 +39,13 @@ const loadAllGroundWaterData = function(nodes, store) {
 
     const siteno = nodesWithGroundWaterLevels[0].dataset.siteno;
     if (config.gwPeriodOfRecord) {
-        Object.keys(config.gwPeriodOfRecord).forEach(function(parameterCode) {
+
+        const loadPromises = Object.keys(config.gwPeriodOfRecord).map(function(parameterCode) {
             const periodOfRecord = config.gwPeriodOfRecord[parameterCode];
             return store.dispatch(
                 retrieveGroundwaterLevels(siteno, parameterCode, periodOfRecord.begin_date, periodOfRecord.end_date));
         });
+        return Promise.all(loadPromises);
     } else {
         return Promise.resolve();
     }

--- a/assets/src/scripts/monitoring-location/selectors/discrete-data-selector.js
+++ b/assets/src/scripts/monitoring-location/selectors/discrete-data-selector.js
@@ -1,6 +1,6 @@
 import {createSelector} from 'reselect';
 
-import {getCurrentParmCd} from './time-series-selector';
+import {getCurrentVariableID} from './time-series-selector';
 
 /*
  * Returns selector function which returns all of the groundwater levels.
@@ -18,8 +18,8 @@ export const getAllGroundwaterLevels =
  */
 export const getIVCurrentVariableGroundwaterLevels = createSelector(
     getAllGroundwaterLevels,
-    getCurrentParmCd,
-    (gwLevels, parameterCode) => {
-        return gwLevels && parameterCode && gwLevels[parameterCode] ? gwLevels[parameterCode] : {};
+    getCurrentVariableID,
+    (gwLevels, variableID) => {
+        return gwLevels && variableID && gwLevels[variableID] ? gwLevels[variableID] : {};
     }
 );

--- a/assets/src/scripts/monitoring-location/selectors/discrete-data-selector.js
+++ b/assets/src/scripts/monitoring-location/selectors/discrete-data-selector.js
@@ -11,6 +11,19 @@ export const getAllGroundwaterLevels =
     (state) => state.discreteData.groundwaterLevels ? state.discreteData.groundwaterLevels : null;
 
 /*
+ * Returns a selector function which returns an array of all variables that have
+ * groundwater levels
+ * @return {Function} The Function returns an array of the variable properties for each variable
+ * in groundwaterLevels.
+ */
+export const getAllGroundwaterLevelVariables = createSelector(
+    getAllGroundwaterLevels,
+    (gwLevels) => {
+        return gwLevels ? Object.values(gwLevels).map(level => level.variable) : [];
+    }
+);
+
+/*
  * Returns selector function which returns the groundwater levels for the current IV variable
  * @return {Function} - The function returns an Object with the following properties:
  *      @prop {Object} variable

--- a/assets/src/scripts/monitoring-location/selectors/discrete-data-selector.test.js
+++ b/assets/src/scripts/monitoring-location/selectors/discrete-data-selector.test.js
@@ -17,9 +17,9 @@ describe('monitoring-location/selectors/discrete-data-selector', () => {
             const TEST_DATA = {
                 '45807042': {
                     variable: {
-                        variableCode: [{
+                        variableCode: {
                             value: '72019'
-                        }],
+                        },
                         oid: '45807042'
                     },
                     values: [
@@ -28,9 +28,9 @@ describe('monitoring-location/selectors/discrete-data-selector', () => {
                 },
                 55807042: {
                     variable: {
-                        variableCode: [{
+                        variableCode: {
                             value: '65433'
-                        }],
+                        },
                         oid: '55807042'
                     },
                     values: [
@@ -75,9 +75,9 @@ describe('monitoring-location/selectors/discrete-data-selector', () => {
                 groundwaterLevels : {
                     '45807042': {
                         variable: {
-                            variableCode: [{
+                            variableCode: {
                                 value: '72019'
-                            }],
+                            },
                             oid: '45807042'
                         },
                         values: [

--- a/assets/src/scripts/monitoring-location/selectors/discrete-data-selector.test.js
+++ b/assets/src/scripts/monitoring-location/selectors/discrete-data-selector.test.js
@@ -15,14 +15,24 @@ describe('monitoring-location/selectors/discrete-data-selector', () => {
 
         it('Return all groundwater levels', () => {
             const TEST_DATA = {
-                '72019': {
-                    variables: {variableID: 1111},
+                '45807042': {
+                    variable: {
+                        variableCode: [{
+                            value: '72019'
+                        }],
+                        oid: '45807042'
+                    },
                     values: [
                         {value: '11.5', qualifiers: [], date: 1586354400000}
                     ]
                 },
-                '65443': {
-                    variables: {variableID: 1111},
+                55807042: {
+                    variable: {
+                        variableCode: [{
+                            value: '65433'
+                        }],
+                        oid: '55807042'
+                    },
                     values: [
                         {value: '15.5', qualifiers: [], date: 1586354400000},
                         {value: '24.3', qualifiers: [], date: 1588946400000}
@@ -46,7 +56,7 @@ describe('monitoring-location/selectors/discrete-data-selector', () => {
                             'value': '72019'
                         }
                     },
-                    '450807142': {
+                    '45807142': {
                         variableCode: {
                             'value': '00010'
                         }
@@ -63,12 +73,12 @@ describe('monitoring-location/selectors/discrete-data-selector', () => {
         const TEST_GROUNDWATER_LEVELS = {
             discreteData : {
                 groundwaterLevels : {
-                    '72019': {
+                    '45807042': {
                         variable: {
-                            variableCode: {
-                                value: '72019',
-                                variableID: '45807042'
-                            }
+                            variableCode: [{
+                                value: '72019'
+                            }],
+                            oid: '45807042'
                         },
                         values: [
                             {
@@ -114,7 +124,7 @@ describe('monitoring-location/selectors/discrete-data-selector', () => {
         it('Should return an empty object if no groundwater levels exist for selected IV variable', () => {
             expect(getIVCurrentVariableGroundwaterLevels({
                 ivTimeSeriesState: {
-                   currenteIVVariableID: 450807142
+                   currentIVVariableID: '45807142'
                 },
                 ...TEST_IV_TIME_SERIES_DATA,
                 ...TEST_GROUNDWATER_LEVELS
@@ -126,7 +136,7 @@ describe('monitoring-location/selectors/discrete-data-selector', () => {
                 ...TEST_IV_TIME_SERIES_DATA,
                 ...TEST_IV_TIME_SERIES_STATE,
                 ...TEST_GROUNDWATER_LEVELS
-            })).toEqual(TEST_GROUNDWATER_LEVELS.discreteData.groundwaterLevels['72019']);
+            })).toEqual(TEST_GROUNDWATER_LEVELS.discreteData.groundwaterLevels['45807042']);
         });
     });
 });

--- a/assets/src/scripts/monitoring-location/selectors/time-series-selector.js
+++ b/assets/src/scripts/monitoring-location/selectors/time-series-selector.js
@@ -42,7 +42,6 @@ export const getCustomTimeRange = state => state.ivTimeSeriesState.customIVTimeR
 export const getTimeSeries = state => state.ivTimeSeriesData.timeSeries ? state.ivTimeSeriesData.timeSeries : {};
 
 
-
 export const hasAnyTimeSeries = createSelector(
     getTimeSeries,
     (timeSeries) => {
@@ -50,10 +49,13 @@ export const hasAnyTimeSeries = createSelector(
     }
 );
 
+/*
+ * Selector function which returns a function which returns True if the state contains IV variables
+ */
 export const hasAnyVariables = createSelector(
     getVariables,
     (variables) => {
-        return variables && Object.keys(variables).length;
+        return !!(variables && Object.keys(variables).length);
     }
 );
 

--- a/assets/src/scripts/monitoring-location/selectors/time-series-selector.js
+++ b/assets/src/scripts/monitoring-location/selectors/time-series-selector.js
@@ -46,7 +46,14 @@ export const getTimeSeries = state => state.ivTimeSeriesData.timeSeries ? state.
 export const hasAnyTimeSeries = createSelector(
     getTimeSeries,
     (timeSeries) => {
-        return Object.keys(timeSeries).length ? true : false;
+        return !!Object.keys(timeSeries).length ;
+    }
+);
+
+export const hasAnyVariables = createSelector(
+    getVariables,
+    (variables) => {
+        return variables && Object.keys(variables).length;
     }
 );
 

--- a/assets/src/scripts/monitoring-location/selectors/time-series-selector.test.js
+++ b/assets/src/scripts/monitoring-location/selectors/time-series-selector.test.js
@@ -7,6 +7,7 @@ import {
     getCurrentDateRange,
     getTimeSeries,
     hasAnyTimeSeries,
+    hasAnyVariables,
     getMonitoringLocationName,
     getAgencyCode,
     getUserInputsForSelectingTimespan,
@@ -314,6 +315,18 @@ describe('monitoring-location/selectors/time-series-selector', () => {
                     }
                 }
             })).toBe(true);
+        });
+    });
+
+    describe('hasAnyVariables', () => {
+        it('Return false if state contains no variables', () => {
+            expect(hasAnyVariables({
+                ivTimeSeriesData: {}
+            })).toBe(false);
+        });
+
+        it('Return true if state contains variables', () => {
+            expect(hasAnyVariables(TEST_DATA)).toBe(true);
         });
     });
 

--- a/assets/src/scripts/monitoring-location/store/discrete-data.js
+++ b/assets/src/scripts/monitoring-location/store/discrete-data.js
@@ -2,6 +2,7 @@ import {DateTime} from 'luxon';
 
 import {fetchGroundwaterLevels} from 'ui/web-services/groundwater-levels';
 
+import {Actions as IVTimeSeriesDataActions} from './instantaneous-value-time-series-data';
 const INITIAL_DATA = {
     groundwaterLevels : null
 };
@@ -70,6 +71,7 @@ export const retrieveGroundwaterLevels = function(monitoringLocationId, paramete
                             variable: variable,
                             values: values
                         }));
+                        dispatch(IVTimeSeriesDataActions.addVariableToIVVariables(variable));
                     }
                 },
                 () => {

--- a/assets/src/scripts/monitoring-location/store/discrete-data.js
+++ b/assets/src/scripts/monitoring-location/store/discrete-data.js
@@ -16,10 +16,10 @@ const INITIAL_DATA = {
  *        @prop {Array of String} qualifiers
  *        @prop {Number} dateTime - Unix epoch time
  */
-export const addGroundwaterLevels = function(parameterCode, data) {
+export const addGroundwaterLevels = function(variableID, data) {
     return {
         type: 'ADD_GROUNDWATER_LEVELS',
-        parameterCode,
+        variableID,
         data
     };
 };
@@ -46,9 +46,7 @@ export const retrieveGroundwaterLevels = function(monitoringLocationId, paramete
         })
             .then(
                 (data) => {
-                    if (!data.value || !data.value.timeSeries || !data.value.timeSeries.length) {
-                        dispatch(addGroundwaterLevels(parameterCode, {}));
-                    } else {
+                    if (data.value && data.value.timeSeries && data.value.timeSeries.length) {
                         let values;
                         const timeSeries = data.value.timeSeries;
                         if (!timeSeries[0].values.length || !timeSeries[0].values[0].value.length) {
@@ -64,8 +62,9 @@ export const retrieveGroundwaterLevels = function(monitoringLocationId, paramete
 
                             });
                         }
-                        dispatch(addGroundwaterLevels(parameterCode, {
-                            variable: timeSeries[0].variable,
+                        const variable = timeSeries[0].variable;
+                        dispatch(addGroundwaterLevels(variable.oid, {
+                            variable: variable,
                             values: values
                         }));
                     }
@@ -81,7 +80,7 @@ export const discreteDataReducer = function(discreteData = INITIAL_DATA, action)
     switch(action.type) {
         case 'ADD_GROUNDWATER_LEVELS': {
             let newData = {};
-            newData[action.parameterCode] = action.data;
+            newData[action.variableID] = action.data;
             return Object.assign(
                 {},
                 discreteData,

--- a/assets/src/scripts/monitoring-location/store/discrete-data.js
+++ b/assets/src/scripts/monitoring-location/store/discrete-data.js
@@ -62,7 +62,10 @@ export const retrieveGroundwaterLevels = function(monitoringLocationId, paramete
 
                             });
                         }
-                        const variable = timeSeries[0].variable;
+                        const variable = {
+                            ...timeSeries[0].variable,
+                            variableCode: timeSeries[0].variable.variableCode[0]
+                        };
                         dispatch(addGroundwaterLevels(variable.oid, {
                             variable: variable,
                             values: values

--- a/assets/src/scripts/monitoring-location/store/discrete-data.test.js
+++ b/assets/src/scripts/monitoring-location/store/discrete-data.test.js
@@ -33,10 +33,10 @@ describe('monitoring-location/store/discrete-data', () => {
     describe('addGroundwaterLevels action', () => {
         const TEST_DATA = {
             variable: {
-                variableCode: {
-                    value: '72019',
-                    variableID: '12345'
-                }
+                variableCode: [{
+                    value: '72019'
+                }],
+                oid: '12345'
             },
             values: [
                 {
@@ -52,19 +52,19 @@ describe('monitoring-location/store/discrete-data', () => {
             ]
         };
         it('adds the groundwater levels to the store', () => {
-            store.dispatch(addGroundwaterLevels('72019', TEST_DATA));
+            store.dispatch(addGroundwaterLevels('12345', TEST_DATA));
             const state = store.getState();
 
-            expect(state.discreteData.groundwaterLevels['72019']).toEqual(TEST_DATA);
+            expect(state.discreteData.groundwaterLevels['12345']).toEqual(TEST_DATA);
         });
 
         it('add the groundwater levels for the parameter code to the store while retaining data from other parameter codes', () => {
             const testDataOne = {
                 variable: {
-                    variableCode: {
-                        value: '60123',
-                        variableID: '55555'
-                    }
+                    variableCode: [{
+                        value: '60123'
+                    }],
+                    oid: '55555'
                 },
                 values: [
                     {
@@ -79,12 +79,12 @@ describe('monitoring-location/store/discrete-data', () => {
                     }
                 ]
             };
-            store.dispatch(addGroundwaterLevels('60123', testDataOne));
-            store.dispatch(addGroundwaterLevels('72019', TEST_DATA));
+            store.dispatch(addGroundwaterLevels('55555', testDataOne));
+            store.dispatch(addGroundwaterLevels('12345', TEST_DATA));
             const state = store.getState();
 
-            expect(state.discreteData.groundwaterLevels['60123']).toEqual(testDataOne);
-            expect(state.discreteData.groundwaterLevels['72019']).toEqual(TEST_DATA);
+            expect(state.discreteData.groundwaterLevels['55555']).toEqual(testDataOne);
+            expect(state.discreteData.groundwaterLevels['12345']).toEqual(TEST_DATA);
         });
 
         it('replace the existing data for the parameter code', () => {
@@ -101,11 +101,11 @@ describe('monitoring-location/store/discrete-data', () => {
                     datetime: 1607972400000
                 }]
             };
-            store.dispatch(addGroundwaterLevels('72019', TEST_DATA));
-            store.dispatch(addGroundwaterLevels('72019', changedTestData));
+            store.dispatch(addGroundwaterLevels('12345', TEST_DATA));
+            store.dispatch(addGroundwaterLevels('12345', changedTestData));
             const state = store.getState();
             
-            expect(state.discreteData.groundwaterLevels['72019']).toEqual(changedTestData);
+            expect(state.discreteData.groundwaterLevels['12345']).toEqual(changedTestData);
         });
     });
 
@@ -117,10 +117,10 @@ describe('monitoring-location/store/discrete-data', () => {
             return dispatchPromise.then(() => {
                 const state = store.getState();
 
-                expect(state.discreteData.groundwaterLevels['72019']).toBeDefined();
-                expect(state.discreteData.groundwaterLevels['72019'].variable.variableCode[0].value).toEqual('72019');
-                expect(state.discreteData.groundwaterLevels['72019'].values).toHaveLength(7);
-                expect(state.discreteData.groundwaterLevels['72019'].values[0]).toEqual({
+                expect(state.discreteData.groundwaterLevels['52331280']).toBeDefined();
+                expect(state.discreteData.groundwaterLevels['52331280'].variable.variableCode[0].value).toEqual('72019');
+                expect(state.discreteData.groundwaterLevels['52331280'].values).toHaveLength(7);
+                expect(state.discreteData.groundwaterLevels['52331280'].values[0]).toEqual({
                     value: '26.07',
                     qualifiers: [],
                     dateTime: 1579770360000
@@ -133,29 +133,29 @@ describe('monitoring-location/store/discrete-data', () => {
                 value: {
                     timeSeries: [
                         {
-                            variable: {variableId: 11112222},
+                            variable: {oid: '11112222'},
                             values: [{value: []}]
                         }
                     ]
                 }
             };
             fakeServer.respondWith([200, {'Content-Type': 'application/json'}, JSON.stringify(MOCK_DATA)]);
-            const dispatchPromise = store.dispatch(retrieveGroundwaterLevels('12345678', '72019', '2020-01-01', '2020-11-17)'));
+            const dispatchPromise = store.dispatch(retrieveGroundwaterLevels('12345678', '11112222', '2020-01-01', '2020-11-17)'));
             fakeServer.respond();
             return dispatchPromise.then(() => {
                 const state = store.getState();
-                expect(state.discreteData.groundwaterLevels['72019'].values).toHaveLength(0);
+                expect(state.discreteData.groundwaterLevels['11112222'].values).toHaveLength(0);
             });
         });
 
         it('Bad fetch updates groundwater level with empty object', () => {
             fakeServer.respondWith([500, {}, 'Internal server error']);
-            const dispatchPromise = store.dispatch(retrieveGroundwaterLevels('12345678', '72019', '2020-01-01', '2020-11-17)'));
+            const dispatchPromise = store.dispatch(retrieveGroundwaterLevels('12345678', '11112222', '2020-01-01', '2020-11-17)'));
             fakeServer.respond();
             return dispatchPromise.then(() => {
                 const state = store.getState();
 
-                expect(state.discreteData.groundwaterLevels['72019']).toEqual({});
+                expect(state.discreteData.groundwaterLevels).toBeUndefined();
             });
         });
     });

--- a/assets/src/scripts/monitoring-location/store/discrete-data.test.js
+++ b/assets/src/scripts/monitoring-location/store/discrete-data.test.js
@@ -33,9 +33,9 @@ describe('monitoring-location/store/discrete-data', () => {
     describe('addGroundwaterLevels action', () => {
         const TEST_DATA = {
             variable: {
-                variableCode: [{
+                variableCode: {
                     value: '72019'
-                }],
+                },
                 oid: '12345'
             },
             values: [
@@ -61,9 +61,9 @@ describe('monitoring-location/store/discrete-data', () => {
         it('add the groundwater levels for the parameter code to the store while retaining data from other parameter codes', () => {
             const testDataOne = {
                 variable: {
-                    variableCode: [{
+                    variableCode: {
                         value: '60123'
-                    }],
+                    },
                     oid: '55555'
                 },
                 values: [
@@ -118,7 +118,7 @@ describe('monitoring-location/store/discrete-data', () => {
                 const state = store.getState();
 
                 expect(state.discreteData.groundwaterLevels['52331280']).toBeDefined();
-                expect(state.discreteData.groundwaterLevels['52331280'].variable.variableCode[0].value).toEqual('72019');
+                expect(state.discreteData.groundwaterLevels['52331280'].variable.variableCode.value).toEqual('72019');
                 expect(state.discreteData.groundwaterLevels['52331280'].values).toHaveLength(7);
                 expect(state.discreteData.groundwaterLevels['52331280'].values[0]).toEqual({
                     value: '26.07',
@@ -133,7 +133,12 @@ describe('monitoring-location/store/discrete-data', () => {
                 value: {
                     timeSeries: [
                         {
-                            variable: {oid: '11112222'},
+                            variable: {
+                                variableCode: [{
+                                    value: '60123'
+                                }],
+                                oid: '11112222'
+                            },
                             values: [{value: []}]
                         }
                     ]

--- a/assets/src/scripts/monitoring-location/store/instantaneous-value-time-series-data.js
+++ b/assets/src/scripts/monitoring-location/store/instantaneous-value-time-series-data.js
@@ -69,6 +69,12 @@ const resetIVTimeSeries = function(tsRequestKey) {
     };
 };
 
+/*
+ * Synchronous Redux action - adds the variable to the store. If the variable already
+ * is in the state, it merges the properties of the variable with the existing variables
+ * @param {Object} variables
+ * @return {Object} - Redux action
+ */
 const addVariableToIVVariables = function(variable) {
     return {
         type: 'ADD_VARIABLE_TO_IV_VARIABLES',

--- a/assets/src/scripts/monitoring-location/store/instantaneous-value-time-series-data.js
+++ b/assets/src/scripts/monitoring-location/store/instantaneous-value-time-series-data.js
@@ -6,7 +6,7 @@ import omitBy from 'lodash/omitBy';
 import {DateTime} from 'luxon';
 
 import {normalize} from 'ui/schema';
-import {calcStartTime, sortedParameters} from 'ui/utils';
+import {calcStartTime} from 'ui/utils';
 import {getPreviousYearTimeSeries, getTimeSeries} from 'ui/web-services/models';
 
 import {convertCelsiusCollectionsToFahrenheitAndMerge, isPeriodCustom, parsePeriodCode} from 'ml/iv-data-utils';
@@ -41,23 +41,6 @@ const getLatestValue = function(collection, parmCd) {
 };
 
 /*
- * @param {Object} timeSeries - keys are time series id
- * @param {Object} variables  - keys are the variable id
- */
-const getCurrentVariableId = function(timeSeries, variables) {
-    const tsVariablesWithData = Object.values(timeSeries)
-        .filter((ts) => ts.points.length)
-        .map((ts) => variables[ts.variable]);
-    const sortedVarsWithData = sortedParameters(tsVariablesWithData);
-    if (sortedVarsWithData.length) {
-        return sortedVarsWithData[0].oid;
-    } else {
-        const sortedVars = sortedParameters(Object.values(variables));
-        return sortedVars.length ? sortedVars[0].oid : '';
-    }
-};
-
-/*
  * Actions for ivTimeSeriesDataReducer
  */
 /*
@@ -83,6 +66,13 @@ const resetIVTimeSeries = function(tsRequestKey) {
     return {
         type: 'RESET_IV_TIME_SERIES',
         tsRequestKey
+    };
+};
+
+const addVariableToIVVariables = function(variable) {
+    return {
+        type: 'ADD_VARIABLE_TO_IV_VARIABLES',
+        variable
     };
 };
 
@@ -115,8 +105,6 @@ const retrieveIVTimeSeries = function(siteno) {
 
                 // Update the application state
                 dispatch(ivTimeSeriesStateActions.setIVTimeSeriesVisibility('current', true));
-                const variable = getCurrentVariableId(collection.timeSeries || {}, collection.variables || {});
-                dispatch(ivTimeSeriesStateActions.setCurrentIVVariable(variable));
                 dispatch(floodInundationActions.setGageHeight(getLatestValue(collection, GAGE_HEIGHT_CD)));
             },
             () => {
@@ -371,6 +359,13 @@ export const ivTimeSeriesDataReducer = function(ivTimeSeriesData={}, action) {
             return newSeries;
         }
 
+        case 'ADD_VARIABLE_TO_IV_VARIABLES': {
+            let newVariable = {};
+            newVariable[action.variable.oid] = action.variable;
+            const mergedVariables = merge({}, ivTimeSeriesData.variables, newVariable);
+            return merge({}, ivTimeSeriesData, {variables: mergedVariables});
+        }
+
         default:
             return ivTimeSeriesData;
     }
@@ -379,6 +374,7 @@ export const ivTimeSeriesDataReducer = function(ivTimeSeriesData={}, action) {
 export const Actions = {
     addIVTimeSeriesCollection,
     resetIVTimeSeries,
+    addVariableToIVVariables,
     retrieveCompareIVTimeSeries,
     retrieveIVTimeSeries,
     retrieveCustomTimePeriodIVTimeSeries,

--- a/assets/src/scripts/monitoring-location/store/instantaneous-value-time-series-data.test.js
+++ b/assets/src/scripts/monitoring-location/store/instantaneous-value-time-series-data.test.js
@@ -29,7 +29,8 @@ describe('monitoring-location/store/instantaneous-value-time-series-data module'
                             '45807197': {
                                 variableCode: {
                                     value: '00060'
-                                }
+                                },
+                                oid: '45807197'
                             }
                         }
                     },
@@ -56,12 +57,15 @@ describe('monitoring-location/store/instantaneous-value-time-series-data module'
             it('Expect data to be added to previously empty collection', () => {
                 store.dispatch(Actions.addIVTimeSeriesCollection({
                     variables: {
-                        'var1': {
-                            value: 'Value 1'
+                        '45807198': {
+                            variableCode: {
+                                value: '72019'
+                            },
+                            oid: '45807198'
                         }
                     },
                     timeSeries: {
-                        'var1:current:P7D': {
+                        '45807198:current:P7D': {
                             values: [1, 2, 3]
                         }
                     }
@@ -69,17 +73,21 @@ describe('monitoring-location/store/instantaneous-value-time-series-data module'
 
                 expect(store.getState().ivTimeSeriesData).toEqual({
                     variables: {
-                        'var1': {
-                            value: 'Value 1'
+                        '45807198': {
+                            variableCode: {
+                                value: '72019'
+                            },
+                            oid: '45807198'
                         },
                         '45807197': {
                             variableCode: {
                                 value: '00060'
-                            }
+                            },
+                            oid: '45807197'
                         }
                     },
                     timeSeries: {
-                        'var1:current:P7D': {
+                        '45807198:current:P7D': {
                             values: [1, 2, 3]
                         }
                     }
@@ -92,26 +100,33 @@ describe('monitoring-location/store/instantaneous-value-time-series-data module'
                         '45807197': {
                             variableCode: {
                                 value: '00060'
-                            }
+                            },
+                            oid: '45807197'
                         },
-                        'var1': {
-                            value: 'Value 1'
+                        '45807198': {
+                            variableCode: {
+                                value: '72019'
+                            },
+                            oid: '45807198'
                         }
                     },
                     timeSeries: {
-                        'var1:current:P7D': {
+                        '45807198:current:P7D': {
                             values: [1, 2, 3]
                         }
                     }
                 }));
                 store.dispatch(Actions.addIVTimeSeriesCollection({
                     variables: {
-                        'var2': {
-                            value: 'Value 2'
+                        '45807199': {
+                            variableCode: {
+                                value: '00010'
+                            },
+                            oid: '45807199'
                         }
                     },
                     timeSeries: {
-                        'var2:current:P7D': {
+                        '45807199:current:P7D': {
                             values: [5, 6, 7]
                         }
                     }
@@ -122,20 +137,27 @@ describe('monitoring-location/store/instantaneous-value-time-series-data module'
                         '45807197': {
                             variableCode: {
                                 value: '00060'
-                            }
+                            },
+                            oid: '45807197'
                         },
-                        'var1': {
-                            value: 'Value 1'
+                        '45807198': {
+                            variableCode: {
+                                value: '72019'
+                            },
+                            oid: '45807198'
                         },
-                        'var2': {
-                            value: 'Value 2'
+                        '45807199': {
+                            variableCode: {
+                                value: '00010'
+                            },
+                            oid: '45807199'
                         }
                     },
                     timeSeries: {
-                        'var1:current:P7D': {
+                        '45807198:current:P7D': {
                             values: [1, 2, 3]
                         },
-                        'var2:current:P7D': {
+                        '45807199:current:P7D': {
                             values: [5, 6, 7]
                         }
                     }
@@ -147,45 +169,91 @@ describe('monitoring-location/store/instantaneous-value-time-series-data module'
             it('Expect the specific time series to be cleared', () => {
                 store.dispatch(Actions.addIVTimeSeriesCollection({
                     requests: {
-                        'var1:current:P7D': {
-                            queryInfo: 'var1:current:P7D'
+                        '45807198:current:P7D': {
+                            queryInfo: '45807198:current:P7D'
                         },
-                        'var2:current:P7D': {
-                            queryInfo: 'var2:current:P7D'
+                        '45807199:current:P7D': {
+                            queryInfo: '45807199:current:P7D'
                         }
                     },
                     timeSeries: {
-                        'var1:current:P7D': {
-                            tsKey: 'var1:current:P7D',
+                        '45807198:current:P7D': {
+                            tsKey: '45807198:current:P7D',
                             values: [1, 2, 3]
                         },
-                        'var2:current:P7D': {
-                            tsKey: 'var2:current:P7D',
+                        '45807199:current:P7D': {
+                            tsKey: '45807199:current:P7D',
                             values: [5, 6, 7]
                         }
                     }
                 }));
-                store.dispatch(Actions.resetIVTimeSeries('var2:current:P7D'));
+                store.dispatch(Actions.resetIVTimeSeries('45807199:current:P7D'));
 
                 expect(store.getState().ivTimeSeriesData).toEqual({
                     variables: {
                         '45807197': {
                             variableCode: {
                                 value: '00060'
-                            }
+                            },
+                            oid: '45807197'
                         }
                     },
                     requests: {
-                        'var1:current:P7D': {
-                            queryInfo: 'var1:current:P7D'
+                        '45807198:current:P7D': {
+                            queryInfo: '45807198:current:P7D'
                         },
-                        'var2:current:P7D': {}
+                        '45807199:current:P7D': {}
                     },
                     timeSeries: {
-                        'var1:current:P7D': {
-                            tsKey: 'var1:current:P7D',
+                        '45807198:current:P7D': {
+                            tsKey: '45807198:current:P7D',
                             values: [1, 2, 3]
                         }
+                    }
+                });
+            });
+        });
+
+        describe('Actions.addVariableToIVVariables', () => {
+            it('The variable to added to the state', () => {
+                store.dispatch(Actions.addVariableToIVVariables({
+                    variableCode: {
+                        value: '72019'
+                    },
+                    oid: '45807198'
+                }));
+                expect(store.getState().ivTimeSeriesData.variables).toEqual({
+                    '45807197': {
+                        variableCode: {
+                            value: '00060'
+                        },
+                        oid: '45807197'
+                    },
+                    '45807198': {
+                        variableCode: {
+                            value: '72019'
+                        },
+                        oid: '45807198'
+                    }
+                });
+            });
+
+            it('Merges new data with existing variable', () => {
+                store.dispatch(Actions.addVariableToIVVariables({
+                    variableCode: {
+                        value: '00060',
+                        description: 'Variable 00060'
+                    },
+                    oid: '45807197'
+                }));
+
+                expect(store.getState().ivTimeSeriesData.variables).toEqual({
+                    '45807197': {
+                        variableCode: {
+                            value: '00060',
+                            description: 'Variable 00060'
+                        },
+                        oid: '45807197'
                     }
                 });
             });
@@ -224,7 +292,6 @@ describe('monitoring-location/store/instantaneous-value-time-series-data module'
                     expect(floodStateActions.setGageHeight).toHaveBeenCalled();
                     expect(tsState.loadingIVTSKeys).not.toContain('current:P7D');
                     expect(tsState.showIVTimeSeries.current).toBe(true);
-                    expect(tsState.currentIVVariableID).toBe('45807197');
                 });
             });
 

--- a/wdfn-server/config.py
+++ b/wdfn-server/config.py
@@ -28,12 +28,13 @@ DEBUG = False
 SERVER_SERVICE_ROOT = 'https://waterservices.usgs.gov'  # Used for webserver calls to waterservices.
 SERVICE_ROOT = 'https://waterservices.usgs.gov'  # Use for client side calls to waterservices. Most be a public url.
 PAST_SERVICE_ROOT = 'https://nwis.waterservices.usgs.gov'
-NWIS_ENDPOINTS = {
+NWIS_PAGE_URLS = {
     'INVENTORY': 'https://waterdata.usgs.gov/nwis/inventory',
     'UV': 'https://waterdata.usgs.gov/nwis/uv'
 }
 WEATHER_SERVICE_ROOT = 'https://api.weather.gov'
 
+SITE_SERVICE_CATALOG_ROOT = SERVICE_ROOT
 OBSERVATIONS_ENDPOINT = 'https://labs.waterdata.usgs.gov/api/observations/'
 GROUNDWATER_LEVELS_ENDPOINT = 'https://waterservices.usgs.gov/nwis/gwlevels/'
 

--- a/wdfn-server/config.py
+++ b/wdfn-server/config.py
@@ -34,7 +34,7 @@ NWIS_PAGE_URLS = {
 }
 WEATHER_SERVICE_ROOT = 'https://api.weather.gov'
 
-SITE_SERVICE_CATALOG_ROOT = SERVICE_ROOT
+SITE_SERVICE_CATALOG_ROOT = 'https://waterservices.usgs.gov'
 OBSERVATIONS_ENDPOINT = 'https://labs.waterdata.usgs.gov/api/observations/'
 GROUNDWATER_LEVELS_ENDPOINT = 'https://waterservices.usgs.gov/nwis/gwlevels/'
 

--- a/wdfn-server/waterdata/services/nwis.py
+++ b/wdfn-server/waterdata/services/nwis.py
@@ -13,7 +13,7 @@ class NwisWebServices:
 
     """
 
-    def __init__(self, service_root, path='/nwis/site/', data_format='rdb'):
+    def __init__(self, service_root, catalog_root, path='/nwis/site/', data_format='rdb'):
         """
         Constructor method.
 
@@ -23,6 +23,7 @@ class NwisWebServices:
 
         """
         self.service_root = service_root
+        self.catalog_root = catalog_root
         self.path = path
         self.data_format = data_format
 
@@ -59,7 +60,7 @@ class NwisWebServices:
 
         """
         resp = execute_get_request(
-            self.service_root,
+            self.catalog_root,
             path=self.path,
             params={
                 'sites': site_no,

--- a/wdfn-server/waterdata/templates/base_plain.html
+++ b/wdfn-server/waterdata/templates/base_plain.html
@@ -24,7 +24,7 @@
             var CONFIG = {
                 'SERVICE_ROOT': '{{ config.SERVICE_ROOT }}/nwis',
                 'PAST_SERVICE_ROOT': '{{ config.PAST_SERVICE_ROOT }}/nwis',
-                'NWIS_INVENTORY_ENDPOINT': '{{ config.NWIS_ENDPOINTS.INVENTORY }}',
+                'NWIS_INVENTORY_PAGE_URL': '{{ config.NWIS_PAGE_URLS.INVENTORY }}',
                 'OBSERVATIONS_ENDPOINT': '{{ config.OBSERVATIONS_ENDPOINT }}',
                 'GROUNDWATER_LEVELS_ENDPOINT': '{{ config.GROUNDWATER_LEVELS_ENDPOINT }}',
                 'HYDRO_ENDPOINT': '{{ config.HYDRO_ENDPOINT }}',

--- a/wdfn-server/waterdata/templates/monitoring_location.html
+++ b/wdfn-server/waterdata/templates/monitoring_location.html
@@ -140,7 +140,7 @@
                         <h1>{{ stations[0].station_nm }}</h1>
                         <div>
                             <span class="usa-tag">Important</span>
-                            <a id="classic-page-link" class="usa-link" aria-describedby="{{ 'classic'|tooltip_content_id }}" href="{{ config.NWIS_ENDPOINTS.UV}}?site_no={{stations[0].site_no}}" target="_blank" rel="noopener">Classic Page</a>
+                            <a id="classic-page-link" class="usa-link" aria-describedby="{{ 'classic'|tooltip_content_id }}" href="{{ config.NWIS_PAGE_URLS.UV}}?site_no={{stations[0].site_no}}" target="_blank" rel="noopener">Classic Page</a>
                             {{ components.QuestionTooltip('classic', 'View all current conditions values on the classic Water Data for the Nation interface.', True) }}
                         </div>
                         <p id="site-description">{{ components.Description(stations[0].site_no, location_with_values, parm_grp_summary) }}
@@ -232,7 +232,7 @@
                                             {% endfor %}
                                         </tbody>
                                     </table>
-                                    <a class="usa-link" href="{{ config.NWIS_ENDPOINTS.INVENTORY}}?site_no={{ stations[0].site_no }}" target="_blank" rel="noopener">Classic Water Data for the Nation Inventory</a>
+                                    <a class="usa-link" href="{{ config.NWIS_PAGE_URLS.INVENTORY}}?site_no={{ stations[0].site_no }}" target="_blank" rel="noopener">Classic Water Data for the Nation Inventory</a>
                                 </div>
                             </div>
                         {% endif %}

--- a/wdfn-server/waterdata/tests/services/test_nwis.py
+++ b/wdfn-server/waterdata/tests/services/test_nwis.py
@@ -13,6 +13,7 @@ class TestNwisWebServices(TestCase):
 
     def setUp(self):
         self.service_root = 'https://fake.nwis.url.gov'
+        self.catalog_root= 'https://fake.nwis.catalog.usgs.gov'
         self.path = '/some/path/'
         self.site_no = '029055631'
         self.agency_cd = 'ABYZ'
@@ -20,13 +21,13 @@ class TestNwisWebServices(TestCase):
         self.county_code = '055:213'
 
     def test_default_attributes(self):
-        nwis = NwisWebServices(self.service_root)
+        nwis = NwisWebServices(self.service_root, self.catalog_root)
         self.assertEqual(nwis.path, '/nwis/site/')
         self.assertEqual(nwis.data_format, 'rdb')
 
     @mock.patch('waterdata.services.nwis.execute_get_request')
     def test_get_site(self, r_mock):
-        nwis = NwisWebServices(self.service_root, self.path)
+        nwis = NwisWebServices(self.service_root, self.catalog_root, self.path)
         nwis.get_site(self.site_no, self.agency_cd)
         r_mock.assert_called_with(
             self.service_root,
@@ -46,10 +47,10 @@ class TestNwisWebServices(TestCase):
         mock_resp.iter_lines.return_value = iter(PARAMETER_RDB.split('\n'))
         r_mock.return_value = mock_resp
 
-        nwis = NwisWebServices(self.service_root, self.path)
+        nwis = NwisWebServices(self.service_root, self.catalog_root, self.path)
         data = nwis.get_site_parameters(self.site_no, self.agency_cd)
         r_mock.assert_called_with(
-            self.service_root,
+            self.catalog_root,
             path=self.path,
             params={
                 'sites': self.site_no,
@@ -68,10 +69,10 @@ class TestNwisWebServices(TestCase):
         mock_resp.status_code = 503
         r_mock.return_value = mock_resp
 
-        nwis = NwisWebServices(self.service_root, self.path)
+        nwis = NwisWebServices(self.service_root, self.catalog_root, self.path)
         data = nwis.get_site_parameters(self.site_no, self.agency_cd)
         r_mock.assert_called_with(
-            self.service_root,
+            self.catalog_root,
             path=self.path,
             params={
                 'sites': self.site_no,
@@ -91,7 +92,7 @@ class TestNwisWebServices(TestCase):
         mock_resp.iter_lines.return_value = iter(SITE_RDB.split('\n'))
         r_mock.return_value = mock_resp
 
-        nwis = NwisWebServices(self.service_root, self.path)
+        nwis = NwisWebServices(self.service_root, self.catalog_root, self.path)
         data = nwis.get_huc_sites(self.huc_cd)
         r_mock.assert_called_with(
             self.service_root,
@@ -110,7 +111,7 @@ class TestNwisWebServices(TestCase):
         mock_resp.status_code = 404
         r_mock.return_value = mock_resp
 
-        nwis = NwisWebServices(self.service_root, self.path)
+        nwis = NwisWebServices(self.service_root, self.catalog_root, self.path)
         data = nwis.get_huc_sites(self.huc_cd)
         r_mock.assert_called_with(
             self.service_root,
@@ -130,7 +131,7 @@ class TestNwisWebServices(TestCase):
         mock_resp.iter_lines.return_value = iter(SITE_RDB.split('\n'))
         r_mock.return_value = mock_resp
 
-        nwis = NwisWebServices(self.service_root, self.path)
+        nwis = NwisWebServices(self.service_root, self.catalog_root, self.path)
         data = nwis.get_county_sites(self.county_code)
         r_mock.assert_called_with(
             self.service_root,
@@ -149,7 +150,7 @@ class TestNwisWebServices(TestCase):
         mock_resp.status_code = 500
         r_mock.return_value = mock_resp
 
-        nwis = NwisWebServices(self.service_root, self.path)
+        nwis = NwisWebServices(self.service_root, self.catalog_root, self.path)
         data = nwis.get_county_sites(self.county_code)
         r_mock.assert_called_with(
             self.service_root,

--- a/wdfn-server/waterdata/tests/services/test_nwis.py
+++ b/wdfn-server/waterdata/tests/services/test_nwis.py
@@ -13,7 +13,7 @@ class TestNwisWebServices(TestCase):
 
     def setUp(self):
         self.service_root = 'https://fake.nwis.url.gov'
-        self.catalog_root= 'https://fake.nwis.catalog.usgs.gov'
+        self.catalog_root = 'https://fake.nwis.catalog.usgs.gov'
         self.path = '/some/path/'
         self.site_no = '029055631'
         self.agency_cd = 'ABYZ'

--- a/wdfn-server/waterdata/views.py
+++ b/wdfn-server/waterdata/views.py
@@ -18,8 +18,7 @@ from .services.camera import get_monitoring_location_camera_details
 # Station Fields Mapping to Descriptions
 from .constants import STATION_FIELDS_D
 
-SERVICE_ROOT = app.config['SERVER_SERVICE_ROOT']
-NWIS = NwisWebServices(SERVICE_ROOT)
+NWIS = NwisWebServices(app.config['SERVER_SERVICE_ROOT'], app.config['SITE_SERVICE_CATALOG_ROOT'])
 
 
 @app.route('/')


### PR DESCRIPTION
Before making a pull request
----------------------------

- [X] Make sure all tests run
- [X] Update the changelog appropriately

Title
-----------
 Allow for selecting parameters that are only 'field visit' groundwater levels

Description
-----------
I am now adding the groundwater variables to the list of variables in ivTimeSeriesData in the Redux store. This was the most
expedient way to allow display of these parameters in the parameter selection table. If we do the refactor of the way we store IV data we should think about separating out the data from the metadata for a particular kind of data.

I also added a new configuration parameter , SITE_SERVICE_CATALOG_ROOT so that I could use our QA service for the service catalog while continuing to use production services for the IV data retrieval. The QA service has the new groundwater level data. For production, this should be set to the production service and should be the same as SERVICE_ROOT.

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
