### PR TITLE
Iow 866 add approvals to groundwater levels table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/usgs/waterdataui/compare/waterdataui-0.42.0...master)
+### Added
+- A column indicating the approval status of the data shows in the DV Data Table.
+
 ### Fixed
 - The converted Fahrenheit line no longer drops off graph with zero values.
 - Locations with only some flood level indicators no longer show  NaN

--- a/assets/src/scripts/monitoring-location/components/hydrograph/data-table.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/data-table.js
@@ -14,12 +14,12 @@ const TABLE_CAPTION = {
 
 const COLUMN_HEADINGS = {
     iv: ['Parameter', 'Time', 'Result', 'Approval', 'Masks'],
-    gw: ['Parameter', 'Time', 'Result']
+    gw: ['Parameter', 'Time', 'Result', 'Approval']
 };
 
 const VALUE_NAMES = {
     iv: ['parameterName', 'dateTime', 'result', 'approvals', 'masks'],
-    gw: ['parameterName', 'dateTime', 'result']
+    gw: ['parameterName', 'dateTime', 'result', 'approvals']
 };
 
 const CONTAINER_ID = {

--- a/assets/src/scripts/monitoring-location/components/hydrograph/data-table.test.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/data-table.test.js
@@ -130,19 +130,19 @@ const TEST_DATA = {
                 },
                 values: [{
                     value: '0',
-                    qualifiers: [],
+                    qualifiers: ['A', '1'],
                     dateTime: 1520351100000
                 }, {
                     value: '0.01',
-                    qualifiers: [],
+                    qualifiers: ['P', '1'],
                     dateTime: 1520352000000
                 }, {
                     value: '0.02',
-                    qualifiers: [],
+                    qualifiers: ['R', '1'],
                     dateTime: 1520352900000
                 }, {
                     value: '0.03',
-                    qualifiers: [],
+                    qualifiers: ['A', '1'],
                     dateTime: 1520353800000
                 }]
             }
@@ -190,5 +190,6 @@ describe('monitoring-location/components/hydrograph/data-table', () => {
         expect(testDiv.selectAll('table').size()).toBe(1);
         expect(testDiv.select('#gw-table-container').select('caption').text()).toEqual('Field visit data');
         expect(testDiv.select('tbody').selectAll('tr').size()).toBe(2);
+        expect(testDiv.selectAll('.approvals').size()).toBe(2);
     });
 });

--- a/assets/src/scripts/monitoring-location/components/hydrograph/selectors/discrete-data.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/selectors/discrete-data.js
@@ -5,8 +5,6 @@ import {getIVCurrentVariableGroundwaterLevels} from 'ml/selectors/discrete-data-
 import {getRequestTimeRange, getCurrentVariable} from 'ml/selectors/time-series-selector';
 import {getIanaTimeZone} from 'ml/selectors/time-zone-selector';
 
