### PR TITLE
Wdfn 520 estimated not rendering correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Reworked Parameter Selection Table--removed tooltips, WaterAlert subscribe, changed from table to UWSD grid, added expandable inner row.
 - Reworked the Change time span section, eliminating the short cut radio buttons for 7/30/365 days. The
 date range now appears first and will be used if filled in. Otherwise, the Days before Today section will be used.
+  
+### Fixed
+- Estimated points are now the correct color, even when the data services return multiple qualifer codes.
 
 ## [0.44.0](https://github.com/usgs/waterdataui/compare/waterdataui-0.43.0...waterdataui-0.44.0) 2021-03-17
 ### Changed

--- a/assets/src/scripts/monitoring-location/components/hydrograph/selectors/iv-data.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/selectors/iv-data.js
@@ -101,7 +101,11 @@ export const getIVDataPoints = memoize(dataKind => createSelector(
             let pointClass;
             const pointQualifiers = point.qualifiers.map(qualifier => qualifier.toLowerCase());
             const maskedQualifier = pointQualifiers.find(qualifier => qualifier in MASKED_QUALIFIERS);
-            const approvalQualifier = pointQualifiers.find(qualifier => qualifier in APPROVAL_QUALIFIERS);
+            // The data services sometimes return more than one approval code per point,
+            // such as ["A", "e"]. In these cases, give priority to 'e', which is 'estimated'.
+            const approvalQualifier = pointQualifiers.includes('e') ? 'e':
+                pointQualifiers.find(qualifier => qualifier in APPROVAL_QUALIFIERS);
+
             if (maskedQualifier) {
                 label = MASKED_QUALIFIERS[maskedQualifier].label;
                 pointClass = MASKED_QUALIFIERS[maskedQualifier].class;

--- a/assets/src/scripts/monitoring-location/components/hydrograph/selectors/iv-data.test.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/selectors/iv-data.test.js
@@ -16,7 +16,7 @@ describe('monitoring-location/components/hydrograph/selectors/iv-data', () => {
                     {value: 24.1, qualifiers: ['A'], dateTime: 1582561800000},
                     {value: null, qualifiers: ['A', 'ICE'], dateTime: 1582562700000},
                     {value: null, qualifiers: ['A', 'ICE'], dateTime: 1582569900000},
-                    {value: 25.2, qualifiers: ['E'], dateTime: 1582570800000},
+                    {value: 25.2, qualifiers: ['A', 'e'], dateTime: 1582570800000},
                     {value: 25.4, qualifiers: ['E'], dateTime: 1600617600000},
                     {value: 25.6, qualifiers: ['E'], dateTime: 1600618500000},
                     {value: 26.5, qualifiers: ['P'], dateTime: 1600619400000},


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [x] Update the changelog appropriately

WDFN-520 Estimated Not Rendering Correctly
-----------
The 'estimated' data points now have the expected color and legend lable.

Description
-----------
Changes here compensated for times with the data services return more than one qualifier code with the 'estimated' code.
The code now give priority to 'estimated', in those cases.

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
