### PR TITLE
Wdfn 506 - Flood Data line is being drawn below hydrograph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ recent data is chosen.
 ### Added
 - If the graph shows no data for the selected time range, a message will appear on top of the graph. In addition, if a particular kind of selected data isn't available (for instance if compare to last year is selected and there is no data for that time range)
 
+### Fixed
+- Flood lines are now only rendered if in range of the Y axis.
+
 ## [0.43.0](https://github.com/usgs/waterdataui/compare/waterdataui-0.43.0...waterdataui-0.42.0)
 ### Added
 - A column indicating the approval status of the data shows in the Field Visit Data Table.

--- a/assets/src/scripts/monitoring-location/components/hydrograph/discrete-data.test.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/discrete-data.test.js
@@ -20,11 +20,11 @@ describe('monitoring-location/components/hydrograph/discrete-data', () => {
                 {value: '13.0', dateTime: 1489672100000, label: 'Provisional', classes: ['gw-class', 'provisional'], radius: 5}
             ];
             xScale = scaleLinear()
-                .domain([0, 100])
-                .range([1489000000000, 1500000000000]);
+                .range([0, 100])
+                .domain([1489000000000, 1500000000000]);
             yScale = scaleLinear()
-                .domain([0, 100])
-                .range([11.0, 15.0]);
+                .range([0, 100])
+                .domain([11.0, 15.0]);
         });
 
         afterEach(() => {

--- a/assets/src/scripts/monitoring-location/components/hydrograph/flood-level-lines.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/flood-level-lines.js
@@ -1,11 +1,16 @@
 import {line as d3Line} from 'd3-shape';
 
 /*
- * Draws the flood lines
+ * Renders the flood lines if available and visible on svg.
+ * @param {D3 selection for svg or group} svg
+ * @param {Boolean} visible
+ * @param {D3 scale} xscale
+ * @param {D3 scale} yscale
+ * @param {Array of Object} floodLevels - array elements describe value, label and class.
  */
-export const drawFloodLevelLines = function(elem, {visible, xscale, yscale, floodLevels}) {
-    elem.select('#flood-level-points').remove();
-    const container = elem.append('g')
+export const drawFloodLevelLines = function(svg, {visible, xscale, yscale, floodLevels}) {
+    svg.select('#flood-level-points').remove();
+    const container = svg.append('g')
         .lower()
         .attr('id', 'flood-level-points');
 

--- a/assets/src/scripts/monitoring-location/components/hydrograph/flood-level-lines.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/flood-level-lines.js
@@ -1,0 +1,29 @@
+import {line as d3Line} from 'd3-shape';
+
+/*
+ * Draws the flood lines
+ */
+export const drawFloodLevelLines = function(elem, {visible, xscale, yscale, floodLevels}) {
+    elem.select('#flood-level-points').remove();
+    const container = elem.append('g')
+        .lower()
+        .attr('id', 'flood-level-points');
+
+    if (!visible) {
+        return;
+    }
+
+    const xRange = xscale.range();
+    const [yStart, yEnd] = yscale.domain();
+    floodLevels.forEach((level) => {
+        if (level.value >= yStart && level.value <= yEnd) {
+            const group = container.append('g');
+            const yRange = yscale(level.value);
+            const floodLine = d3Line()([[xRange[0], yRange], [xRange[1], yRange]]);
+            group.append('path')
+                .classed('waterwatch-data-series', true)
+                .classed(level.class, true)
+                .attr('d', floodLine);
+        }
+    });
+};

--- a/assets/src/scripts/monitoring-location/components/hydrograph/flood-level-lines.test.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/flood-level-lines.test.js
@@ -1,0 +1,86 @@
+import {select} from 'd3-selection';
+import {scaleLinear} from 'd3-scale';
+
+import {drawFloodLevelLines} from './flood-level-lines';
+
+describe('monitoring-location/components/hydrograph/flood-level-lines', () => {
+    let svg;
+    beforeEach(() => {
+        svg = select('body').append('svg')
+    });
+
+    afterEach(() => {
+        svg.remove();
+    });
+    describe('drawFloodLevelLines', () => {
+        let xscale, yscale;
+        const TEST_LEVELS = [
+            {value: 5, label: 'Action stage', class: 'action-stage'},
+            {value: 10, label: 'Flood stage', class: 'flood-stage'},
+            {value: 12, label: 'Moderate flood stage', class: 'moderate-flood-stage'},
+            {value: 14, label: 'Major flood stage', class: 'major-flood-stage'}
+        ];
+        beforeEach(() => {
+            xscale = scaleLinear()
+                .domain([1489000000000, 1500000000000])
+                .range([0, 100]);
+            yscale = scaleLinear()
+                .domain([4, 11.5])
+                .range([0, 100]);
+        });
+
+        it('Does not render the flood levels if not visible', () => {
+            drawFloodLevelLines(svg, {
+                visible: false,
+                xscale,
+                yscale,
+                floodLevels: TEST_LEVELS
+            });
+            const group = svg.select('#flood-level-points');
+            expect(group.select('g').size()).toBe(0);
+        });
+
+        it('Does not render flood levels if non are defined', () => {
+            drawFloodLevelLines(svg, {
+                visible: true,
+                xscale,
+                yscale,
+                floodLevels: []
+            });
+            const group = svg.select('#flood-level-points');
+            expect(group.select('g').size()).toBe(0);
+        });
+
+        it('Renders visible flood levels', () => {
+            drawFloodLevelLines(svg, {
+                visible: true,
+                xscale,
+                yscale,
+                floodLevels: TEST_LEVELS
+            });
+            const group = svg.select('#flood-level-points');
+            expect(group.select('.action-stage').size()).toBe(1);
+            expect(group.select('.flood-stage').size()).toBe(1);
+            expect(group.select('.moderate-flood-stage').size()).toBe(0);
+            expect(group.select('.major-flood-stage').size()).toBe(0);
+        });
+
+        it('Will remove flood levels if no longer visible', () => {
+            drawFloodLevelLines(svg, {
+                visible: true,
+                xscale,
+                yscale,
+                floodLevels: TEST_LEVELS
+            });
+            drawFloodLevelLines(svg, {
+                visible: false,
+                xscale,
+                yscale,
+                floodLevels: TEST_LEVELS
+            });
+
+            const group = svg.select('#flood-level-points');
+            expect(group.select('g').size()).toBe(0);
+        });
+    });
+});

--- a/assets/src/scripts/monitoring-location/components/hydrograph/flood-level-lines.test.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/flood-level-lines.test.js
@@ -40,7 +40,7 @@ describe('monitoring-location/components/hydrograph/flood-level-lines', () => {
             expect(group.select('g').size()).toBe(0);
         });
 
-        it('Does not render flood levels if non are defined', () => {
+        it('Does not render flood levels if none are defined', () => {
             drawFloodLevelLines(svg, {
                 visible: true,
                 xscale,

--- a/assets/src/scripts/monitoring-location/components/hydrograph/selectors/flood-level-data.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/selectors/flood-level-data.js
@@ -1,0 +1,39 @@
+import {createSelector} from 'reselect';
+
+import {getWaterwatchFloodLevels} from 'ml/selectors/flood-data-selector';
+
+const STAGES = {
+    actionStage: {
+        label: 'Action stage',
+        class: 'action-stage'
+    },
+    floodStage: {
+        label: 'Flood stage',
+        class: 'flood-stage'
+    },
+    moderateFloodStage: {
+        label: 'Moderate flood stage',
+        class: 'moderate-flood-stage'
+    },
+    majorFloodStage: {
+        label: 'Major flood stage',
+        class: 'major-flood-stage'
+    }
+};
+
+export const getFloodLevelData = createSelector(
+    getWaterwatchFloodLevels,
+    levels => {
+        const result = [];
+        Object.keys(levels).forEach(stage => {
+            if (levels[stage]) {
+                result.push({
+                    value: levels[stage],
+                    label: STAGES[stage].label,
+                    class: STAGES[stage].class
+                });
+            }
+        });
+        return result;
+    }
+);

--- a/assets/src/scripts/monitoring-location/components/hydrograph/selectors/flood-level-data.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/selectors/flood-level-data.js
@@ -21,19 +21,28 @@ const STAGES = {
     }
 };
 
+/*
+ * Returns a selector function which returns an array of {Object}. Each object
+ * represents a flood level and includes the properties:
+ *      @prop {Number} value - the value of the flood level
+ *      @prop {String} label - a human friendly label for the flood level
+ *      @prop {String} class - a class to be used to decorate the flood level
+ */
 export const getFloodLevelData = createSelector(
     getWaterwatchFloodLevels,
     levels => {
         const result = [];
-        Object.keys(levels).forEach(stage => {
-            if (levels[stage]) {
-                result.push({
-                    value: levels[stage],
-                    label: STAGES[stage].label,
-                    class: STAGES[stage].class
-                });
-            }
-        });
+        if (levels) {
+            Object.keys(levels).forEach(stage => {
+                if (levels[stage]) {
+                    result.push({
+                        value: levels[stage],
+                        label: STAGES[stage].label,
+                        class: STAGES[stage].class
+                    });
+                }
+            });
+        }
         return result;
     }
 );

--- a/assets/src/scripts/monitoring-location/components/hydrograph/selectors/flood-level-data.test.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/selectors/flood-level-data.test.js
@@ -1,0 +1,31 @@
+import {getFloodLevelData} from './flood-level-data';
+
+describe('monitoring-location/components/hydrograph/selectors/flood-level-data', () => {
+
+    describe('getFloodLevelData', () => {
+        it('Returns an empty array if no flood data', () => {
+            expect(getFloodLevelData({
+                floodData: {
+                    floodLevels: null
+                }
+            })).toHaveLength(0);
+        });
+
+        it('Returns the expected data for flood data', () => {
+            const result = getFloodLevelData({
+                floodData: {
+                    floodLevels: {
+                        action_stage: '5',
+                        flood_stage: '10',
+                        moderate_flood_stage: '12',
+                        major_flood_stage: '14'
+                    }
+                }
+            });
+            expect(result).toHaveLength(4);
+            expect(result[0].label).toBeDefined();
+            expect(result[0].class).toBeDefined();
+            expect(result.map(level => level.value)).toEqual([5, 10, 12, 14]);
+        });
+    });
+});

--- a/assets/src/scripts/monitoring-location/components/hydrograph/selectors/legend-data.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/selectors/legend-data.js
@@ -4,12 +4,13 @@ import config from 'ui/config';
 
 import {defineLineMarker, defineRectangleMarker, defineCircleMarker, defineTextOnlyMarker} from 'd3render/markers';
 
-import {getWaterwatchFloodLevels, isWaterwatchVisible} from 'ml/selectors/flood-data-selector';
+import {isWaterwatchVisible} from 'ml/selectors/flood-data-selector';
 import {getPrimaryMedianStatisticsData, getPrimaryParameter} from 'ml/selectors/hydrograph-data-selector';
 import {isCompareIVDataVisible, isMedianDataVisible} from 'ml/selectors/hydrograph-state-selector';
 
-import {getIVUniqueDataKinds, HASH_ID} from './iv-data';
 import {getUniqueGWKinds} from './discrete-data';
+import {getFloodLevelData} from './flood-level-data';
+import {getIVUniqueDataKinds, HASH_ID} from './iv-data';
 
 const TS_LABEL = {
     'primary': 'Current: ',
@@ -32,7 +33,7 @@ const getLegendDisplay = createSelector(
     getIVUniqueDataKinds('primary'),
     getIVUniqueDataKinds('compare'),
     isWaterwatchVisible,
-    getWaterwatchFloodLevels,
+    getFloodLevelData,
     getUniqueGWKinds,
     getPrimaryParameter,
     (showCompare, showMedian, medianSeries, currentClasses, compareClasses, showWaterWatch, floodLevels, gwLevelKinds,
@@ -111,36 +112,14 @@ const getGWMarkers = function(gwLevelKinds) {
     }
 };
 
-const floodLevelDisplay = function(floodLevels) {
-    let floodLevelsForDisplay = {};
-    Object.keys(floodLevels).forEach(key => {
-        if (floodLevels[key]) {
-            const keyWithCapitalFirstLetter = `${key.charAt(0).toUpperCase()}${key.slice(1)}`;
-            // Format label by cutting the camel case word at upper case letters
-            const label = keyWithCapitalFirstLetter.match(/([A-Z]?[^A-Z]*)/g).slice(0,-1);
-
-            Object.assign(floodLevelsForDisplay,
-                {[key]: {
-                    'label': [label.join(' ')],
-                    'class': [label.join('-').toLowerCase()]
-                }}
-            );
-        }
-    });
-
-    return floodLevelsForDisplay;
-};
-
 const getFloodLevelMarkers = function(floodLevels) {
-    const floodLevelsForDisplay = floodLevelDisplay(floodLevels);
-
-    return Object.keys(floodLevelsForDisplay).map((stage) => {
+    return floodLevels.map((level) => {
         return [
-            defineTextOnlyMarker(floodLevelsForDisplay[stage].label),
+            defineTextOnlyMarker(level.label),
             defineLineMarker(
                 null,
-                `waterwatch-data-series ${floodLevelsForDisplay[stage].class}`,
-                `${floodLevels[stage]} ft`)
+                `waterwatch-data-series ${level.class}`,
+                `${level.value} ft`)
         ];
     });
 };

--- a/assets/src/scripts/monitoring-location/selectors/flood-data-selector.test.js
+++ b/assets/src/scripts/monitoring-location/selectors/flood-data-selector.test.js
@@ -105,8 +105,16 @@ describe('monitoring-location/selectors/flood-data-selector', () => {
         });
     });
 
-    describe('getWaterwatchData', () => {
-        it('Return true if waterwatch flood levels are returned', () => {
+    describe('getWaterwatchFloodLevels', () => {
+        it('Expects null if no flood levels are defined', () => {
+           expect(getWaterwatchFloodLevels({
+               floodData: {
+                   floodLevels: null
+               }
+           })).toBeNull();
+        });
+        
+        it('Waterwatch flood levels are returned', () => {
             expect(Object.values(getWaterwatchFloodLevels({
                 floodData: {
                     floodLevels: {


### PR DESCRIPTION
Before making a pull request
----------------------------

- [X] Make sure all tests run
- [X] Update the changelog appropriately

Description
-----------
All flood data lines were being rendered even if outside the range of the graph. This caused flood lines to occasionally appear just below and just above the graph. I took this opportunity to refactor the flood line rendering code to follow the same pattern as the IV and GW levels data in that a selector was created which returned the information needed to render the lines and to render the legend. Also simplified the drawing code since it is really just a straight horizontal line across the width of the graph.


After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the JIRA ticket
- [ ] Assign someone to review unless the change is trivial