-import {approvalCodeText} from 'ui/utils';
-
 /*
  * Returns a selector function that returns the groundwater levels that will be visible
  * on the hydrograpnh
@@ -34,6 +32,22 @@ export const getVisibleGroundwaterLevelPoints = createSelector(
             });
     }
 );
+
+/*
+* When given an approval code, will return the text equivalent
+*  @param {String} approvalCode - Usually a letter such as 'A'
+*   @return {String} - an easy to understand text version of an approval code
+*/
+const approvalCodeText = function(approvalCode) {
+    const approvalText = {
+        P: 'Provisional',
+        A: 'Approved',
+        R: 'Revised',
+        default: `unknown code: ${approvalCode}`
+    };
+
+    return approvalText[approvalCode] || approvalText.default;
+};
 
 /*
  * Selector function which returns a function that returns an array of gw data appropriate

--- a/assets/src/scripts/monitoring-location/components/hydrograph/selectors/discrete-data.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/selectors/discrete-data.js
@@ -5,6 +5,8 @@ import {getIVCurrentVariableGroundwaterLevels} from 'ml/selectors/discrete-data-
 import {getRequestTimeRange, getCurrentVariable} from 'ml/selectors/time-series-selector';
 import {getIanaTimeZone} from 'ml/selectors/time-zone-selector';
 
+import {approvalCodeText} from 'ui/utils';
+
 /*
  * Returns a selector function that returns the groundwater levels that will be visible
  * on the hydrograpnh
@@ -46,6 +48,7 @@ export const getVisibleGroundwaterLevelsTableData = createSelector(
     getVisibleGroundwaterLevelPoints,
     getIanaTimeZone,
     (currentVariable, gwLevels, timeZone) => {
+        console.log('gwLevels', gwLevels)
         return gwLevels.map((point) => {
             return {
                 parameterName: currentVariable.variableName,
@@ -53,7 +56,8 @@ export const getVisibleGroundwaterLevelsTableData = createSelector(
                 dateTime: DateTime.fromMillis(point.dateTime, {zone: timeZone}).toISO({
                     suppressMilliseconds: true,
                     suppressSeconds: true
-                })
+                }),
+                approvals: approvalCodeText(point.qualifiers[0])
             };
         });
     }

--- a/assets/src/scripts/monitoring-location/components/hydrograph/selectors/discrete-data.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/selectors/discrete-data.js
@@ -48,7 +48,7 @@ export const getVisibleGroundwaterLevelsTableData = createSelector(
     getVisibleGroundwaterLevelPoints,
     getIanaTimeZone,
     (currentVariable, gwLevels, timeZone) => {
-        console.log('gwLevels', gwLevels)
+
         return gwLevels.map((point) => {
             return {
                 parameterName: currentVariable.variableName,

--- a/assets/src/scripts/monitoring-location/components/hydrograph/selectors/discrete-data.test.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/selectors/discrete-data.test.js
@@ -47,10 +47,10 @@ describe('monitoring-location/components/hydrograph/selectors/discrete-data', ()
                             oid: '45807042'
                         },
                         values: [
-                            {value: '12.0', dateTime: 1489672800000},
-                            {value: '13.0', dateTime: 1490536800000},
-                            {value: '14.5', dateTime: 1490882400000},
-                            {value: '14.0', dateTime: 1491055200000}
+                            {value: '12.0', qualifiers: 'P', dateTime: 1489672800000},
+                            {value: '13.0', qualifiers: 'P', dateTime: 1490536800000},
+                            {value: '14.5', qualifiers: 'A', dateTime: 1490882400000},
+                            {value: '14.0', qualifiers: 'E', dateTime: 1491055200000}
                         ]
                     }
                 }
@@ -85,10 +85,12 @@ describe('monitoring-location/components/hydrograph/selectors/discrete-data', ()
 
             expect(result).toHaveLength(2);
             expect(result[0]).toEqual({
+                'qualifiers': 'P',
                 value: 13.0,
                 dateTime: 1490536800000
             });
             expect(result[1]).toEqual({
+                'qualifiers': 'A',
                 value: 14.5,
                 dateTime: 1490882400000
             });
@@ -123,11 +125,13 @@ describe('monitoring-location/components/hydrograph/selectors/discrete-data', ()
 
             expect(result).toHaveLength(2);
             expect(result[0]).toEqual({
+                approvals: 'Provisional',
                 parameterName: 'Depth to water level',
                 result: '13',
                 dateTime: '2017-03-26T09:00-05:00'
             });
             expect(result[1]).toEqual({
+                'approvals': 'Approved',
                 parameterName: 'Depth to water level',
                 result: '14.5',
                 dateTime: '2017-03-30T09:00-05:00'

--- a/assets/src/scripts/utils.js
+++ b/assets/src/scripts/utils.js
@@ -290,3 +290,17 @@ export const getNearestTime = function(data, time) {
     // Return the nearest data point and its index.
     return datum;
 };
+
+/*
+*
+*/
+export const approvalCodeText = function(approvalCode) {
+    const approvalText = {
+        P: 'Provisional',
+        A: 'Approved',
+        E: 'Estimated',
+        default: 'unknown code'
+    };
+
+    return approvalText[approvalCode] || approvalText.default;
+};

