### PR TITLE
fix feedback links for networks pages

### DIFF
--- a/assets/src/scripts/monitoring-location/components/hydrograph/date-controls.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/date-controls.js
@@ -55,7 +55,7 @@ const isCustomPeriod = function(dateRange) {
 * time spans to graph (P7D, P30D, P365D), or they can select a 'custom' time span in the form of calendar dates or a
 * numerical entry of days before today. Only the calendar dates is a 'custom' selection. Even though 'days before today'
 * is a custom choice by users, it uses the standard time span format of P<some number of days>D (such as P34D), so
-* in for this function selection of days before today is NOT custom.
+* in this function selection of days before today is NOT custom.
 * @param {String} dateRange -- Will be either one of the quick select time spans (P7D, P30D, P365D) or the word 'custom'
 * or a 'custom' days selection with the form of P<some number of days>D (such as P3230D).
 * @return {Boolean} -- true if the user selection is 'Calendar Dates'.

--- a/wdfn-server/waterdata/templates/partials/footer.html
+++ b/wdfn-server/waterdata/templates/partials/footer.html
@@ -1,6 +1,6 @@
 {% if request.endpoint == 'monitoring_location' or request.endpoint == 'networks'%}
     <div class="user-feedback">
-        <a href="{{ url_for('questions_comments', page_type=page_type, email_for_data_questions=email_for_data_questions) }}"
+        <a href="{{ url_for('questions_comments', referring_page_type=referring_page_type, email_for_data_questions=email_for_data_questions) }}"
            target="_blank"
            ga-on="click" ga-event-category="navigation" ga-event-action="toFeedBackForm_floatingLink">
             <p class="usa-prose">Questions or Comments</p>

--- a/wdfn-server/waterdata/templates/partials/footer.html
+++ b/wdfn-server/waterdata/templates/partials/footer.html
@@ -1,10 +1,12 @@
-<div class="user-feedback">
-    <a href="{{ url_for('questions_comments', email_for_data_questions=email_for_data_questions) }}"
-       target="_blank"
-       ga-on="click" ga-event-category="navigation" ga-event-action="toFeedBackForm_floatingLink">
-        <p class="usa-prose">Questions or Comments</p>
-    </a>
-</div>
+{% if request.endpoint == 'monitoring_location' or request.endpoint == 'networks'%}
+    <div class="user-feedback">
+        <a href="{{ url_for('questions_comments', page_type=page_type, email_for_data_questions=email_for_data_questions) }}"
+           target="_blank"
+           ga-on="click" ga-event-category="navigation" ga-event-action="toFeedBackForm_floatingLink">
+            <p class="usa-prose">Questions or Comments</p>
+        </a>
+    </div>
+{%  endif %}
 <footer class="usa-footer usa-footer-slim" role="contentinfo">
     <nav class="usa-footer-primary-section content-container" aria-label="Footer Navigation">
         <div class="usgs-footer-nav">

--- a/wdfn-server/waterdata/templates/partials/footer.html
+++ b/wdfn-server/waterdata/templates/partials/footer.html
@@ -1,4 +1,4 @@
-{% if request.endpoint == 'monitoring_location' or request.endpoint == 'networks'%}
+{% if has_feedback_link(request.endpoint) %}
     <div class="user-feedback">
         <a href="{{ url_for('questions_comments', referring_page_type=referring_page_type, email_for_data_questions=email_for_data_questions) }}"
            target="_blank"

--- a/wdfn-server/waterdata/templates/partials/header.html
+++ b/wdfn-server/waterdata/templates/partials/header.html
@@ -130,13 +130,15 @@
                   <li class="usa-nav__secondary-item">
                       <a href="https://dashboard.waterdata.usgs.gov/" rel="noopener">Water Dashboard</a>
                   </li>
-                  <li class="usa-nav__secondary-item">
-                      <a href="{{ url_for('questions_comments', email_for_data_questions=email_for_data_questions) }}"
-                         target="_blank"
-                         ga-on="click" ga-event-category="navigation" ga-event-action="toFeedBackForm_navbar">
-                          Questions or Comments
-                      </a>
-                  </li>
+                  {% if request.endpoint == 'monitoring_location' or request.endpoint == 'networks'%}
+                      <li class="usa-nav__secondary-item">
+                          <a href="{{ url_for('questions_comments', page_type=page_type, email_for_data_questions=email_for_data_questions) }}"
+                             target="_blank"
+                             ga-on="click" ga-event-category="navigation" ga-event-action="toFeedBackForm_navbar">
+                              Questions or Comments
+                          </a>
+                      </li>
+                  {% endif %}
               </ul>
             </div>
         </div>

--- a/wdfn-server/waterdata/templates/partials/header.html
+++ b/wdfn-server/waterdata/templates/partials/header.html
@@ -132,7 +132,7 @@
                   </li>
                   {% if request.endpoint == 'monitoring_location' or request.endpoint == 'networks'%}
                       <li class="usa-nav__secondary-item">
-                          <a href="{{ url_for('questions_comments', page_type=page_type, email_for_data_questions=email_for_data_questions) }}"
+                          <a href="{{ url_for('questions_comments', referring_page_type=referring_page_type, email_for_data_questions=email_for_data_questions) }}"
                              target="_blank"
                              ga-on="click" ga-event-category="navigation" ga-event-action="toFeedBackForm_navbar">
                               Questions or Comments

--- a/wdfn-server/waterdata/templates/partials/header.html
+++ b/wdfn-server/waterdata/templates/partials/header.html
@@ -130,7 +130,7 @@
                   <li class="usa-nav__secondary-item">
                       <a href="https://dashboard.waterdata.usgs.gov/" rel="noopener">Water Dashboard</a>
                   </li>
-                  {% if request.endpoint == 'monitoring_location' or request.endpoint == 'networks'%}
+                  {% if has_feedback_link(request.endpoint)%}
                       <li class="usa-nav__secondary-item">
                           <a href="{{ url_for('questions_comments', referring_page_type=referring_page_type, email_for_data_questions=email_for_data_questions) }}"
                              target="_blank"

--- a/wdfn-server/waterdata/templates/questions_comments.html
+++ b/wdfn-server/waterdata/templates/questions_comments.html
@@ -30,8 +30,7 @@
         <form class="usa-form" action="{{ url_for('questions_comments', email_for_data_questions=email_for_data_questions) }}" method="post" >
             <fieldset id="feedback-destination-selection" class="usa-fieldset">
                 <legend class="usa-legend usa-legend">Let us help you to:</legend>
-
-                {% if page_type == "monitoring" %}
+                {% if referring_page_type == "monitoring" %}
                     <div class="usa-radio">
                         <input class="usa-radio__input" id="feedback-selection-contact" type="radio" name="feedback-type" value="contact" required>
                         <label class="usa-radio__label" for="feedback-selection-contact">Contact someone about data at this location</label>
@@ -40,7 +39,7 @@
                 <div class="usa-radio">
                     <input class="usa-radio__input" id="feedback-selection-report" type="radio" name="feedback-type" value="report">
                     <label class="usa-radio__label" for="feedback-selection-report">
-                        Report a problem{%  if page_type ==  "monitoring" %} with this location {% endif %}
+                        Report a problem{%  if referring_page_type ==  "monitoring" %} with this location {% endif %}
                     </label>
                 </div>
                 <div class="usa-radio">

--- a/wdfn-server/waterdata/templates/questions_comments.html
+++ b/wdfn-server/waterdata/templates/questions_comments.html
@@ -30,13 +30,18 @@
         <form class="usa-form" action="{{ url_for('questions_comments', email_for_data_questions=email_for_data_questions) }}" method="post" >
             <fieldset id="feedback-destination-selection" class="usa-fieldset">
                 <legend class="usa-legend usa-legend">Let us help you to:</legend>
-                <div class="usa-radio">
-                    <input class="usa-radio__input" id="feedback-selection-contact" type="radio" name="feedback-type" value="contact" required>
-                    <label class="usa-radio__label" for="feedback-selection-contact">Contact someone about data at this location</label>
-                </div>
+
+                {% if page_type == "monitoring" %}
+                    <div class="usa-radio">
+                        <input class="usa-radio__input" id="feedback-selection-contact" type="radio" name="feedback-type" value="contact" required>
+                        <label class="usa-radio__label" for="feedback-selection-contact">Contact someone about data at this location</label>
+                    </div>
+                {% endif %}
                 <div class="usa-radio">
                     <input class="usa-radio__input" id="feedback-selection-report" type="radio" name="feedback-type" value="report">
-                    <label class="usa-radio__label" for="feedback-selection-report">Report a problem with this location</label>
+                    <label class="usa-radio__label" for="feedback-selection-report">
+                        Report a problem{%  if page_type ==  "monitoring" %} with this location {% endif %}
+                    </label>
                 </div>
                 <div class="usa-radio">
                     <input class="usa-radio__input" id="feedback-selection-comment" type="radio" name="feedback-type" value="comment">

--- a/wdfn-server/waterdata/tests/test_views.py
+++ b/wdfn-server/waterdata/tests/test_views.py
@@ -32,7 +32,7 @@ class TestQuestionsCommentsView(TestCase):
 
     def test_successful_view(self):
         fake_email = 'test%40test.gov'
-        response = self.app_client.get('/questions-comments/{}/'.format(fake_email))
+        response = self.app_client.get('/questions-comments/{}/?referring_page_type=monitoring'.format(fake_email))
         self.assertEqual(200, response.status_code)
 
 

--- a/wdfn-server/waterdata/views.py
+++ b/wdfn-server/waterdata/views.py
@@ -34,7 +34,7 @@ def questions_comments(email_for_data_questions):
     """Render the user feedback form."""
     referring_url = request.referrer
     user_system_data = request.user_agent.string
-    page_type = request.args.get('page_type')
+    referring_page_type = request.args.get('referring_page_type')
 
     if request.method == 'POST':
         target_email = email_for_data_questions
@@ -59,7 +59,7 @@ def questions_comments(email_for_data_questions):
         'questions_comments.html',
         email_for_data_questions=email_for_data_questions,
         monitoring_location_url=referring_url,
-        page_type=page_type
+        referring_page_type=referring_page_type
     )
 
 
