### PR TITLE
Iow 853 - add discrete groundwater levels to little brush graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added Beta tags for Groundwater Data and Affiliated Networks sections
 - Added sticky tab for questions and comments.
 - Added tooltips for the field visit circles
+- Added field visit circles to brush
 
 ### Changed
 - Camera metadata is now fetched and the client is using html5 video when video format is supported, otherwise the most recent image is shown.

--- a/assets/src/scripts/monitoring-location/components/hydrograph/discrete-data.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/discrete-data.js
@@ -11,10 +11,13 @@ const GW_LEVEL_CLASS = 'gw-level-point';
  * @param {D3 scale} xScale
  * @param {D3 scale } yScale
  */
-export const drawGroundwaterLevels = function(svg, {levels, xScale, yScale}) {
+export const drawGroundwaterLevels = function(svg, {levels, xScale, yScale, enableClip}) {
     svg.selectAll('#iv-graph-gw-levels-group').remove();
     const group = svg.append('g')
         .attr('id', 'iv-graph-gw-levels-group');
+    if (enableClip) {
+        group.attr('clip-path', 'url(#graph-clip)');
+    }
 
     levels.forEach((level) => {
         group.append('circle')

--- a/assets/src/scripts/monitoring-location/components/hydrograph/graph-brush.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/graph-brush.js
@@ -12,9 +12,11 @@ import {Actions} from 'ml/store/instantaneous-value-time-series-state';
 import {getBrushXAxis} from './selectors/axes';
 import {getCurrentVariableLineSegments} from './selectors/drawing-data';
 import {getBrushLayout} from './selectors/layout';
-import {getBrushXScale, getBrushYScale} from './selectors/scales';
+import {getBrushXScale, getBrushYScale, getMainXScale, getMainYScale} from './selectors/scales';
 import {isVisible} from './selectors/time-series-data';
 import {drawDataLines} from './time-series-lines';
+import {drawGroundwaterLevels} from "./discrete-data";
+import {getVisibleGroundWaterLevelPoints} from "./selectors/discrete-data";
 
 
 /*
@@ -90,6 +92,12 @@ export const drawGraphBrush = function(container, store) {
                     xScale: getBrushXScale('current'),
                     yScale: getBrushYScale,
                     tsKey: () => 'current',
+                    enableClip: () => false
+                })))
+                .call(link(store, drawGroundwaterLevels, createStructuredSelector({
+                    levels: getVisibleGroundWaterLevelPoints,
+                    xScale: getBrushXScale('current'),
+                    yScale: getBrushYScale,
                     enableClip: () => false
                 })));
         })

--- a/assets/src/scripts/monitoring-location/components/hydrograph/selectors/scales.test.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/selectors/scales.test.js
@@ -3,7 +3,7 @@ import {DateTime} from 'luxon';
 
 import * as utils from 'ui/utils';
 
-import {createXScale, createYScale, getMainYScale, getBrushYScale, getSecondaryYScale} from './scales';
+import {createXScale, createYScale, getTimeRange, getMainYScale, getBrushYScale} from './scales';
 
 
 describe('monitoring-location/components/hydrograph/scales', () => {
@@ -102,6 +102,62 @@ describe('monitoring-location/components/hydrograph/scales', () => {
 
         expect(linear10 - linear20).toBeCloseTo(linear20 - linear30);
         expect(singleLinear10 - singleLinear20).toBeCloseTo(singleLinear20 - singleLinear30);
+    });
+
+    describe('getTimeRange', () => {
+        const TEST_STATE = {
+            ianaTimeZone: 'America/Chicago',
+            ivTimeSeriesData: {
+                queryInfo: {
+                    'current:P7D': {
+                        notes: {
+                            requestDT: 1490936400000,
+                            'filter:timeRange': {
+                                mode: 'PERIOD',
+                                periodDays: 7,
+                                modifiedSince: null
+                            }
+                        }
+                    }
+                }
+            },
+            ivTimeSeriesState: {
+                currentIVDateRange: 'P7D',
+                ivGraphBrushOffset: null
+            }
+        };
+
+        it('Return full time range if not brush offset is set for both BRUSH and MAIN', () => {
+            expect(getTimeRange('BRUSH', 'current')(TEST_STATE)).toEqual({
+                start: 1490331600000,
+                end: 1490936400000
+            });
+            expect(getTimeRange('MAIN', 'current')(TEST_STATE)).toEqual({
+                start: 1490331600000,
+                end: 1490936400000
+            });
+        });
+
+        it('Return the full time range for BRUSH but reduce MAIN by brush offset', () => {
+            const testState = {
+                ...TEST_STATE,
+                ivTimeSeriesState: {
+                    ...TEST_STATE.ivTimeSeriesState,
+                    ivGraphBrushOffset: {
+                        start: 100000,
+                        end: 900000
+                    }
+                }
+            };
+            expect(getTimeRange('BRUSH', 'current')(testState)).toEqual({
+                start: 1490331600000,
+                end: 1490936400000
+            });
+            expect(getTimeRange('MAIN', 'current')(testState)).toEqual({
+                start: 1490331700000,
+                end: 1490935500000
+            });
+        });
     });
 
     describe('getMainYScale', () => {

--- a/assets/src/scripts/monitoring-location/components/hydrograph/time-series-graph.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/time-series-graph.js
@@ -274,7 +274,8 @@ export const drawTimeSeriesGraph = function(elem, store, siteNo, showMLName, sho
         .call(link(store, drawGroundwaterLevels, createStructuredSelector({
             levels: getVisibleGroundWaterLevelPoints,
             xScale: getMainXScale('current'),
-            yScale: getMainYScale
+            yScale: getMainYScale,
+            enableClip: () => true
         })))
         .call(link(store, plotAllFloodLevelPoints, createStructuredSelector({
             visible: isWaterwatchVisible,

--- a/assets/src/scripts/monitoring-location/components/hydrograph/time-series-graph.test.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/time-series-graph.test.js
@@ -84,7 +84,7 @@ const TEST_STATE = {
                         mode: 'PERIOD',
                         periodDays: 7
                     },
-                    requestDT: 1522425600000
+                    requestDT: 1514926800000
                 }
             }
         },
@@ -236,8 +236,8 @@ describe('monitoring-location/components/hydrograph/time-series-graph', () => {
 
             expect(svg.select('title').html()).toEqual('Test title for 00060, method description');
             expect(descText).toContain('Test description for 00060');
-            expect(descText).toContain('3/23/2018');
-            expect(descText).toContain('3/30/2018');
+            expect(descText).toContain('12/26/2017');
+            expect(descText).toContain('1/2/2018');
             expect(svg.attr('aria-labelledby')).toContain('title');
             expect(svg.attr('aria-describedby')).toContain('desc');
         });
@@ -364,7 +364,7 @@ describe('monitoring-location/components/hydrograph/time-series-graph', () => {
 
              expect(div.selectAll('.tooltip-text-group').size()).toBe(1);
              expect(div.selectAll('.focus-overlay').size()).toBe(1);
-             expect(div.selectAll('.focus-circle').size()).toBe(2);
+             expect(div.selectAll('.focus-circle').size()).toBe(1);
              expect(div.selectAll('.focus-line').size()).toBe(1);
         });
     });

--- a/assets/src/scripts/monitoring-location/components/hydrograph/tooltip.test.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/tooltip.test.js
@@ -33,6 +33,7 @@ describe('monitoring-location/components/hydrograph/tooltip module', () => {
     data = data.concat(maskedData);
 
     const testState = {
+        ianaTimeZone: 'America/Chicago',
         ivTimeSeriesData: {
             timeSeries: {
                 '69928:current:P7D': {
@@ -115,7 +116,7 @@ describe('monitoring-location/components/hydrograph/tooltip module', () => {
                             mode: 'RANGE',
                             interval: {
                                 start: new Date('2018-01-03T12:00:00.000Z').getTime(),
-                                end: new Date('2018-01-03T16:00:00.000Z').getTime()
+                                end: new Date('2018-01-04T16:00:00.000Z').getTime()
                             }
                         }
                     }
@@ -348,14 +349,14 @@ describe('monitoring-location/components/hydrograph/tooltip module', () => {
                     })
                 }),
                 ivTimeSeriesState: Object.assign({}, testState.ivTimeSeriesState, {
-                    ivGraphCursorOffset: null
+                    ivGraphCursorOffset: 3 * 60 * 60 * 1000
                 })
             }));
 
             svg.call(drawTooltipFocus, store);
 
             expect(svg.selectAll('.focus-line').size()).toBe(1);
-            expect(svg.selectAll('.focus-circle').size()).toBe(3);
+            expect(svg.selectAll('.focus-circle').size()).toBe(2);
             expect(svg.select('.focus-overlay').size()).toBe(1);
         });
 
@@ -378,14 +379,14 @@ describe('monitoring-location/components/hydrograph/tooltip module', () => {
                     })
                 }),
                 ivTimeSeriesState: Object.assign({}, testState.ivTimeSeriesState, {
-                    ivGraphCursorOffset: 39 * 60 * 1000
+                    ivGraphCursorOffset: 3 * 60 * 60 * 1000
                 })
             }));
 
             svg.call(drawTooltipFocus, store);
 
             expect(svg.selectAll('.focus-line').size()).toBe(1);
-            expect(svg.selectAll('.focus-circle').size()).toBe(3);
+            expect(svg.selectAll('.focus-circle').size()).toBe(2);
             expect(svg.select('.focus-overlay').size()).toBe(1);
         });
     });

--- a/assets/src/scripts/monitoring-location/selectors/time-series-selector.js
+++ b/assets/src/scripts/monitoring-location/selectors/time-series-selector.js
@@ -33,6 +33,8 @@ export const getCurrentDateRange = (state) => {
     return state.ivTimeSeriesState.currentIVDateRange || null;
 };
 
+export const getIVGraphBrushOffset = state => state.ivTimeSeriesState.ivGraphBrushOffset || null;
+
 export const getLoadingTsKeys = state => state.ivTimeSeriesState.loadingIVTSKeys || [];
 
 export const getNwisTimeZone = state => state.ivTimeSeriesData.timeZones || {};

--- a/assets/src/scripts/monitoring-location/selectors/time-series-selector.test.js
+++ b/assets/src/scripts/monitoring-location/selectors/time-series-selector.test.js
@@ -5,6 +5,7 @@ import {
     getSiteCodes,
     getCurrentVariableID,
     getCurrentDateRange,
+    getIVGraphBrushOffset,
     getTimeSeries,
     hasAnyTimeSeries,
     hasAnyVariables,
@@ -524,6 +525,28 @@ describe('monitoring-location/selectors/time-series-selector', () => {
                     currentIVDateRange: 'P30D'
                 }
             })).toEqual('P30D');
+        });
+    });
+
+    describe('getIVGraphBrushOffset', () => {
+        it('Return null if no ivGraphBrushOffset defined', () => {
+            expect(getIVGraphBrushOffset({
+                ivTimeSeriesState: {}
+            })).toBeNull();
+        });
+
+        it('Return the current date range', () => {
+            expect(getIVGraphBrushOffset({
+                ivTimeSeriesState: {
+                    ivGraphBrushOffset: {
+                        start:  1580318458000,
+                        end: 1611940858000
+                    }
+                }
+            })).toEqual({
+                start:  1580318458000,
+                end: 1611940858000
+            });
         });
     });
 


### PR DESCRIPTION
Before making a pull request
----------------------------

- [X] Make sure all tests run
- [X] Update the changelog appropriately

Title
-----------
Add discrete groundwater levels to little brush graph

Description
-----------
I also fixed an issue where focus circles could potentially appear of of the graph. We needed to filter the set of points used in the getNearestTime function to those that are in the domain of the main graph which can vary as the brush varies.

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the JIRA ticket
- [ ] Assign someone to review unless the change is trivial
