### PR TITLE
Wdfn 514 rework questions comments button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - The data loading indicator for the hydrograph now appears on top of the graph rather than with the date controls.
+- Floating feedback link is now centered on page and an additional link added in header.
 
 ## [0.43.0](https://github.com/usgs/waterdataui/compare/waterdataui-0.43.0...waterdataui-0.42.0)
 ### Added

--- a/assets/src/styles/pages/_monitoring-location.scss
+++ b/assets/src/styles/pages/_monitoring-location.scss
@@ -70,7 +70,8 @@ table {
     @include u-margin-right(2);
     border-radius: 15px 15px 0 0;
     display: block;
-    float: right;
+    width: 17em;
+    margin: 0 auto;
     @include u-padding-left(2);
     @include u-padding-right(2);
   }

--- a/wdfn-server/waterdata/templates/monitoring_location.html
+++ b/wdfn-server/waterdata/templates/monitoring_location.html
@@ -305,7 +305,7 @@
     <div class="user-feedback">
         <a href="{{ url_for('questions_comments', email_for_data_questions=email_for_data_questions) }}"
            target="_blank"
-           ga-on="click" ga-event-category="navigation" ga-event-action="toFeedBackForm">
+           ga-on="click" ga-event-category="navigation" ga-event-action="toFeedBackForm_floatingLink">
             <p class="usa-prose">Questions or Comments</p>
         </a>
     </div>

--- a/wdfn-server/waterdata/templates/partials/header.html
+++ b/wdfn-server/waterdata/templates/partials/header.html
@@ -130,6 +130,13 @@
                   <li class="usa-nav__secondary-item">
                       <a href="https://dashboard.waterdata.usgs.gov/" rel="noopener">Water Dashboard</a>
                   </li>
+                  <li class="usa-nav__secondary-item">
+                      <a href="{{ url_for('questions_comments', email_for_data_questions=email_for_data_questions) }}"
+                         target="_blank"
+                         ga-on="click" ga-event-category="navigation" ga-event-action="toFeedBackForm_navbar">
+                          Questions or Comments
+                      </a>
+                  </li>
               </ul>
             </div>
         </div>


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [x] Update the changelog appropriately

WDFN-514 Rework Questions and Comments Button
-----------
User testing indicated that the floating feedback, when located to the far right, was utterly invisible to users. So this tries something different. 

Description
-----------
To help users see the feedback button, it is now moved to a centered location. Additionally, a second link has been added to the link section of the header so that we can user test and see which location is the most visible to users. 

Image of links
![image](https://user-images.githubusercontent.com/36997804/110867231-138d6d00-828c-11eb-9e35-6bc9ce8f68ae.png)


After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