@@ -182,7 +182,7 @@ def monitoring_location(site_no):
                 'parm_grp_summary': grouped_dataseries,
                 'cooperators': cooperators,
                 'email_for_data_questions': email_for_data_questions,
-                'page_type': 'monitoring',
+                'referring_page_type': 'monitoring',
                 'cameras': get_monitoring_location_camera_details((site_no)) if app.config[
                     'MONITORING_LOCATION_CAMERA_ENABLED'] else []
             }
@@ -293,7 +293,7 @@ def networks(network_cd):
         extent=extent,
         narrative=narrative,
         email_for_data_questions=app.config['EMAIL_TARGET']['report'],
-        page_type='network'
+        referring_page_type='network'
     ), http_code
 
 

--- a/wdfn-server/waterdata/views.py
+++ b/wdfn-server/waterdata/views.py
@@ -23,6 +23,22 @@ from .constants import STATION_FIELDS_D
 
 NWIS = NwisWebServices(app.config['SERVER_SERVICE_ROOT'], app.config['SITE_SERVICE_CATALOG_ROOT'])
 
+
+def has_feedback_link(request_endpoint):
+    """
+    Return true if page is eligible for feedback form links
+    :return: Boolean
+    """
+    if request_endpoint == 'monitoring_location' or request_endpoint == 'networks':
+        return True
+    else:
+        return False
+
+
+@app.context_processor
+def inject_has_feedback_link():
+    return dict(has_feedback_link=has_feedback_link)
+
 @app.route('/')
 def home():
     """Render the home page."""

