### PR TITLE
Wdfn 499 - add date-controls back to hydrograph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/usgs/waterdataui/compare/waterdataui-0.42.0...master)
+### Fixed
+- The converted Fahrenheit line no longer drops off graph with zero values.
 ## [0.42.0](https://github.com/usgs/waterdataui/compare/waterdataui-0.40.0...waterdataui-0.42.0)
 ### Added
 - Added display of discrete ground water level data on the IV hydrograph.

--- a/assets/src/scripts/monitoring-location/components/hydrograph/date-controls.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/date-controls.js
@@ -1,15 +1,14 @@
+import {select} from 'd3-selection';
 import {DateTime} from 'luxon';
-import {createStructuredSelector} from 'reselect';
 // required to make the USWDS component JS available to init after page load
 import components from 'uswds/src/js/components';
 
 import config from 'ui/config';
-import {link} from 'ui/lib/d3-redux';
 
-import {getInputsForRetrieval, getSelectedDateRange, getSelectedCustomTimeRange} from 'ml/selectors/hydrograph-state-selector';
+import {getInputsForRetrieval} from 'ml/selectors/hydrograph-state-selector';
 
 import {retrieveHydrographData} from 'ml/store/hydrograph-data';
-import {clearGraphBrushOffset, setSelectedCustomTimeRange, setSelectedDateRange} from 'ml/store/hydrograph-state';
+import {clearGraphBrushOffset, setSelectedDateRange, setSelectedCustomDateRange} from 'ml/store/hydrograph-state';
 
 const DATE_RANGE = [{
     name: '7 days',
@@ -22,356 +21,300 @@ const DATE_RANGE = [{
     period: 'P365D'
 }, {
     name: 'Custom',
-    period: 'custom',
-    ariaExpanded: false
+    period: 'custom'
 }];
 const CUSTOM_TIMEFRAME_RADIO_BUTTON_DETAILS = [
     {
         id: 'custom-input-days-before-today',
         value: 'days',
-        text: 'Days before today',
-        ariaExpanded: false
+        text: 'Days before today'
     },
     {
         id: 'custom-input-calendar-days',
         value: 'calendar',
-        text: 'Calendar days',
-        ariaExpanded: false
+        text: 'Calendar days'
     }
 ];
 
 const isCustomPeriod = function(dateRange) {
     return dateRange !== 'custom' && !DATE_RANGE.find(range => range.period === dateRange);
-}
+};
+const isCustomDateRange = function(dateRange) {
+    return dateRange === 'custom';
+};
 const showCustomContainer = function(dateRange) {
-    return dateRange === 'custom' ? true : !DATE_RANGE.find(range => range.period === dateRange);
-}
+    return isCustomPeriod(dateRange) || isCustomDateRange(dateRange);
+};
 
