### PR TITLE
Wdfn 483 flood stage legend shows nan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased](https://github.com/usgs/waterdataui/compare/waterdataui-0.42.0...master)
 ### Fixed
 - The converted Fahrenheit line no longer drops off graph with zero values.
+- Locations with only some flood level indicators no longer show  NaN
+
 ## [0.42.0](https://github.com/usgs/waterdataui/compare/waterdataui-0.40.0...waterdataui-0.42.0)
 ### Added
 - Added display of discrete ground water level data on the IV hydrograph.

--- a/assets/src/scripts/monitoring-location/components/hydrograph/legend.test.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/legend.test.js
@@ -17,8 +17,6 @@ describe('monitoring-location/components/hydrograph/legend module', () => {
             timeSeries: {
                 '00060:current': {
                     tsKey: 'current:P7D',
-                    startTime: new Date('2018-03-06T15:45:00.000Z'),
-                    endTime: new Date('2018-03-13T13:45:00.000Z'),
                     variable: '45807197',
                     points: [{
                         value: 10,
@@ -36,55 +34,19 @@ describe('monitoring-location/components/hydrograph/legend module', () => {
                         approved: false,
                         estimated: false
                     }]
-                },
-                '00060:compare': {
-                    tsKey: 'compare:P7D',
-                    startTime: new Date('2018-03-06T15:45:00.000Z'),
-                    endTime: new Date('2018-03-06T15:45:00.000Z'),
-                    variable: '45807202',
-                    points: [{
-                        value: 1,
-                        qualifiers: ['A'],
-                        approved: false,
-                        estimated: false
-                    }, {
-                        value: 2,
-                        qualifiers: ['A'],
-                        approved: false,
-                        estimated: false
-                    }, {
-                        value: 3,
-                        qualifiers: ['E'],
-                        approved: false,
-                        estimated: false
-                    }]
                 }
             },
             variables: {
                 '45807197': {
                     variableCode: {value: '00060'},
-                    variableName: 'Streamflow',
-                    variableDescription: 'Discharge, cubic feet per second',
                     oid: '45807197'
-                },
-                '45807202': {
-                    variableCode: {value: '00065'},
-                    variableName: 'Gage height',
-                    oid: '45807202'
                 }
             }
         },
         statisticsData: {
             median: {
                 '00060': {
-                    '1': [{
-                        month_nu: '2',
-                        day_nu: '25',
-                        p50_va: '43',
-                        begin_yr: '1970',
-                        end_yr: '2017',
-                        loc_web_ds: 'This method'
-                    }]
+                    '1': [{ }]
                 }
             }
         },
@@ -93,17 +55,7 @@ describe('monitoring-location/components/hydrograph/legend module', () => {
             currentIVDateRange: 'P7D',
             showIVTimeSeries: {
                 current: true,
-                compare: true,
                 median: true
-            }
-        },
-        floodData: {
-            floodLevels: {
-                site_no: '07144100',
-                action_stage: null,
-                flood_stage: '22',
-                moderate_flood_stage: '25',
-                major_flood_stage: '26'
             }
         }
     };

--- a/assets/src/scripts/monitoring-location/components/hydrograph/legend.test.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/legend.test.js
@@ -37,7 +37,6 @@ describe('monitoring-location/components/hydrograph/legend module', () => {
                         estimated: false
                     }]
                 },
-
                 '00060:compare': {
                     tsKey: 'compare:P7D',
                     startTime: new Date('2018-03-06T15:45:00.000Z'),
@@ -101,7 +100,7 @@ describe('monitoring-location/components/hydrograph/legend module', () => {
         floodData: {
             floodLevels: {
                 site_no: '07144100',
-                action_stage: '20',
+                action_stage: null,
                 flood_stage: '22',
                 moderate_flood_stage: '25',
                 major_flood_stage: '26'

--- a/assets/src/scripts/monitoring-location/components/hydrograph/selectors/legend-data.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/selectors/legend-data.js
@@ -121,7 +121,9 @@ const floodLevelDisplay = function(floodLevels) {
     let floodLevelsForDisplay = {};
     Object.keys(floodLevels).forEach(key => {
         if (!isNaN(floodLevels[key])) {
-            const label = key.match(/([A-Z]?[^A-Z]*)/g).slice(0,-1);
+            const keyWithCapitalFirstLetter = `${key.charAt(0).toUpperCase()}${key.slice(1)}`;
+            // Format label by cutting at the camel case word at upper case letters
+            const label = keyWithCapitalFirstLetter.match(/([A-Z]?[^A-Z]*)/g).slice(0,-1);
 
             Object.assign(floodLevelsForDisplay,
                 {[key]: {

--- a/assets/src/scripts/monitoring-location/components/hydrograph/selectors/legend-data.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/selectors/legend-data.js
@@ -120,9 +120,9 @@ const getMedianMarkers = function(medianMetaData) {
 const floodLevelDisplay = function(floodLevels) {
     let floodLevelsForDisplay = {};
     Object.keys(floodLevels).forEach(key => {
-        if (!isNaN(floodLevels[key])) {
+        if (floodLevels[key]) {
             const keyWithCapitalFirstLetter = `${key.charAt(0).toUpperCase()}${key.slice(1)}`;
-            // Format label by cutting at the camel case word at upper case letters
+            // Format label by cutting the camel case word at upper case letters
             const label = keyWithCapitalFirstLetter.match(/([A-Z]?[^A-Z]*)/g).slice(0,-1);
 
             Object.assign(floodLevelsForDisplay,

--- a/assets/src/scripts/monitoring-location/components/hydrograph/selectors/legend-data.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/selectors/legend-data.js
@@ -117,31 +117,33 @@ const getMedianMarkers = function(medianMetaData) {
     });
 };
 
-const getFloodLevelMarkers = function(floodLevels) {
-    const FLOOD_LEVEL_DISPLAY = {
-        actionStage: {
-            label: 'Action Stage',
-            class: 'action-stage'
-        },
-        floodStage: {
-            label: 'Flood Stage',
-            class: 'flood-stage'
-        },
-        moderateFloodStage: {
-            label: 'Moderate Flood Stage',
-            class: 'moderate-flood-stage'
-        },
-        majorFloodStage: {
-            label: 'Major Flood Stage',
-            class: 'major-flood-stage'
+const floodLevelDisplay = function(floodLevels) {
+    let floodLevelsForDisplay = {};
+    Object.keys(floodLevels).forEach(key => {
+        if (!isNaN(floodLevels[key])) {
+            const label = key.match(/([A-Z]?[^A-Z]*)/g).slice(0,-1);
+
+            Object.assign(floodLevelsForDisplay,
+                {[key]: {
+                    'label': [label.join(' ')],
+                    'class': [label.join('-').toLowerCase()]
+                }}
+            );
         }
-    };
-    return Object.keys(floodLevels).map((stage) => {
+    });
+
+    return floodLevelsForDisplay;
+};
+
+const getFloodLevelMarkers = function(floodLevels) {
+    const floodLevelsForDisplay = floodLevelDisplay(floodLevels);
+
+    return Object.keys(floodLevelsForDisplay).map((stage) => {
         return [
-            defineTextOnlyMarker(FLOOD_LEVEL_DISPLAY[stage].label),
+            defineTextOnlyMarker(floodLevelsForDisplay[stage].label),
             defineLineMarker(
                 null,
-                `waterwatch-data-series ${FLOOD_LEVEL_DISPLAY[stage].class}`,
+                `waterwatch-data-series ${floodLevelsForDisplay[stage].class}`,
                 `${floodLevels[stage]} ft`)
         ];
     });

--- a/assets/src/scripts/monitoring-location/components/hydrograph/selectors/legend-data.test.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/selectors/legend-data.test.js
@@ -122,7 +122,7 @@ describe('monitoring-location/components/hydrograph/selectors/legend-data', () =
         floodData: {
             floodLevels: {
                 site_no: '07144100',
-                action_stage: '20',
+                action_stage: null,
                 flood_stage: '22',
                 moderate_flood_stage: '25',
                 major_flood_stage: '26'
@@ -172,7 +172,7 @@ describe('monitoring-location/components/hydrograph/selectors/legend-data', () =
             };
             const result = getLegendMarkerRows(newData);
 
-            expect(result).toHaveLength(5);
+            expect(result).toHaveLength(4);
             expect(result[0]).toHaveLength(3);
             expect(result[0][0].type).toEqual(textOnlyMarker);
             expect(result[0][1].type).toEqual(lineMarker);


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [x] Update the changelog appropriately

WDFN-483 Flood Stage Legend Shows NaN
-----------
Fixed the NaN problem

Description
-----------
Not all monitoring locations that have flood stage information have information for the four major alert levels. These changes add only the alert levels active at a location to the legend. 

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