--- a/wdfn-server/waterdata/views.py
+++ b/wdfn-server/waterdata/views.py
@@ -34,6 +34,7 @@ def questions_comments(email_for_data_questions):
     """Render the user feedback form."""
     referring_url = request.referrer
     user_system_data = request.user_agent.string
+    page_type = request.args.get('page_type')
 
     if request.method == 'POST':
         target_email = email_for_data_questions
@@ -57,7 +58,8 @@ def questions_comments(email_for_data_questions):
     return render_template(
         'questions_comments.html',
         email_for_data_questions=email_for_data_questions,
-        monitoring_location_url=referring_url
+        monitoring_location_url=referring_url,
+        page_type=page_type
     )
 
 
@@ -180,6 +182,7 @@ def monitoring_location(site_no):
                 'parm_grp_summary': grouped_dataseries,
                 'cooperators': cooperators,
                 'email_for_data_questions': email_for_data_questions,
+                'page_type': 'monitoring',
                 'cameras': get_monitoring_location_camera_details((site_no)) if app.config[
                     'MONITORING_LOCATION_CAMERA_ENABLED'] else []
             }
@@ -288,7 +291,9 @@ def networks(network_cd):
         network_cd=network_cd,
         collection=collection,
         extent=extent,
-        narrative=narrative
+        narrative=narrative,
+        email_for_data_questions=app.config['EMAIL_TARGET']['report'],
+        page_type='network'
     ), http_code
 
 


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [ ] Update the changelog appropriately

WDFN-512 Change Order of Custom Date (Fix links to feedback form on Network pages) 
-----------
I realized that there was a problem with the way the links to the Feedback form worked on the Network pages. The gist of it is, the feedback form that is called from a Monitoring Location page needs an email address that is regionally specific to that monitoring location. Since there is no one monitoring location on a Networks page, there is no region specific email associated with that page. 

A second issue is that the radio button selections have wording tailored to the giving feedback on for monitoring location page which didn't make much sense for feedback on a Networks page. 

Description
-----------
To deal with the above issues
1) I added a query parameter called 'page_type' that can tell the feedback form which page requested it.
2) On Network pages the URL for the feedback page uses the Default NWIS support email.
3) On the Feedback form called from a Networks page the option to ask a question about the data  has been removed.
4) Conditional Logic was added to the creation of the feedback link in both the header and the footer so that those links will only show on Monitoring Location and Networks pages. 

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