--- a/assets/src/scripts/utils.js
+++ b/assets/src/scripts/utils.js
@@ -292,7 +292,9 @@ export const getNearestTime = function(data, time) {
 };
 
 /*
-*
+* When given an approval code, will return the text equivalent
+*  @param {String} approvalCode - Usually a letter such as 'A'
+*   @return {String} - an easy to understand text version of an approval code
 */
 export const approvalCodeText = function(approvalCode) {
     const approvalText = {

--- a/assets/src/scripts/utils.js
+++ b/assets/src/scripts/utils.js
@@ -301,6 +301,7 @@ export const approvalCodeText = function(approvalCode) {
         P: 'Provisional',
         A: 'Approved',
         E: 'Estimated',
+        p: 'Partial record',
         default: `unknown code: ${approvalCode}`
     };
 

--- a/assets/src/scripts/utils.js
+++ b/assets/src/scripts/utils.js
@@ -301,7 +301,7 @@ export const approvalCodeText = function(approvalCode) {
         P: 'Provisional',
         A: 'Approved',
         E: 'Estimated',
-        default: 'unknown code'
+        default: `unknown code: ${approvalCode}`
     };
 
     return approvalText[approvalCode] || approvalText.default;

--- a/assets/src/scripts/utils.js
+++ b/assets/src/scripts/utils.js
@@ -300,8 +300,8 @@ export const approvalCodeText = function(approvalCode) {
     const approvalText = {
         P: 'Provisional',
         A: 'Approved',
+        R: 'Revised',
         E: 'Estimated',
-        p: 'Partial record',
         default: `unknown code: ${approvalCode}`
     };
 

--- a/assets/src/scripts/utils.test.js
+++ b/assets/src/scripts/utils.test.js
@@ -1,20 +1,10 @@
 import {
-    approvalCodeText, unicodeHtmlEntity, getHtmlFromString, replaceHtmlEntities, setEquality,
+    unicodeHtmlEntity, getHtmlFromString, replaceHtmlEntities, setEquality,
     calcStartTime, callIf, parseRDB, convertFahrenheitToCelsius,
     convertCelsiusToFahrenheit, sortedParameters, getNearestTime} from './utils';
 
 
 describe('Utils module', () => {
-
-    describe('approvalCodeText', () => {
-        it('Will return a text explanation for a known code', () => {
-            expect(approvalCodeText('A')).toBe('Approved');
-        });
-        it('Will return a text message for any code not known', () => {
-            expect(approvalCodeText('some messed up code')).toBe('unknown code: some messed up code');
-        });
-    });
-
     describe('unicodeHtmlEntity', () => {
 
         it('Can determine the unicode of a decimal entity', () => {

--- a/assets/src/scripts/utils.test.js
+++ b/assets/src/scripts/utils.test.js
@@ -1,11 +1,19 @@
-import {select} from 'd3-selection';
 import {
-    unicodeHtmlEntity, getHtmlFromString, replaceHtmlEntities, setEquality,
-    wrap, mediaQuery, calcStartTime, callIf, parseRDB, convertFahrenheitToCelsius,
+    approvalCodeText, unicodeHtmlEntity, getHtmlFromString, replaceHtmlEntities, setEquality,
+    calcStartTime, callIf, parseRDB, convertFahrenheitToCelsius,
     convertCelsiusToFahrenheit, sortedParameters, getNearestTime} from './utils';
 
 
 describe('Utils module', () => {
+
+    describe('approvalCodeText', () => {
+        it('Will return a text explanation for a known code', () => {
+            expect(approvalCodeText('A')).toBe('Approved');
+        });
+        it('Will return a text message for any code not known', () => {
+            expect(approvalCodeText('some messed up code')).toBe('unknown code');
+        });
+    });
 
     describe('unicodeHtmlEntity', () => {
 

--- a/assets/src/scripts/utils.test.js
+++ b/assets/src/scripts/utils.test.js
@@ -11,7 +11,7 @@ describe('Utils module', () => {
             expect(approvalCodeText('A')).toBe('Approved');
         });
         it('Will return a text message for any code not known', () => {
-            expect(approvalCodeText('some messed up code')).toBe('unknown code');
+            expect(approvalCodeText('some messed up code')).toBe('unknown code: some messed up code');
         });
     });
 


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [x] Update the changelog appropriately

IOW-866 Add Approvals to Groundwater Level Table
-----------
Adds a column indicating the approval status of the data to the DV (groundwater) Data Table.

Description
-----------
Looks like this . . .
![image](https://user-images.githubusercontent.com/36997804/108567681-4d430780-72ce-11eb-8040-a7d7d63c961c.png)

This is a monitoring location with a provisional value, http://localhost:5050/monitoring-location/375259097252901/#parameterCode=72019 , which looks like . . . 
![image](https://user-images.githubusercontent.com/36997804/108567797-854a4a80-72ce-11eb-934a-add8fd51f8aa.png)


After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