-export const drawDateRangeControls = function(elem, store, siteno, initialPeriod, initialStartTime, initialEndTime) {
-    let isCustomPeriod = false;
-    let isCustomCalendarDays = false;
-    if (initialPeriod) {
-        store.dispatch(setSelectedDateRange(initialPeriod));
-        isCustomPeriod = !DATE_RANGE.find(range => range.period === period);
-    } else if (initialStartTime && initialEndTime) {
-        isCustomCalendarDays = true;
-        store.dispatch(setSelectedCustomTimeRange(
-            DateTime.fromISO(initialStartTime, {zone: config.locationTimeZone}).toMillis(),
-            DateTime.fromISO(initialEndTime, {zone: config.locationTimeZone}).toMillis()));
+const setCustomFormVisibility = function(showCustom) {
+    const customContainer = select('#container-radio-group-and-form-buttons');
+    customContainer.attr('hidden', showCustom ? null : true);
+    // Clear text inputs if form is not visible
+    if (!showCustom) {
+        customContainer.selectAll('input[type="text"]').property('value', '');
     }
-    const isCustomSelected = isCustomPeriod || isCustomCalendarDays;
+};
 
-    const containerRadioGroupMainSelectButtons = elem.insert('div', ':nth-child(2)')
-        .attr('id', 'ts-daterange-select-container')
-        .attr('role', 'radiogroup')
-        .attr('aria-label', 'Time interval select');
+const drawSelectRadioButtons = function(elem, store, siteno, initialDateRange) {
+    const listContainer = elem.append('ul')
+        .attr('class', 'usa-fieldset usa-list--unstyled');
 
-    // Add a container that holds the custom selection radio buttons and the form fields
-    const containerRadioGroupAndFormButtons = elem.insert('div', ':nth-child(3)')
-        .attr('class', 'container-radio-group-and-form-buttons')
-        .attr('hidden', isCustomSelected ? null : true);
+    const li = listContainer.selectAll('li')
+        .attr('class', 'usa-fieldset')
+        .data(DATE_RANGE)
+        .enter().append('li');
 
-    const containerRadioGroupCustomSelectButtons = containerRadioGroupAndFormButtons.append('div')
+    li.append('input')
+        .attr('type', 'radio')
+        .attr('name', 'ts-daterange-input')
+        .attr('id', d => `${d.period}-input`)
+        .attr('class', 'usa-radio__input')
+        .property('value', d => d.period)
+        .attr('ga-on', 'click')
+        .attr('ga-event-category', 'TimeSeriesGraph')
+        .attr('ga-event-action', d => `changeDateRangeTo${d.period}`)
+        .property('checked', d => d.period === initialDateRange || d.period === 'custom' && isCustomPeriod(initialDateRange))
+        .on('change', function() {
+            const checkedButton = li.select('input:checked');
+            const selectedValue = checkedButton.property('value');
+            const isCustom = selectedValue === 'custom';
+            setCustomFormVisibility(isCustom);
+            li.select('#custom-input').attr('aria-expanded', isCustom);
+            if (!isCustom) {
+                store.dispatch(setSelectedDateRange(selectedValue));
+                store.dispatch(retrieveHydrographData(siteno, getInputsForRetrieval(store.getState())));
+            }
+        });
+    li.select('#custom-input').attr('aria-expanded', isCustomPeriod(initialDateRange));
+
+    li.append('label')
+        .attr('class', 'usa-radio__label')
+        .attr('for', (d) => `${d.period}-input`)
+        .text((d) => d.name);
+};
+
+const drawCustomRadioButtons = function(container, initialDateRange) {
+    const radioButtonContainer = container.append('div')
         .attr('id', 'ts-custom-date-radio-group')
         .attr('role', 'radiogroup')
         .attr('aria-label', 'Custom time interval select');
+    radioButtonContainer.append('p').text('Enter timespan using');
+    const listContainer = radioButtonContainer.append('ul')
+            .attr('class', 'usa-fieldset usa-list--unstyled');
+    const radioButtonListItem = listContainer.selectAll('li')
+        .attr('class', 'usa-fieldset')
+        .data(CUSTOM_TIMEFRAME_RADIO_BUTTON_DETAILS)
+        .enter()
+        .append('li');
 
-    const containerCustomDaysBeforeToday = containerRadioGroupAndFormButtons.append('div')
+    radioButtonListItem.append('input')
+        .attr('type', 'radio')
+        .attr('name', 'ts-custom-daterange-input')
+        .attr('id', d => `${d.value}-input`)
+        .attr('class', 'usa-radio__input')
+        .property('value', d => d.value)
+        .property('checked', d => d.value === 'calendar' ? initialDateRange === 'custom' : initialDateRange !== 'custom')
+        .attr('ga-on', 'click')
+        .attr('aria-expanded', d => d.value === 'calendar' ? initialDateRange === 'custom' : initialDateRange !== 'custom')
+        .attr('ga-event-category', 'TimeSeriesGraph')
+        .attr('ga-event-action', d => `changeDateRangeWith${d.value}`)
+        .on('change', function(_, d) {
+            container.select('#days-input').attr('aria-expanded', d.value === 'days');
+            container.select('#calendar-input').attr('aria-expanded', d.value === 'calendar');
+            container.select('#ts-custom-days-before-today-select-container')
+                .attr('hidden', d.value === 'days' ? null : true);
+            container.select('#ts-customdaterange-select-container')
+                .attr('hidden', d.value === 'calendar' ? null : true);
+        });
+        radioButtonListItem.append('label')
+            .attr('class', 'usa-radio__label')
+            .attr('for', (d) => `${d.value}-input`)
+            .text((d) => d.text);
+};
+
+const drawCustomDaysBeforeForm = function(container, store, siteno, initialDateRange) {
+    const formContainer = container.append('div')
         .attr('id', 'ts-custom-days-before-today-select-container')
         .attr('class', 'usa-form')
         .attr('aria-label', 'Custom date by days before today specification')
-        .attr('hidden', isCustomCalendarDays ? true : null);
+        .attr('hidden', initialDateRange === 'custom' ? true : null);
 
-    const containerCustomCalendarDays = containerRadioGroupAndFormButtons.append('div')
+    const daysBeforeContainer = formContainer.append('div')
+            .attr('class', 'usa-character-count')
+            .append('div')
+            .attr('class', 'usa-form-group');
+    daysBeforeContainer.append('label')
+        .attr('class', 'usa-label')
+        .attr('for', 'with-hint-input-days-from-today' )
+        .text('Days');
+    daysBeforeContainer.append('span')
+        .attr('id', 'with-hint-input-days-from-today-hint')
+        .attr('class', 'usa-hint')
+        .text('Timespan in days before today');
+    daysBeforeContainer.append('input')
+        .attr('class', 'usa-input usa-character-count__field')
+        .attr('type', 'text')
+        .attr('id', 'with-hint-input-days-from-today')
+        .attr('maxlength', `${config.MAX_DIGITS_FOR_DAYS_FROM_TODAY}`)
+        .attr('name', 'with-hint-input-days-from-today')
+        .property('value', isCustomPeriod(initialDateRange) ? initialDateRange.slice(1, -1) : '')
+        .attr('aria-describedby', 'with-hint-input-days-from-today-info with-hint-input-days-from-today-hint');
+
+    daysBeforeContainer.append('span')
+        .text(`${config.MAX_DIGITS_FOR_DAYS_FROM_TODAY} digits allowed`)
+        .attr('id', 'with-hint-input-days-from-today-info')
+        .attr('class', 'usa-hint usa-character-count__message')
+        .attr('aria-live', 'polite');
+    // Create a validation alert for user selection of number of days before today
+    const daysBeforeValidationContainer = daysBeforeContainer.append('div')
+        .attr('class', 'usa-alert usa-alert--warning usa-alert--validation')
+        .attr('id', 'custom-days-before-today-alert-container')
+        .attr('hidden', true);
+    const daysBeforeAlertBody = daysBeforeValidationContainer.append('div')
+        .attr('class', 'usa-alert__body')
+        .attr('id', 'custom-days-before-today-alert');
+    daysBeforeAlertBody.append('h3')
+        .attr('class', 'usa-alert__heading')
+        .text('Requirements');
+
+    // Adds controls for the 'days before today' submit button
+    const daysBeforeSubmitContainer = daysBeforeContainer.append('div')
+        .attr('class', 'submit-button');
+    daysBeforeSubmitContainer.append('button')
+        .attr('class', 'usa-button')
+        .attr('id', 'custom-date-submit-days')
+        .attr('ga-on', 'click')
+        .attr('ga-event-category', 'TimeSeriesGraph')
+        .attr('ga-event-action', 'customDaysSubmit')
+        .text('Display data on graph')
+        .on('click', function() {
+            const daysBefore = daysBeforeContainer.select('#with-hint-input-days-from-today').property('value');
+            // Validate user input for things not a number and blank entries
+            if (isNaN(daysBefore) || daysBefore.length === 0) {
+                daysBeforeAlertBody.selectAll('p').remove();
+                daysBeforeAlertBody.append('p')
+                    .text('Entry must be a number.');
+                daysBeforeValidationContainer.attr('hidden', null);
+            } else {
+                daysBeforeValidationContainer.attr('hidden', true);
+                store.dispatch(setSelectedDateRange(`P${parseInt(daysBefore)}D`));
+                store.dispatch(retrieveHydrographData(siteno, getInputsForRetrieval(store.getState())))
+                    .then(() => store.dispatch(clearGraphBrushOffset()));
+            }
+        });
+};
+
+const drawDatePicker = function(container, id, label, initialDate) {
+    container.append('label')
+        .attr('class', 'usa-label')
+        .attr('id', `${id}-label`)
+        .attr('for', id)
+        .text(label);
+
+    container.append('div')
+        .attr('class', 'usa-hint')
+        .attr('id', `${id}-hint`)
+        .text('mm/dd/yyyy')
+        .append('div')
+            .attr('class', 'usa-date-picker')
+            .attr('data-default-value', initialDate)
+            .attr('data-min-date', '1900-01-01')
+            .attr('data-max-date', '2100-12-31')
+            .append('input')
+                .attr('class', 'usa-input')
+                .attr('type', 'text')
+                .attr('id', id)
+                .attr('name', id)
+                .attr('aria-describedby', `${id}-label ${id}-hint`)
+                .attr('type', 'text');
+};
+
+const drawCustomCalendarDaysForm = function(container, store, siteno, initialDateRange, initialCustomDateRange) {
+    const calendarDaysContainer = container.append('div')
         .attr('id', 'ts-customdaterange-select-container')
         .attr('role', 'customdate')
         .attr('class', 'usa-form')
         .attr('aria-label', 'Custom date specification')
-        .attr('hidden', isCustomCalendarDays ? null : true);
+        .attr('hidden', initialDateRange === 'custom' ? null : true);
 
-    const createRadioButtonsForCustomDaterangeSelection = function(containerRadioGroupCustomSelectButtons) {
-        containerRadioGroupCustomSelectButtons.append('p').text('Enter timespan using');
-        const listContainerForCustomSelectRadioButtons = containerRadioGroupCustomSelectButtons.append('ul')
-            .attr('class', 'usa-fieldset usa-list--unstyled');
-        const listItemForCustomSelectRadioButtons  = listContainerForCustomSelectRadioButtons.selectAll('li')
-            .attr('class', 'usa-fieldset')
-            .data(CUSTOM_TIMEFRAME_RADIO_BUTTON_DETAILS)
-            .enter()
-            .append('li');
-        listItemForCustomSelectRadioButtons.append('input')
-            .attr('type', 'radio')
-            .attr('name', 'ts-custom-daterange-input')
-            .attr('id', d => `${d.value}-input`)
-            .attr('class', 'usa-radio__input')
-            .attr('value', d => d.value)
-            .property('checked', d => d.value === 'days' && !isCustomCalendarDays || isCustomCalendarDays)
-            .attr('ga-on', 'click')
-            .attr('aria-expanded', d => d.value === 'days' && !isCustomCalendarDays || isCustomCalendarDays)
-            .attr('ga-event-category', 'TimeSeriesGraph')
-            .attr('ga-event-action', d => `changeDateRangeWith${d.value}`)
-            .on('change', function(_, d) {
-                containerCustomDaysBeforeToday.attr('hidden', d.value === 'days' ? null : true);
-                containerCustomCalendarDays.attr('hidden', d.value === 'calendar' ? null : true);
-            });
-        listItemForCustomSelectRadioButtons.append('label')
-            .attr('class', 'usa-radio__label')
-            .attr('for', (d) => `${d.value}-input`)
-            .text((d) => d.text);
-    };
-
-    const createControlsForSelectingTimeSpanInDaysFromToday = function() {
-        const numberOfDaysSelection = containerCustomDaysBeforeToday.append('div')
-            .attr('class', 'usa-character-count')
-            .append('div')
-            .attr('class', 'usa-form-group');
-        numberOfDaysSelection.append('label')
-            .attr('class', 'usa-label')
-            .attr('for', 'with-hint-input-days-from-today' )
-            .text('Days');
-        numberOfDaysSelection.append('span')
-            .attr('id', 'with-hint-input-days-from-today-hint')
-            .attr('class', 'usa-hint')
-            .text('Timespan in days before today');
-        numberOfDaysSelection.append('input')
-            .attr('class', 'usa-input usa-character-count__field')
-            .attr('id', 'with-hint-input-days-from-today')
-            .attr('maxlength', `${config.MAX_DIGITS_FOR_DAYS_FROM_TODAY}`)
-            .attr('name', 'with-hint-input-days-from-today')
-            .attr('value', isCustomPeriod ? initialPeriod.slice(1, -2) : '')
-            .attr('aria-describedby', 'with-hint-input-days-from-today-info with-hint-input-days-from-today-hint');
-
-        numberOfDaysSelection.append('span')
-            .text(`${config.MAX_DIGITS_FOR_DAYS_FROM_TODAY} digits allowed`)
-            .attr('id', 'with-hint-input-days-from-today-info')
-            .attr('class', 'usa-hint usa-character-count__message')
-            .attr('aria-live', 'polite');
-        // Create a validation alert for user selection of number of days before today
-        const customDaysBeforeTodayValidationContainer = containerCustomDaysBeforeToday.append('div')
-            .attr('class', 'usa-alert usa-alert--warning usa-alert--validation')
-            .attr('id', 'custom-days-before-today-alert-container')
-            .attr('hidden', true);
-        const customDaysBeforeTodayAlertBody = customDaysBeforeTodayValidationContainer.append('div')
-            .attr('class', 'usa-alert__body')
-            .attr('id', 'custom-days-before-today-alert');
-        customDaysBeforeTodayAlertBody.append('h3')
-            .attr('class', 'usa-alert__heading')
-            .text('Requirements');
-
-        // Adds controls for the 'days before today' submit button
-        const daysBeforeTodaySubmitContainer = containerCustomDaysBeforeToday.append('div')
-            .attr('class', 'submit-button');
-        daysBeforeTodaySubmitContainer.append('button')
-            .attr('class', 'usa-button')
-            .attr('id', 'custom-date-submit-days')
-            .attr('ga-on', 'click')
-            .attr('ga-event-category', 'TimeSeriesGraph')
-            .attr('ga-event-action', 'customDaysSubmit')
-            .text('Display data on graph')
-            .on('click', function() {
-                const userSpecifiedNumberOfDays = document.getElementById('with-hint-input-days-from-today').value;
-                const formattedPeriodQueryParameter = `P${parseInt(userSpecifiedNumberOfDays)}D`;
-                // Validate user input for things not a number and blank entries
-                if (isNaN(userSpecifiedNumberOfDays) || userSpecifiedNumberOfDays.length === 0) {
-                    customDaysBeforeTodayAlertBody.selectAll('p').remove();
-                    customDaysBeforeTodayAlertBody.append('p')
-                        .text('Entry must be a number.');
-                    customDaysBeforeTodayValidationContainer.attr('hidden', null);
-                } else {
-                    customDaysBeforeTodayValidationContainer.attr('hidden', true);
-
-                    store.dispatch(setUserInputsForSelectingTimespan('numberOfDaysFieldValue', userSpecifiedNumberOfDays));
-                    store.dispatch(setUserInputsForSelectingTimespan('mainTimeRangeSelectionButton', 'custom'));
-                    store.dispatch(setSelectedDateRange(formattedPeriodQueryParameter));
-                    store.dispatch(retrieveHydrographData(siteno, getInputsForRetrieval(store.getState())))
-                        .then(() => store.dispatch(clearGraphBrushOffset()));
-                }
-            });
-    };
-
-    const createControlsForDateRangePicker = function() {
-        const dateRangePicker = containerCustomCalendarDays.append('div')
+    const dateRangePickerContainer = calendarDaysContainer.append('div')
             .attr('class', 'usa-date-range-picker');
+    dateRangePickerContainer.append('div')
+        .attr('id', 'start-date-form-group')
+        .attr('class', 'usa-form-group')
+        .call(drawDatePicker, 'custom-start-date', 'Start Date', initialCustomDateRange ? initialCustomDateRange.start : '');
+    dateRangePickerContainer.append('div')
+        .attr('id', 'end-date-form-group')
+        .attr('class', 'usa-form-group')
+        .call(drawDatePicker, 'custom-end-date', 'End Date', initialCustomDateRange ? initialCustomDateRange.end : '');
 
-        const customDateValidationContainer = containerCustomCalendarDays.append('div')
-            .attr('class', 'usa-alert usa-alert--warning usa-alert--validation')
-            .attr('id', 'custom-date-alert-container')
-            .attr('hidden', true);
+    const calendarDaysValidationContainer = calendarDaysContainer.append('div')
+        .attr('class', 'usa-alert usa-alert--warning usa-alert--validation')
+        .attr('id', 'custom-date-alert-container')
+        .attr('hidden', true);
+    const dateAlertBody = calendarDaysValidationContainer.append('div')
+        .attr('class', 'usa-alert__body')
+        .attr('id', 'custom-date-alert');
+    dateAlertBody.append('h3')
+        .attr('class', 'usa-alert__heading')
+        .text('Date requirements');
 
-        const dateAlertBody = customDateValidationContainer.append('div')
-            .attr('class', 'usa-alert__body')
-            .attr('id', 'custom-date-alert');
+    // required to init the USWDS date picker after page load before calling the
+    // dateRangePicker on function
+    components.datePicker.init(dateRangePickerContainer.node());
+    // required to init the USWDS date range picker after page load
+    components.dateRangePicker.on(dateRangePickerContainer.node());
 
-        dateAlertBody.append('h3')
-            .attr('class', 'usa-alert__heading')
-            .text('Date requirements');
-
-        const startDateFormGroup = dateRangePicker.append('div')
-            .attr('id', 'start-date-form-group')
-            .attr('class', 'usa-form-group');
-
-        const endDateFormGroup = dateRangePicker.append('div')
-            .attr('id', 'end-date-form-group')
-            .attr('class', 'usa-form-group');
-
-        startDateFormGroup.append('label')
-            .attr('class', 'usa-label')
-            .attr('id', 'custom-start-date-label')
-            .attr('for', 'custom-start-date')
-            .text('Start Date');
-
-        startDateFormGroup.append('div')
-            .attr('class', 'usa-hint')
-            .attr('id', 'custom-start-date-hint')
-            .text('mm/dd/yyyy')
-            .append('div')
-                .attr('class', 'usa-date-picker')
-                .attr('data-min-date', '1900-01-01')
-                .attr('data-max-date', '2100-12-31')
-            .append('input')
-                .attr('class', 'usa-input')
-                .attr('id', 'custom-start-date')
-                .attr('name', 'custom-start-date')
-                .attr('aria-describedby', 'custom-start-date-label custom-start-date-hint')
-                .attr('type', 'text');
-
-        endDateFormGroup.append('label')
-            .attr('class', 'usa-label')
-            .attr('id', 'custom-end-date-label')
-            .attr('for', 'custom-end-date')
-            .text('End Date');
-
-        endDateFormGroup.append('div')
-            .attr('class', 'usa-hint')
-            .attr('id', 'custom-end-date-hint')
-            .text('mm/dd/yyyy')
-            .append('div')
-            .attr('class', 'usa-date-picker')
-            .attr('data-min-date', '1900-01-01')
-            .attr('data-max-date', '2100-12-31')
-            .append('input')
-            .attr('class', 'usa-input')
-            .attr('id', 'custom-end-date')
-            .attr('name', 'custom-end-date')
-            .attr('type', 'text')
-            .attr('aria-describedby', 'custom-end-date-label custom-end-date-hint');
-
-        // required to init the USWDS date picker after page load before calling the
-        // dateRangePicker on function
-        components.datePicker.init(dateRangePicker.node());
-        // required to init the USWDS date range picker after page load
-        components.dateRangePicker.on(dateRangePicker.node());
-
-        // Adds controls for the calendar day submit button
-        const calendarDaysSubmitContainer = containerCustomCalendarDays.append('div')
-            .attr('class', 'submit-button');
-
-        calendarDaysSubmitContainer.append('button')
-            .attr('class', 'usa-button')
-            .attr('id', 'custom-date-submit-calendar')
-            .attr('ga-on', 'click')
-            .attr('ga-event-category', 'TimeSeriesGraph')
-            .attr('ga-event-action', 'customDateSubmit')
-            .text('Display data on graph')
-            .on('click', function() {
-                let userSpecifiedStart = document.getElementById('custom-start-date').value;
-                let userSpecifiedEnd = document.getElementById('custom-end-date').value;
-                if (userSpecifiedStart.length === 0 || userSpecifiedEnd.length === 0) {
-                    dateAlertBody.selectAll('p').remove();
-                    dateAlertBody.append('p')
-                        .text('Both start and end dates must be specified.');
-                    customDateValidationContainer.attr('hidden', null);
-                } else if (DateTime.fromFormat(userSpecifiedEnd, 'LL/dd/yyyy') < DateTime.fromFormat(userSpecifiedStart, 'LL/dd/yyyy')) {
+    // Adds controls for the calendar day submit button
+    const calendarDaysSubmitContainer = calendarDaysContainer.append('div')
+        .attr('class', 'submit-button');
+    calendarDaysSubmitContainer.append('button')
+        .attr('class', 'usa-button')
+        .attr('id', 'custom-date-submit-calendar')
+        .attr('ga-on', 'click')
+        .attr('ga-event-category', 'TimeSeriesGraph')
+        .attr('ga-event-action', 'customDateSubmit')
+        .text('Display data on graph')
+        .on('click', function() {
+            const startDateStr = calendarDaysContainer.select('#custom-start-date').property('value');
+            const endDateStr = calendarDaysContainer.select('#custom-end-date').property('value');
+            if (startDateStr.length === 0 || endDateStr.length === 0) {
+                dateAlertBody.selectAll('p').remove();
+                dateAlertBody.append('p')
+                    .text('Both start and end dates must be specified.');
+                calendarDaysValidationContainer.attr('hidden', null);
+            } else {
+                const startTime = DateTime.fromFormat(startDateStr, 'LL/dd/yyyy').toMillis();
+                const endTime = DateTime.fromFormat(endDateStr, 'LL/dd/yyyy').toMillis();
+                if (startTime > endTime) {
                     dateAlertBody.selectAll('p').remove();
                     dateAlertBody.append('p')
                         .text('The start date must precede the end date.');
-                    customDateValidationContainer.attr('hidden', null);
+                    calendarDaysValidationContainer.attr('hidden', null);
                 } else {
-                    customDateValidationContainer.attr('hidden', true);
-                    userSpecifiedStart = DateTime.fromFormat(userSpecifiedStart, 'LL/dd/yyyy').toISODate();
-                    userSpecifiedEnd = DateTime.fromFormat(userSpecifiedEnd, 'LL/dd/yyyy').toISODate();
-                    store.dispatch(ivTimeSeriesDataActions.retrieveUserRequestedIVDataForDateRange(
-                        siteno,
-                        userSpecifiedStart,
-                        userSpecifiedEnd
-                    )).then(() => store.dispatch(ivTimeSeriesStateActions.clearIVGraphBrushOffset()));
+                    calendarDaysValidationContainer.attr('hidden', true);
+                    store.dispatch(setSelectedCustomDateRange(DateTime.fromMillis(startTime, {zone: config.locationTimeZone}).toISODate(),
+                        DateTime.fromMillis(endTime, {zone: config.locationTimeZone}).toISODate()));
+                    store.dispatch(setSelectedDateRange('custom'));
+                    store.dispatch(retrieveHydrographData(siteno, getInputsForRetrieval(store.getState())))
+                        .then(() => store.dispatch(clearGraphBrushOffset()));
                 }
-            });
-
-        containerCustomCalendarDays.call(link(store, (container, {customTimeRange, ianaTimeZone}) => {
-            container.select('#custom-start-date')
-                .property('value', customTimeRange && customTimeRange.start ? DateTime.fromMillis(customTimeRange.start, {zone: ianaTimeZone}).startOf('day').toFormat('LL/dd/yyyy') : '');
-            container.select('#custom-end-date')
-                .property('value', customTimeRange && customTimeRange.end ? DateTime.fromMillis(customTimeRange.end, {zone: ianaTimeZone}).toFormat('LL/dd/yyyy') : '');
-        }, createStructuredSelector({
-            customTimeRange: getCustomTimeRange,
-            ianaTimeZone: getIanaTimeZone
-        })));
-    };
-
-    const createRadioButtonsForPrimaryTimeframes = function() {
-        const listContainer = containerRadioGroupMainSelectButtons.append('ul')
-            .attr('class', 'usa-fieldset usa-list--unstyled');
-        const li = listContainer.selectAll('li')
-            .attr('class', 'usa-fieldset')
-            .data(DATE_RANGE)
-            .enter().append('li');
-        listContainer.call(link(store, drawLoadingIndicator, createStructuredSelector({
-            showLoadingIndicator: isLoadingTS('current'),
-            sizeClass: () => 'fa-lg'
-        })));
-
-        li.append('input')
-            .attr('type', 'radio')
-            .attr('name', 'ts-daterange-input')
-            .attr('id', d => `${d.period}-input`)
-            .attr('class', 'usa-radio__input')
-            .attr('value', d => d.period)
-            .attr('ga-on', 'click')
-            .attr('aria-expanded', d => d.ariaExpanded)
-            .attr('ga-event-category', 'TimeSeriesGraph')
-            .attr('ga-event-action', d => `changeDateRangeTo${d.period}`)
-            .on('change', function() {
-                const selected = li.select('input:checked');
-                const selectedVal = selected.attr('value');
-
-                // Remove any values stored in the form, because they may not match what is shown in the graph until the submit button is pushed
-                store.dispatch(ivTimeSeriesStateActions.setUserInputsForSelectingTimespan('numberOfDaysFieldValue', ''));
-
-                if (selectedVal === 'custom') {
-                    selected.attr('aria-expanded', true);
-                    containerRadioGroupCustomSelectButtons.attr('hidden', null);
-                    containerCustomDaysBeforeToday.attr('hidden', null);
-                    containerCustomCalendarDays.attr('hidden', true);
-                    store.dispatch(ivTimeSeriesStateActions.setUserInputsForSelectingTimespan('mainTimeRangeSelectionButton', 'custom'));
-                } else {
-                    const userInputTimeframeButtonSelected = li.select('input:checked').attr('value');
-
-                    li.select('input#custom-date-range').attr('aria-expanded', false);
-                    containerRadioGroupCustomSelectButtons.attr('hidden', true);
-                    containerCustomDaysBeforeToday.attr('hidden', true);
-                    containerCustomCalendarDays.attr('hidden', true);
-                    store.dispatch(ivTimeSeriesStateActions.setUserInputsForSelectingTimespan('mainTimeRangeSelectionButton', userInputTimeframeButtonSelected));
-                    store.dispatch(ivTimeSeriesDataActions.retrieveExtendedIVTimeSeries(
-                        siteno,
-                        userInputTimeframeButtonSelected
-                    )).then(() => {
-                        store.dispatch(ivTimeSeriesStateActions.clearIVGraphBrushOffset());
-                    });
-                }
-            });
-
-        li.append('label')
-            .attr('class', 'usa-radio__label')
-            .attr('for', (d) => `${d.period}-input`)
-            .text((d) => d.name);
-        li.call(link(store, (elem, userInputsForSelectingTimespan) => {
-            elem.select(`#${userInputsForSelectingTimespan.mainTimeRangeSelectionButton}-input`).property('checked', true);
-        }, getUserInputsForSelectingTimespan));
-    };
+            }
+        });
+};
 
 
-    createRadioButtonsForCustomDaterangeSelection(containerRadioGroupCustomSelectButtons);
-    createControlsForSelectingTimeSpanInDaysFromToday();
-    createControlsForDateRangePicker();
-    createRadioButtonsForPrimaryTimeframes();
+export const drawDateRangeControls = function(elem, store, siteno, initialDateRange, initialCustomDateRange) {
+    // Add a container that holds the custom selection radio buttons and the form fields
+    elem.insert('div', '.graph-container')
+        .attr('id', 'ts-daterange-select-container')
+        .attr('role', 'radiogroup')
+        .attr('aria-label', 'Time interval select')
+        .call(drawSelectRadioButtons, store, siteno, initialDateRange);
+    elem.insert('div', '.graph-container')
+        .attr('id', 'container-radio-group-and-form-buttons')
+        .call(drawCustomRadioButtons, initialDateRange)
+        .call(drawCustomDaysBeforeForm, store, siteno, initialDateRange)
+        .call(drawCustomCalendarDaysForm, store, siteno, initialDateRange, initialCustomDateRange);
+    setCustomFormVisibility(showCustomContainer(initialDateRange));
 };

--- a/assets/src/scripts/monitoring-location/components/hydrograph/date-controls.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/date-controls.js
@@ -46,6 +46,10 @@ const showCustomContainer = function(dateRange) {
     return isCustomPeriod(dateRange) || isCustomDateRange(dateRange);
 };
 
+/*
+ * Set custom form hidden attribute and clear custom container inputs if it is being hidden
+ * @param {Boolean} showCustom
+ */
 const setCustomFormVisibility = function(showCustom) {
     const customContainer = select('#container-radio-group-and-form-buttons');
     customContainer.attr('hidden', showCustom ? null : true);
@@ -55,6 +59,13 @@ const setCustomFormVisibility = function(showCustom) {
     }
 };
 
+/*
+ * Render the time range radio buttons
+ * @param {D3 container} elem
+ * @param {Redux store} store
+ * @param {String} siteno
+ * @param {String} initialDateRange - used to set the initial selected radio button
+ */
 const drawSelectRadioButtons = function(elem, store, siteno, initialDateRange) {
     const listContainer = elem.append('ul')
         .attr('class', 'usa-fieldset usa-list--unstyled');
@@ -81,6 +92,7 @@ const drawSelectRadioButtons = function(elem, store, siteno, initialDateRange) {
             setCustomFormVisibility(isCustom);
             li.select('#custom-input').attr('aria-expanded', isCustom);
             if (!isCustom) {
+                store.dispatch(clearGraphBrushOffset());
                 store.dispatch(setSelectedDateRange(selectedValue));
                 store.dispatch(retrieveHydrographData(siteno, getInputsForRetrieval(store.getState())));
             }
@@ -93,6 +105,11 @@ const drawSelectRadioButtons = function(elem, store, siteno, initialDateRange) {
         .text((d) => d.name);
 };
 
+/*
+ * Render the radio buttons that select which kind of custom timespan is desired
+ * @param {D3 selection} container
+ * @param {String} initialDateRange - Used to set the initial radio button selection
+ */
 const drawCustomRadioButtons = function(container, initialDateRange) {
     const radioButtonContainer = container.append('div')
         .attr('id', 'ts-custom-date-radio-group')
@@ -132,6 +149,13 @@ const drawCustomRadioButtons = function(container, initialDateRange) {
             .text((d) => d.text);
 };
 
+/*
+ * Render the custom "days before today" container
+ * @param {D3 selection} container
+ * @param {Redux store} store
+ * @param {String} siteno
+ * @param {String} initialDateRange - Used to set the initial contents of the text field.
+ */
 const drawCustomDaysBeforeForm = function(container, store, siteno, initialDateRange) {
     const formContainer = container.append('div')
         .attr('id', 'ts-custom-days-before-today-select-container')
@@ -197,13 +221,20 @@ const drawCustomDaysBeforeForm = function(container, store, siteno, initialDateR
                 daysBeforeValidationContainer.attr('hidden', null);
             } else {
                 daysBeforeValidationContainer.attr('hidden', true);
+                store.dispatch(clearGraphBrushOffset());
                 store.dispatch(setSelectedDateRange(`P${parseInt(daysBefore)}D`));
-                store.dispatch(retrieveHydrographData(siteno, getInputsForRetrieval(store.getState())))
-                    .then(() => store.dispatch(clearGraphBrushOffset()));
+                store.dispatch(retrieveHydrographData(siteno, getInputsForRetrieval(store.getState())));
             }
         });
 };
 
+/*
+ * Render a USWDS date picker markup
+ * @param {D3 selection} container
+ * @param {String} id - id for the date picker
+ * @param {String} label - label for the date picker
+ * @param {String} initialDate - ISO 8601 Date format
+ */
 const drawDatePicker = function(container, id, label, initialDate) {
     container.append('label')
         .attr('class', 'usa-label')
@@ -229,6 +260,15 @@ const drawDatePicker = function(container, id, label, initialDate) {
                 .attr('type', 'text');
 };
 
+/*
+ * Render the custom calendar days form
+ * @param {D3 selection} container
+ * @param {Redux store} store
+ * @param {String} siteno
+ * @param {String} initialDateRange - if 'custom' then this container is made visible
+ * @param {Object} initialCustomDateRange - has start and end String properties containing an ISO 8601 date string
+ *      and is used to set the initial values of the calendar pickers
+ */
 const drawCustomCalendarDaysForm = function(container, store, siteno, initialDateRange, initialCustomDateRange) {
     const calendarDaysContainer = container.append('div')
         .attr('id', 'ts-customdaterange-select-container')
@@ -293,17 +333,25 @@ const drawCustomCalendarDaysForm = function(container, store, siteno, initialDat
                     calendarDaysValidationContainer.attr('hidden', null);
                 } else {
                     calendarDaysValidationContainer.attr('hidden', true);
+                    store.dispatch(clearGraphBrushOffset());
                     store.dispatch(setSelectedCustomDateRange(DateTime.fromMillis(startTime, {zone: config.locationTimeZone}).toISODate(),
                         DateTime.fromMillis(endTime, {zone: config.locationTimeZone}).toISODate()));
                     store.dispatch(setSelectedDateRange('custom'));
-                    store.dispatch(retrieveHydrographData(siteno, getInputsForRetrieval(store.getState())))
-                        .then(() => store.dispatch(clearGraphBrushOffset()));
+                    store.dispatch(retrieveHydrographData(siteno, getInputsForRetrieval(store.getState())));
                 }
             }
         });
 };
 
-
+/*
+ * Renders the date controls used to set the time range. This can be done by using short cut selections or by
+ * using the custom date range form.
+ * @param {D3 selection} elem
+ * @param {Redux store} store
+ * @param {String} siteno
+ * @param {String} initialDateRange
+ * @param {Object} initialCustomDateRange - has string start and end components containing an ISO 8601 date string
+ */
 export const drawDateRangeControls = function(elem, store, siteno, initialDateRange, initialCustomDateRange) {
     // Add a container that holds the custom selection radio buttons and the form fields
     elem.insert('div', '.graph-container')

--- a/assets/src/scripts/monitoring-location/components/hydrograph/date-controls.test.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/date-controls.test.js
@@ -238,7 +238,7 @@ describe('monitoring-location/components/hydrograph/date-controls', () => {
             });
             expect(clearBrushOffsetSpy).toHaveBeenCalled();
             expect(retrieveSpy.mock.calls).toHaveLength(1);
-            expect(retrieveSpy.mock.calls[0][0]).toEqual('12345678')
+            expect(retrieveSpy.mock.calls[0][0]).toEqual('12345678');
             expect(retrieveSpy.mock.calls[0][1]).toEqual({
                 parameterCode: '00065',
                 period: null,

--- a/assets/src/scripts/monitoring-location/components/hydrograph/date-controls.test.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/date-controls.test.js
@@ -1,171 +1,37 @@
 import {select} from 'd3-selection';
 import sinon from 'sinon';
 
+import config from 'ui/config';
+
+import {getSelectedDateRange, getSelectedCustomDateRange} from 'ml/selectors/hydrograph-state-selector';
+
 import {configureStore} from 'ml/store';
-import {Actions as ivTimeSeriesDataActions} from 'ml/store/instantaneous-value-time-series-data';
+import * as hydrographData from 'ml/store/hydrograph-data';
+import * as hydrographState from 'ml/store/hydrograph-state';
 
 import {drawDateRangeControls} from './date-controls';
 
 const TEST_STATE = {
-    ivTimeSeriesData: {
-        timeSeries: {
-            '00010:current': {
-                points: [{
-                    dateTime: 1514926800000,
-                    value: 4,
-                    qualifiers: ['P']
-                }],
-                method: 'method1',
-                tsKey: 'current:P7D',
-                variable: '45807190'
-            },
-            '00060:current': {
-                points: [{
-                    dateTime: 1514926800000,
-                    value: 10,
-                    qualifiers: ['P']
-                }],
-                method: 'method1',
-                tsKey: 'current:P7D',
-                variable: '45807197'
-            },
-            '00060:compare': {
-                points: [{
-                    dateTime: 1514926800000,
-                    value: 10,
-                    qualifiers: ['P']
-                }],
-                method: 'method1',
-                tsKey: 'compare:P7D',
-                variable: '45807197'
-            }
-        },
-        timeSeriesCollections: {
-            'coll1': {
-                variable: '45807197',
-                timeSeries: ['00060:current']
-            },
-            'coll2': {
-                variable: '45807197',
-                timeSeries: ['00060:compare']
-            },
-            'coll3': {
-                variable: '45807197',
-                timeSeries: ['00060:median']
-            },
-            'coll4': {
-                variable: '45807190',
-                timeSeries: ['00010:current']
-            }
-        },
-        queryInfo: {
-            'current:P7D': {
-                notes: {
-                    'filter:timeRange':  {
-                        mode: 'PERIOD',
-                        periodDays: 7
-                    },
-                    requestDT: 1522425600000
-                }
-            }
-        },
-        requests: {
-            'current:P7D': {
-                timeSeriesCollections: ['coll1']
-            },
-            'compare:P7D': {
-                timeSeriesCollections: ['coll2', 'col4']
-            }
-        },
-        variables: {
-            '45807197': {
-                variableCode: {
-                    value: '00060'
-                },
-                oid: '45807197',
-                variableName: 'Test title for 00060',
-                variableDescription: 'Test description for 00060',
-                unit: {
-                    unitCode: 'unitCode'
-                }
-            },
-            '45807190': {
-                variableCode: {
-                    value: '00010'
-                },
-                oid: '45807190',
-                unit: {
-                    unitCode: 'unitCode'
-                }
-            }
-        },
-        methods: {
-            'method1': {
-                methodDescription: 'method description'
-            }
-        }
-    },
-    statisticsData : {
-        median: {
-            '00060': {
-                '1234': [
-                    {
-                        month_nu: '2',
-                        day_nu: '20',
-                        p50_va: '40',
-                        begin_yr: '1970',
-                        end_yr: '2017',
-                        loc_web_ds: 'This method'
-                    }, {
-                        month_nu: '2',
-                        day_nu: '21',
-                        p50_va: '41',
-                        begin_yr: '1970',
-                        end_yr: '2017',
-                        loc_web_ds: 'This method'
-                    }, {
-                        month_nu: '2',
-                        day_nu: '22',
-                        p50_va: '42',
-                        begin_yr: '1970',
-                        end_yr: '2017',
-                        loc_web_ds: 'This method'
-                    }
-                ]
-            }
-        }
-    },
-    ivTimeSeriesState: {
-        currentIVVariableID: '45807197',
-        currentIVDateRange: 'P7D',
-        userInputsForTimeRange: {
-            mainTimeRangeSelectionButton: 'P7D',
-            customTimeRangeSelectionButton: 'days-input',
-            numberOfDaysFieldValue: ''
-        },
-        showIVTimeSeries: {
-            current: true,
-            compare: true,
-            median: true
-        },
-        loadingIVTSKeys: []
-    },
-    ui: {
-        width: 400
+    hydrographState: {
+       selectedDateRange: 'P7D',
+       selectedCustomDateRange: null,
+       selectedParameterCode: '00065'
     }
 };
 
 
 describe('monitoring-location/components/hydrograph/date-controls', () => {
-    let fakeServer;
     let div;
+    let fakeServer;
     let store;
+    let retrieveSpy;
+    config.locationTimeZone = 'America/Chicago';
 
     beforeEach(() => {
         div = select('body').append('div');
         store = configureStore(TEST_STATE);
-        div.call(drawDateRangeControls, store, '12345678');
         fakeServer = sinon.createFakeServer();
+        retrieveSpy = jest.spyOn(hydrographData, 'retrieveHydrographData');
     });
 
     afterEach(() => {
@@ -173,102 +39,260 @@ describe('monitoring-location/components/hydrograph/date-controls', () => {
         div.remove();
     });
 
-    it('Expects the date range controls to be created', () => {
-        let dateRangeContainer = select('#ts-daterange-select-container');
-        let subSelectionRadioButtonsContainer = select('div#ts-custom-date-radio-group');
-        let customDateDiv = select('div#ts-customdaterange-select-container');
+    describe('Initial rendering', () => {
+        it('Expects the date range controls to be created and initialized with the custom container hidden', () => {
+            drawDateRangeControls(div, store, '12345678', 'P7D', null);
 
-        expect(dateRangeContainer.size()).toBe(1);
-        expect(dateRangeContainer.selectAll('input[type=radio]').size()).toBe(4);
-        expect(subSelectionRadioButtonsContainer.size()).toBe(1);
-        expect(subSelectionRadioButtonsContainer.selectAll('input[type=radio]').size()).toBe(2);
-        expect(customDateDiv.attr('hidden')).toBe('true');
+            expect(div.select('input[name="ts-daterange-input"]:checked').property('value')).toBe('P7D');
+            expect(div.select('#container-radio-group-and-form-buttons').attr('hidden')).toBe('true');
+        });
+
+        it('Expects the "P30D" radio button is selected with the custom container hidden', () => {
+            drawDateRangeControls(div, store, '12345678', 'P30D', null);
+
+            expect(div.select('input[name="ts-daterange-input"]:checked').property('value')).toBe('P30D');
+            expect(div.select('#container-radio-group-and-form-buttons').attr('hidden')).toBe('true');
+        });
+
+        it('Expects the "P365D" radio button is selected with the custom container hidden', () => {
+            drawDateRangeControls(div, store, '12345678', 'P365D', null);
+
+            expect(div.select('input[name="ts-daterange-input"]:checked').property('value')).toBe('P365D');
+            expect(div.select('#container-radio-group-and-form-buttons').attr('hidden')).toBe('true');
+        });
+
+        it('Expects the custom radio button is selected with the custom container shown if initialDateRange is P10D', () => {
+            drawDateRangeControls(div, store, '12345678', 'P10D', null);
+
+            expect(div.select('input[name="ts-daterange-input"]:checked').property('value')).toBe('custom');
+            expect(div.select('#container-radio-group-and-form-buttons').attr('hidden')).toBeNull();
+            expect(div.select('input[name="ts-custom-daterange-input"]:checked').property('value')).toBe('days');
+            expect(div.select('#ts-custom-days-before-today-select-container').attr('hidden')).toBeNull();
+            expect(div.select('#with-hint-input-days-from-today').property('value')).toBe('10');
+            expect(div.select('#ts-customdaterange-select-container').attr('hidden')).toBe('true');
+        });
+
+        it('Expects the custom radio button is selected with the custom container shown if initialDateRange is custom', () => {
+            drawDateRangeControls(div, store, '12345678', 'custom', {
+                start: '2020-01-03',
+                end: '2020-04-15'
+            });
+
+            expect(div.select('input[name="ts-daterange-input"]:checked').property('value')).toBe('custom');
+            expect(div.select('#container-radio-group-and-form-buttons').attr('hidden')).toBeNull();
+            expect(div.select('input[name="ts-custom-daterange-input"]:checked').property('value')).toBe('calendar');
+            expect(div.select('#ts-custom-days-before-today-select-container').attr('hidden')).toBe('true');
+            expect(div.select('#ts-customdaterange-select-container').attr('hidden')).toBeNull();
+            expect(div.select('#custom-start-date').property('value')).toBe('01/03/2020');
+            expect(div.select('#custom-end-date').property('value')).toBe('04/15/2020');
+        });
     });
 
-    it('Expects to retrieve the extended time series when the radio buttons are changed', () => {
-        jest.spyOn(ivTimeSeriesDataActions, 'retrieveExtendedIVTimeSeries');
-        let lastRadio = select('#P1Y-input');
-        lastRadio.property('checked', true);
-        lastRadio.dispatch('change');
+    describe('Select radio button interactions', () => {
+        let clearBrushOffsetSpy;
+        beforeEach(() => {
+            clearBrushOffsetSpy = jest.spyOn(hydrographState, 'clearGraphBrushOffset');
+            drawDateRangeControls(div, store, '12345678', 'P7D', null);
+        }) ;
 
-        expect(ivTimeSeriesDataActions.retrieveExtendedIVTimeSeries).toHaveBeenCalledWith('12345678', 'P1Y');
+        it('Expect change to P30D to fetch new data', () => {
+            const radioButton = div.select('#P30D-input').property('checked', true);
+            radioButton.dispatch('change');
+
+            expect(div.select('#container-radio-group-and-form-buttons').attr('hidden')).toBe('true');
+            expect(getSelectedDateRange(store.getState())).toEqual('P30D');
+            expect(clearBrushOffsetSpy).toHaveBeenCalled();
+            expect(retrieveSpy.mock.calls).toHaveLength(1);
+            expect(retrieveSpy.mock.calls[0][0]).toEqual('12345678');
+            expect(retrieveSpy.mock.calls[0][1]).toEqual({
+                parameterCode: '00065',
+                period: 'P30D',
+                startTime: null,
+                endTime: null,
+                loadCompare: false,
+                loadMedian: false
+            });
+        });
+
+        it('Expect change to P365D to fetch new data', () => {
+            const radioButton = div.select('#P365D-input').property('checked', true);
+            radioButton.dispatch('change');
+
+            expect(div.select('#container-radio-group-and-form-buttons').attr('hidden')).toBe('true');
+            expect(getSelectedDateRange(store.getState())).toEqual('P365D');
+            expect(clearBrushOffsetSpy).toHaveBeenCalled();
+            expect(retrieveSpy.mock.calls).toHaveLength(1);
+            expect(retrieveSpy.mock.calls[0][0]).toEqual('12345678');
+            expect(retrieveSpy.mock.calls[0][1]).toEqual({
+                parameterCode: '00065',
+                period: 'P365D',
+                startTime: null,
+                endTime: null,
+                loadCompare: false,
+                loadMedian: false
+            });
+        });
+
+        it('Expect change to custom to show the custom form but no new data is fetched', () => {
+            const radioButton = div.select('#custom-input').property('checked', true);
+            radioButton.dispatch('change');
+
+            expect(div.select('#container-radio-group-and-form-buttons').attr('hidden')).toBeNull();
+            expect(getSelectedDateRange(store.getState())).toEqual('P7D');
+            expect(clearBrushOffsetSpy).not.toHaveBeenCalled();
+            expect(retrieveSpy).not.toHaveBeenCalled();
+        });
+
+        it('Expects a change from custom to P7D to fetch new data and hide custom form', () => {
+            const radioButton = div.select('#custom-input').property('checked', true);
+            radioButton.dispatch('change');
+
+            const radioButtonP7D = div.select('#P7D-input').property('checked', true);
+            radioButtonP7D.dispatch('change');
+
+            expect(div.select('#container-radio-group-and-form-buttons').attr('hidden')).toBe('true');
+            expect(getSelectedDateRange(store.getState())).toEqual('P7D');
+            expect(clearBrushOffsetSpy).toHaveBeenCalled();
+            expect(retrieveSpy.mock.calls).toHaveLength(1);
+            expect(retrieveSpy.mock.calls[0][0]).toEqual('12345678');
+            expect(retrieveSpy.mock.calls[0][1]).toEqual({
+                parameterCode: '00065',
+                period: 'P7D',
+                startTime: null,
+                endTime: null,
+                loadCompare: false,
+                loadMedian: false
+            });
+        });
     });
 
-    it('Expects to show the days before today form when only the Custom radio is selected', () => {
-        let customRadioButtonElement = select('#custom-input');
-        customRadioButtonElement.property('checked', true);
-        customRadioButtonElement.dispatch('change');
+    describe('Custom form interactions', () => {
+        let clearBrushOffsetSpy;
+        beforeEach(() => {
+            clearBrushOffsetSpy = jest.spyOn(hydrographState, 'clearGraphBrushOffset');
+            drawDateRangeControls(div, store, '12345678', 'P10D', null);
+        });
 
-        let customDaysBeforeTodayDiv = select('div#ts-custom-days-before-today-select-container');
-        expect(customDaysBeforeTodayDiv.attr('hidden')).toBeNull();
+        it('Expects that selecting the calendar days radio shows the calendar days form', () => {
+            const radioButton = div.select('#calendar-input')
+                .property('checked', true);
+            radioButton.dispatch('change');
 
-        let customDaysBeforeTodayAlertDiv = select('div#custom-days-before-today-alert-container');
-        expect(customDaysBeforeTodayAlertDiv.attr('hidden')).toBe('true');
-    });
+            expect(div.select('#ts-custom-days-before-today-select-container').attr('hidden')).toBe('true');
+            expect(div.select('#ts-customdaterange-select-container').attr('hidden')).toBeNull();
+        });
 
-    it('Expects an alert to be thrown if custom dates are not provided.', () => {
-         let submitButton = select('#custom-date-submit-calendar');
-         submitButton.dispatch('click');
+        it('Expects that switching back to days before shows the days before form', () => {
+            let radioButton = div.select('#calendar-input').property('checked', true);
+            radioButton.dispatch('change');
 
-         let customDateAlertDiv = select('#custom-date-alert');
-         expect(customDateAlertDiv.attr('hidden')).toBeNull();
-         expect(customDateAlertDiv.select('p').text()).toEqual('Both start and end dates must be specified.');
-    });
+            radioButton = div.select('#days-input').property('checked', true);
+            radioButton.dispatch('change');
 
-    it('Expects an alert to be thrown if the end date is earlier than the start date.', () => {
-        select('#custom-start-date').property('value', '04/05/2063');
-        select('#custom-end-date').property('value', '04/03/2063');
+            expect(div.select('#ts-custom-days-before-today-select-container').attr('hidden')).toBeNull();
+            expect(div.select('#ts-customdaterange-select-container').attr('hidden')).toBe('true');
+        });
 
-        select('#custom-date-submit-calendar').dispatch('click');
+        it('Expects updating the days before and clicking Submit updates the store and retrieves data', () => {
+            div.select('#with-hint-input-days-from-today').property('value', '45');
+            const submitButton = div.select('#custom-date-submit-days');
+            submitButton.dispatch('click');
 
-        let customDateAlertDiv = select('#custom-date-alert-container');
-        expect(customDateAlertDiv.attr('hidden')).toBeNull();
-        expect(customDateAlertDiv.select('p').text()).toEqual('The start date must precede the end date.');
-    });
+            expect(clearBrushOffsetSpy).toHaveBeenCalled();
+            expect(getSelectedDateRange(store.getState())).toEqual('P45D');
+            expect(retrieveSpy.mock.calls[0][0]).toEqual('12345678');
+            expect(retrieveSpy.mock.calls[0][1]).toEqual({
+                parameterCode: '00065',
+                period: 'P45D',
+                startTime: null,
+                endTime: null,
+                loadCompare: false,
+                loadMedian: false
+            });
+        });
 
-    it('Expects data to be retrieved if both custom start and end dates are provided', () => {
-        jest.spyOn(ivTimeSeriesDataActions, 'retrieveUserRequestedIVDataForDateRange');
+        it('Expects an warning to show if the days input is invalid', () => {
+            div.select('#with-hint-input-days-from-today').property('value', '45 days');
+            const submitButton = div.select('#custom-date-submit-days');
+            submitButton.dispatch('click');
 
-        select('#custom-start-date').property('value', '04/03/2063');
-        select('#custom-end-date').property('value', '04/05/2063');
+            expect(div.select('#custom-days-before-today-alert-container').attr('hidden')).toBeNull();
+            expect(clearBrushOffsetSpy).not.toHaveBeenCalled();
+            expect(getSelectedDateRange(store.getState())).toEqual('P7D');
+            expect(retrieveSpy).not.toHaveBeenCalled();
+        });
 
-        select('#custom-date-submit-calendar').dispatch('click');
+        it('Expect submitting calendar times sets the date range to custom and saves the time range', () => {
+            let radioButton = div.select('#calendar-input').property('checked', true);
+            radioButton.dispatch('change');
 
-        let customDateAlertDiv = select('#custom-date-alert-container');
-        expect(customDateAlertDiv.attr('hidden')).toBe('true');
+            div.select('#custom-start-date').property('value', '01/03/2020');
+            div.select('#custom-end-date').property('value', '01/16/2020');
+            const submitButton = div.select('#custom-date-submit-calendar');
+            submitButton.dispatch('click');
 
-        expect(ivTimeSeriesDataActions.retrieveUserRequestedIVDataForDateRange).toHaveBeenCalledWith(
-            '12345678', '2063-04-03', '2063-04-05'
-        );
-    });
+            expect(getSelectedDateRange(store.getState())).toEqual('custom');
+            expect(getSelectedCustomDateRange(store.getState())).toEqual({
+                start: '2020-01-03',
+                end: '2020-01-16'
+            });
+            expect(clearBrushOffsetSpy).toHaveBeenCalled();
+            expect(retrieveSpy.mock.calls).toHaveLength(1);
+            expect(retrieveSpy.mock.calls[0][0]).toEqual('12345678')
+            expect(retrieveSpy.mock.calls[0][1]).toEqual({
+                parameterCode: '00065',
+                period: null,
+                startTime: '2020-01-03T00:00:00.000-06:00',
+                endTime: '2020-01-16T23:59:59.999-06:00',
+                loadCompare: false,
+                loadMedian: false
+            });
+        });
 
-    it('Expects an alert if no number is entered in days before today form field.', () => {
-        select('#custom-date-submit-days').dispatch('click');
+        it('Show validation error container if start date is missing', () => {
+            let radioButton = div.select('#calendar-input').property('checked', true);
+            radioButton.dispatch('change');
 
-        let userInputDaysBeforeTodayAlertDiv = select('#custom-days-before-today-alert-container');
-        expect(userInputDaysBeforeTodayAlertDiv.attr('hidden')).toBeNull();
-        expect(userInputDaysBeforeTodayAlertDiv.select('p').text()).toEqual('Entry must be a number.');
-    });
+            div.select('#custom-end-date').property('value', '01/16/2020');
+            const submitButton = div.select('#custom-date-submit-calendar');
+            submitButton.dispatch('click');
 
-    it('Expects an alert if something other than a number is entered in days before today form field.', () => {
-        let userInputDaysBeforeTodayAlertDiv = select('#custom-days-before-today-alert-container');
-        userInputDaysBeforeTodayAlertDiv.property('value', 'not');
-        select('#custom-date-submit-days').dispatch('click');
+            expect(div.select('#custom-date-alert-container').attr('hidden')).toBeNull();
+            expect(getSelectedDateRange(store.getState())).toEqual('P7D');
+            expect(getSelectedCustomDateRange(store.getState())).toBeNull();
+            expect(clearBrushOffsetSpy).not.toHaveBeenCalled();
+            expect(retrieveSpy).not.toHaveBeenCalled();
+        });
 
-        expect(userInputDaysBeforeTodayAlertDiv.attr('hidden')).toBeNull();
-        expect(userInputDaysBeforeTodayAlertDiv.select('p').text()).toEqual('Entry must be a number.');
-    });
+        it('Show validation error container if end date is missing', () => {
+            let radioButton = div.select('#calendar-input').property('checked', true);
+            radioButton.dispatch('change');
 
-    it('Expects data to be retrieved if a number of correct length is entered in days before today form field.', () => {
-        jest.spyOn(ivTimeSeriesDataActions, 'retrieveCustomTimePeriodIVTimeSeries');
-        select('#with-hint-input-days-from-today').property('value', 3);
-        select('#custom-date-submit-days').dispatch('click');
+            div.select('#custom-start-date').property('value', '01/03/2020');
+            const submitButton = div.select('#custom-date-submit-calendar');
+            submitButton.dispatch('click');
 
-        let userInputDaysBeforeTodayAlertDiv = select('#custom-days-before-today-alert-container');
-        expect(userInputDaysBeforeTodayAlertDiv.attr('hidden')).toBe('true');
+            expect(div.select('#custom-date-alert-container').attr('hidden')).toBeNull();
+            expect(getSelectedDateRange(store.getState())).toEqual('P7D');
+            expect(getSelectedCustomDateRange(store.getState())).toBeNull();
+            expect(clearBrushOffsetSpy).not.toHaveBeenCalled();
+            expect(retrieveSpy).not.toHaveBeenCalled();
+        });
 
-        expect(ivTimeSeriesDataActions.retrieveCustomTimePeriodIVTimeSeries).toHaveBeenCalledWith(
-            '12345678', '00060', 'P3D'
-        );
+        it('Show validation error container if start date is after end date', () => {
+            let radioButton = div.select('#calendar-input').property('checked', true);
+            radioButton.dispatch('change');
+
+            div.select('#custom-start-date').property('value', '01/03/2020');
+            div.select('#custom-end-date').property('value', '12/26/2019');
+            const submitButton = div.select('#custom-date-submit-calendar');
+            submitButton.dispatch('click');
+
+            expect(div.select('#custom-date-alert-container').attr('hidden')).toBeNull();
+            expect(getSelectedDateRange(store.getState())).toEqual('P7D');
+            expect(getSelectedCustomDateRange(store.getState())).toBeNull();
+            expect(clearBrushOffsetSpy).not.toHaveBeenCalled();
+            expect(retrieveSpy).not.toHaveBeenCalled();
+        });
     });
 });

--- a/assets/src/scripts/monitoring-location/components/hydrograph/index.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/index.js
@@ -96,7 +96,7 @@ export const attachToNode = function(store,
         } else {
             store.dispatch(setSelectedDateRange('P7D'));
         }
-        store.dispatch(setSelectedIVMethodID(timeSeriesId));DateTime.fromISO(endDT, {zone: config.locationTimeZone}).endOf('day').toISO()
+        store.dispatch(setSelectedIVMethodID(timeSeriesId));
     }
 
     // Fetch waterwatch flood levels - TODO: consider only fetching when gage height is requested

--- a/assets/src/scripts/monitoring-location/components/hydrograph/method-picker.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/method-picker.js
@@ -15,7 +15,7 @@ export const drawMethodPicker = function(elem, store, initialTimeSeriesId) {
     if (initialTimeSeriesId) {
         store.dispatch(setSelectedIVMethodID(initialTimeSeriesId));
     }
-    const pickerContainer = elem.insert('div', ':nth-child(2)')
+    const pickerContainer = elem.insert('div', '.graph-container')
         .attr('id', 'ts-method-select-container');
 
     pickerContainer.append('label')

--- a/assets/src/scripts/monitoring-location/iv-data-utils.js
+++ b/assets/src/scripts/monitoring-location/iv-data-utils.js
@@ -167,7 +167,8 @@ const getConvertedTimeSeries = function(timeSeries, tsRequestKey, parameterCode)
             return {
                 ...point,
                 qualifiers: [...point.qualifiers],
-                value: point.value ? convertCelsiusToFahrenheit(point.value).toFixed(2) : null
+                value: point.value === '' || isNaN(point.value) ?
+                    null : convertCelsiusToFahrenheit(point.value).toFixed(2)
             };
         }),
         variable: `${timeSeries.variable}${config.CALCULATED_TEMPERATURE_VARIABLE_CODE}`

--- a/assets/src/scripts/monitoring-location/iv-data-utils.test.js
+++ b/assets/src/scripts/monitoring-location/iv-data-utils.test.js
@@ -88,35 +88,35 @@ describe('convertCelsiusCollectionsToFahrenheitAndMerge', () => {
                 'variable': '45807042',
                 'points': [
                     {
-                        'value': 2.9,
+                        'value': 0,
                         'qualifiers': [
                             'P'
                         ],
                         'dateTime': 1609515000000
                     },
                     {
-                        'value': 3,
+                        'value': 'something wrong with this value',
                         'qualifiers': [
                             'P'
                         ],
                         'dateTime': 1609515900000
                     },
                     {
-                        'value': 3,
+                        'value': '',
                         'qualifiers': [
                             'P'
                         ],
                         'dateTime': 1609516800000
                     },
                     {
-                        'value': 3,
+                        'value': 0.01,
                         'qualifiers': [
                             'P'
                         ],
                         'dateTime': 1609517700000
                     },
                     {
-                        'value': 3.1,
+                        'value': -3.1,
                         'qualifiers': [
                             'P'
                         ],
@@ -200,42 +200,42 @@ describe('convertCelsiusCollectionsToFahrenheitAndMerge', () => {
             'qualifiers': [
                 'P'
             ],
-            'value': '37.22'
+            'value': '32.00'
         },
         {
             'dateTime': 1609515900000,
             'qualifiers': [
                 'P'
             ],
-            'value': '37.40'
+            'value': null
         },
         {
             'dateTime': 1609516800000,
             'qualifiers': [
                 'P'
             ],
-            'value': '37.40'
+            'value': null
         },
         {
             'dateTime': 1609517700000,
             'qualifiers': [
                 'P'
             ],
-            'value': '37.40'
+            'value': '32.02'
         },
         {
             'dateTime': 1609518600000,
             'qualifiers': [
                 'P'
             ],
-            'value': '37.58'
+            'value': '26.42'
         },
         {
             'dateTime': 1609519500000,
             'qualifiers': [
                 'P', 'Eqp'
             ],
-            'value': null
+            'value': '32.00'
         },
         {
             'dateTime': 1609520400000,

--- a/assets/src/scripts/monitoring-location/selectors/hydrograph-state-selector.js
+++ b/assets/src/scripts/monitoring-location/selectors/hydrograph-state-selector.js
@@ -2,28 +2,31 @@
 import {DateTime} from 'luxon';
 import {createSelector} from 'reselect';
 
+import config from 'ui/config';
+
 export const isCompareIVDataVisible = state => state.hydrographState.showCompareIVData || false;
 export const isMedianDataVisible = state => state.hydrographState.showMedianData || false;
 
 export const getSelectedDateRange = state => state.hydrographState.selectedDateRange || null;
-export const getSelectedCustomTimeRange = state => state.hydrographState.selectedCustomTimeRange || null;
+export const getSelectedCustomDateRange = state => state.hydrographState.selectedCustomDateRange || null;
 export const getSelectedParameterCode = state => state.hydrographState.selectedParameterCode || null;
 export const getSelectedIVMethodID = state => state.hydrographState.selectedIVMethodID || null;
 export const getGraphCursorOffset = state => state.hydrographState.graphCursorOffset || null;
 export const getGraphBrushOffset = state => state.hydrographState.graphBrushOffset || null;
-export const getUserInputsForTimeRange = state => state.hydrographState.userInputsForTimeRange || null;
 
 export const getInputsForRetrieval = createSelector(
     getSelectedParameterCode,
     getSelectedDateRange,
-    getSelectedCustomTimeRange,
+    getSelectedCustomDateRange,
     isCompareIVDataVisible,
     isMedianDataVisible,
-    (parameterCode, selectedDateRange, selectedCustomTimeRange, loadCompare, loadMedian) => {
+    (parameterCode, selectedDateRange, selectedCustomDateRange, loadCompare, loadMedian) => {
         const isCustomTime = selectedDateRange === 'custom';
         const period = isCustomTime ? null : selectedDateRange;
-        const startTime = isCustomTime ? DateTime.toISO(DateTime.fromMillis(selectedCustomTimeRange.start)) : null;
-        const endTime = isCustomTime ? DateTime.toISO(DateTime.fromMillis(selectedCustomTimeRange.end)) : null;
+        const startTime = isCustomTime ?
+            DateTime.fromISO(selectedCustomDateRange.start, {zone: config.locationTimeZone}).toISO() : null;
+        const endTime = isCustomTime ?
+            DateTime.fromISO(selectedCustomDateRange.end, {zone: config.locationTimeZone}).endOf('day').toISO() : null;
 
         return {
             parameterCode,

--- a/assets/src/scripts/monitoring-location/store/hydrograph-data.js
+++ b/assets/src/scripts/monitoring-location/store/hydrograph-data.js
@@ -276,7 +276,7 @@ export const retrieveHydrographData = function(siteno, {parameterCode, period, s
         dispatch(clearHydrographData());
 
         let timeRange;
-        if (period) {
+        if (period && period !== 'custom') {
             const now = DateTime.local();
             timeRange = {
                 start: now.minus(Duration.fromISO(period)).toMillis(),
@@ -285,7 +285,7 @@ export const retrieveHydrographData = function(siteno, {parameterCode, period, s
         } else {
             timeRange = {
                 start: DateTime.fromISO(startTime).toMillis(),
-                end: DateTime.fromISO(startTime).toMillis()
+                end: DateTime.fromISO(endTime).toMillis()
             };
         }
         dispatch(setHydrographTimeRange(timeRange, 'current'));

--- a/assets/src/scripts/monitoring-location/store/hydrograph-state.js
+++ b/assets/src/scripts/monitoring-location/store/hydrograph-state.js
@@ -2,7 +2,7 @@ export const INITIAL_STATE = {
     showCompareIVData: false,
     showMedianData : false,
     selectedDateRange: 'P7D',
-    selectedCustomTimeRange: null,
+    selectedCustomDateRange: null,
     selectedParameterCode: null,
     selectedIVMethodID: null,
     graphCursorOffset: null,

--- a/assets/src/scripts/monitoring-location/store/hydrograph-state.js
+++ b/assets/src/scripts/monitoring-location/store/hydrograph-state.js
@@ -78,32 +78,15 @@ export const setSelectedDateRange = function(dateRange) {
 
 /*
  * Synchronous action sets the custom date range for the hydrograph
- * @param {Number} startTime - epoch in milliseconds
- * @param {Number} endTime - epoch in milliseconds
+ * @param {String} startDate - ISO 8601 Date (yyyy-mm-dd)
+ * @param {String} endDate - ISO 8601 Date (yyyy-mm-dd)
  * @return {Object} - Redux action
  */
-export const setSelectedCustomTimeRange = function(startTime, endTime) {
+export const setSelectedCustomDateRange = function(startDate, endDate) {
     return {
-        type: 'SET_SELECTED_CUSTOM_TIME_RANGE',
-        startTime,
-        endTime
-    };
-};
-
-/*
- * Synchronous action sets
- * @param {String} key which is one of the three following options
- * - customTimeRangeSelectionButton - one of two selections for custom time periods, either 'days-input' or 'calender-input'
- * - mainTimeRangeSelectionButton - one of the four main timeframe selections, 'P7D', 'P30D', 'P1Y', or 'custom'
- * - numberOfDaysFieldValue - number of days from today that is entered in the form field for 'days before today' on the custom date range menu.
- * @param {String} a value suitable for the above mentioned keys
- * @return {Object} - Redux action
- */
-export const setUserInputsForSelectingTimespan = function(key, value) {
-    return {
-        type: 'SET_USER_INPUTS_FOR_SELECTING_TIMESPAN',
-        key,
-        value
+        type: 'SET_SELECTED_CUSTOM_DATE_RANGE',
+        startDate,
+        endDate
     };
 };
 
@@ -178,22 +161,14 @@ export const hydrographStateReducer = function(hydrographState=INITIAL_STATE, ac
                 selectedDateRange: action.dateRange
             };
 
-        case 'SET_SELECTED_CUSTOM_TIME_RANGE':
+        case 'SET_SELECTED_CUSTOM_DATE_RANGE':
             return {
                 ...hydrographState,
-                selectedCustomTimeRange: {
-                    start: action.startTime,
-                    end: action.endTime
+                selectedCustomDateRange: {
+                    start: action.startDate,
+                    end: action.endDate
                 }
             };
-
-        case 'SET_USER_INPUTS_FOR_SELECTING_TIMESPAN': {
-            const timespanInputSettings = {};
-            timespanInputSettings[action.key] = action.value;
-            return Object.assign({}, hydrographState, {
-                userInputsForTimeRange: Object.assign({}, hydrographState.userInputsForTimeRange, timespanInputSettings)
-            });
-        }
 
         case 'SET_GRAPH_CURSOR_OFFSET':
             return {

--- a/assets/src/scripts/monitoring-location/store/hydrograph-state.test.js
+++ b/assets/src/scripts/monitoring-location/store/hydrograph-state.test.js
@@ -2,7 +2,7 @@ import {applyMiddleware, combineReducers, createStore} from 'redux';
 import {default as thunk} from 'redux-thunk';
 
 import {INITIAL_STATE, setCompareDataVisibility, setMedianDataVisibility, setSelectedParameterCode,
-    setSelectedIVMethodID, setSelectedDateRange, setSelectedCustomTimeRange, setUserInputsForSelectingTimespan,
+    setSelectedIVMethodID, setSelectedDateRange, setSelectedCustomDateRange,
     setGraphCursorOffset, setGraphBrushOffset, clearGraphBrushOffset, hydrographStateReducer
 } from './hydrograph-state';
 
@@ -63,35 +63,17 @@ describe('monitoring-location/store/hydrograph-state', () => {
             });
         });
 
-        describe('setSelectedCustomTimeRange', () => {
-            it('sets the selected custom time range', () => {
-                store.dispatch(setSelectedCustomTimeRange(1586880394000, 1587398794000));
+        describe('setSelectedCustomDateRange', () => {
+            it('sets the selected custom date range', () => {
+                store.dispatch(setSelectedCustomDateRange('2020-01-03', '2020-01-16'));
                 const state = store.getState().hydrographState;
 
-                expect(state.selectedCustomTimeRange).toEqual({
-                    start: 1586880394000,
-                    end: 1587398794000
+                expect(state.selectedCustomDateRange).toEqual({
+                    start: '2020-01-03',
+                    end: '2020-01-16'
                 });
             });
         });
-
-        describe('setUserInputsForSelectingTimespan', () => {
-            it('sets the value for which of the main time range selection buttons are checked', () => {
-                store.dispatch(setUserInputsForSelectingTimespan('mainTimeRangeSelectionButton', 'custom'));
-                expect(store.getState().hydrographState.userInputsForTimeRange.mainTimeRangeSelectionButton).toBe('custom');
-            });
-
-            it('sets the value for which of the Custom subselection time range selection buttons are checked', () => {
-                store.dispatch(setUserInputsForSelectingTimespan('customTimeRangeSelectionButton', 'calender-input'));
-                expect(store.getState().hydrographState.userInputsForTimeRange.customTimeRangeSelectionButton).toBe('calender-input');
-            });
-
-            it('sets the value entered in the Custom subselection from field for days before today', () => {
-                store.dispatch(setUserInputsForSelectingTimespan('numberOfDaysFieldValue', '23'));
-                expect(store.getState().hydrographState.userInputsForTimeRange.numberOfDaysFieldValue).toBe('23');
-            });
-        });
-    });
 
         describe('setGraphCursorOffset', () => {
             it('sets the graph cursor offset', () => {
@@ -119,4 +101,5 @@ describe('monitoring-location/store/hydrograph-state', () => {
                 expect(store.getState().hydrographState.graphBrushOffset).toBeNull();
             });
         });
+    });
 });

--- a/assets/src/scripts/monitoring-location/url-params.js
+++ b/assets/src/scripts/monitoring-location/url-params.js
@@ -1,10 +1,8 @@
-import {DateTime} from 'luxon';
 import {createStructuredSelector} from 'reselect';
 
-import config from 'ui/config';
 import {listen} from 'ui/lib/d3-redux';
 import {getPrimaryMethods} from 'ml/selectors/hydrograph-data-selector';
-import {isCompareIVDataVisible, getSelectedIVMethodID, getSelectedDateRange, getSelectedCustomTimeRange,
+import {isCompareIVDataVisible, getSelectedIVMethodID, getSelectedDateRange, getSelectedCustomDateRange,
     getSelectedParameterCode
 } from 'ml/selectors/hydrograph-state-selector';
 
@@ -24,8 +22,8 @@ export const renderTimeSeriesUrlParams = function(store) {
         methods: getPrimaryMethods,
         compare: isCompareIVDataVisible,
         currentDateRange: getSelectedDateRange,
-        customTimeRange: getSelectedCustomTimeRange
-    }), ({parameterCode, methodId, methods, compare, currentDateRange, customTimeRange}) => {
+        customDateRange: getSelectedCustomDateRange
+    }), ({parameterCode, methodId, methods, compare, currentDateRange, customDateRange}) => {
         let params = new window.URLSearchParams();
 
         /* filter the 'currentDateRange', which comes in one of two forms
@@ -55,12 +53,8 @@ export const renderTimeSeriesUrlParams = function(store) {
                 params.set('period', currentDateRange);
                 break;
             case 'custom':
-                params.set(
-                    'startDT',
-                    DateTime.fromMillis(customTimeRange.start, {zone: config.locationTimeZone}).toFormat('yyyy-LL-dd'));
-                params.set(
-                    'endDT',
-                    DateTime.fromMillis(customTimeRange.end, {zone: config.locationTimeZone}).toFormat('yyyy-LL-dd'));
+                params.set('startDT', customDateRange.start);
+                params.set('endDT', customDateRange.end);
         }
         if (compare) {
             params.set('compare', true);

--- a/assets/src/styles/components/hydrograph/_app.scss
+++ b/assets/src/styles/components/hydrograph/_app.scss
@@ -19,7 +19,7 @@
     }
   }
 }
-.container-radio-group-and-form-buttons {
+#container-radio-group-and-form-buttons {
   border: solid 1px color('black');
   @include u-margin-bottom(1);
   #ts-custom-date-radio-group {


### PR DESCRIPTION
Before making a pull request
----------------------------

- [ ] Make sure all tests run - the date-controls.test.js and hydrograph-state.test.js. All other changes to other modules will have their tests updated as part of WDFN-501
- [ ] Update the changelog appropriately - Not updating the changelog until refactor is complete and merged back to master

Title
-----------
Wdfn 499 - add date-controls back to hydrograph

Description
-----------
Did a major reorganization of the date-controls control. Created local functions to render the different parts of the date controls component. Initialization is now done explictly when calling the draw function. This eliminates the need fo UserInputsForTimeRange in the HydrographState.

Also modified the way custom date ranges are saved in the Redux store in the hydrographState. Since these dates are now used exclusively to represent user input elements, I decided to save these as ISO 8601 date strings rather than convert back and forth from Epoch time. The time for graph renderering is saved in the hydrographData portion of the Redux store.

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the JIRA ticket
- [ ] Assign someone to review unless the change is trivial
