### PR TITLE
Wdfn 537 - Not rendering precipitation correctly on hydrograph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - Estimated points are now the correct color, even when the data services return multiple qualifer codes.
+- Precipitation scale is now correctly determined.
 
 ## [0.44.0](https://github.com/usgs/waterdataui/compare/waterdataui-0.43.0...waterdataui-0.44.0) 2021-03-17
 ### Changed

--- a/assets/src/scripts/monitoring-location/components/hydrograph/selectors/discrete-data.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/selectors/discrete-data.js
@@ -54,6 +54,11 @@ export const getGroundwaterLevelPoints = createSelector(
     }
 );
 
+/*
+ * Returns a selector function which returns a two element Array for the
+ * value range for the groundwater levels.
+ * @return {Function} return an {Array of Number} - [min, max]
+ */
 export const getGroundwaterLevelDataRange = createSelector(
     getGroundwaterLevelPoints,
     points => {
@@ -64,9 +69,11 @@ export const getGroundwaterLevelDataRange = createSelector(
         const values = points.filter(data => data.value !== null).map(data => data.value);
         if (values.length) {
             return [Math.min(...values), Math.max(...values)];
+        } else {
+            return null;
         }
     }
-)
+);
 
 /*
  * Returns a selector function which returns the unique classes/label/radius for the gw level points

--- a/assets/src/scripts/monitoring-location/components/hydrograph/selectors/discrete-data.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/selectors/discrete-data.js
@@ -54,6 +54,20 @@ export const getGroundwaterLevelPoints = createSelector(
     }
 );
 
+export const getGroundwaterLevelDataRange = createSelector(
+    getGroundwaterLevelPoints,
+    points => {
+        if (!points) {
+            return null;
+        }
+
+        const values = points.filter(data => data.value !== null).map(data => data.value);
+        if (values.length) {
+            return [Math.min(...values), Math.max(...values)];
+        }
+    }
+)
+
 /*
  * Returns a selector function which returns the unique classes/label/radius for the gw level points
  * @return {Function} which returns an {Array of Object} with the following properties:

--- a/assets/src/scripts/monitoring-location/components/hydrograph/selectors/discrete-data.test.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/selectors/discrete-data.test.js
@@ -1,7 +1,8 @@
 import config from 'ui/config';
 
-import {getGroundwaterLevelPoints, getUniqueGWKinds, getGroundwaterLevelsTableData,
-    anyVisibleGroundwaterLevels} from './discrete-data';
+import {getGroundwaterLevelPoints, getGroundwaterLevelDataRange, getUniqueGWKinds,
+    getGroundwaterLevelsTableData
+} from './discrete-data';
 
 describe('monitoring-location/components/hydrograph/selectors/discrete-data', () => {
     config.locationTimeZone = 'America/Chicago';
@@ -57,6 +58,18 @@ describe('monitoring-location/components/hydrograph/selectors/discrete-data', ()
             expect(points[3].classes).toContain('revised');
             expect(points[3].label).toEqual('Revised');
             expect(points[3].radius).toBeDefined();
+        });
+    });
+
+    describe('getGroundwaterLevelDataRange', () => {
+        it('Return null if no ground water levels data', () => {
+            expect(getGroundwaterLevelDataRange({
+                hydrographData: {}
+            })).toBeNull();
+        });
+
+        it('Return groundwater range if there is data', () => {
+            expect(getGroundwaterLevelDataRange(TEST_STATE)).toEqual([26.1, 27.2])
         });
     });
 

--- a/assets/src/scripts/monitoring-location/components/hydrograph/selectors/domain.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/selectors/domain.js
@@ -6,11 +6,11 @@ import config from 'ui/config';
 import {mediaQuery} from 'ui/utils';
 
 import {
-    getGroundwaterLevelsValueRange,
     getPrimaryMedianStatisticsValueRange,
     getPrimaryParameter
 } from 'ml/selectors/hydrograph-data-selector';
 
+import {getGroundwaterLevelDataRange} from './discrete-data';
 import {getIVDataRange} from './iv-data';
 import {isVisible} from './time-series-data';
 
@@ -141,8 +141,9 @@ export const getRoundedTickValues = function(additionalTickValues, yDomain) {
 /**
  *  Helper function that, when negative values are present on the y-axis, adds additional negative values to the set of
  *  tick values used to fill tick mark value gaps on the y-axis on some log scale graphs
- * @param {array} tickValues, a set of tick mark values
- * @returns {array} additionalTickValues, a set of tick mark values with (when needed) additional negative values
+ * @param {Array} tickValues, a set of tick mark values
+ * @param {Array} additionalTickValues, a set of tick mark values with (when needed) additional negative values
+ * @retirm {Array}
  */
 export const generateNegativeTicks = function(tickValues, additionalTickValues) {
     if (tickValues.some(value => value < 0)) {
@@ -184,7 +185,7 @@ export const getPrimaryValueRange = createSelector(
     getIVDataRange('primary'),
     getIVDataRange('compare'),
     getPrimaryMedianStatisticsValueRange,
-    getGroundwaterLevelsValueRange,
+    getGroundwaterLevelDataRange,
     getPrimaryParameter,
     (showCompare, showMedian, primaryRange, compareRange, medianRange, gwLevelsRange, parameter) => {
         const valueExtent = [];

--- a/assets/src/scripts/monitoring-location/components/hydrograph/selectors/domain.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/selectors/domain.js
@@ -6,12 +6,12 @@ import config from 'ui/config';
 import {mediaQuery} from 'ui/utils';
 
 import {
-    getIVValueRange,
     getGroundwaterLevelsValueRange,
     getPrimaryMedianStatisticsValueRange,
     getPrimaryParameter
 } from 'ml/selectors/hydrograph-data-selector';
 
+import {getIVDataRange} from './iv-data';
 import {isVisible} from './time-series-data';
 
 const Y_TICK_COUNT = 5;
@@ -181,8 +181,8 @@ export const getFullArrayOfAdditionalTickMarks = function(tickValues, yDomain) {
 export const getPrimaryValueRange = createSelector(
     isVisible('compare'),
     isVisible('median'),
-    getIVValueRange('primary'),
-    getIVValueRange('compare'),
+    getIVDataRange('primary'),
+    getIVDataRange('compare'),
     getPrimaryMedianStatisticsValueRange,
     getGroundwaterLevelsValueRange,
     getPrimaryParameter,

--- a/assets/src/scripts/monitoring-location/components/hydrograph/selectors/iv-data.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/selectors/iv-data.js
@@ -136,7 +136,7 @@ export const getIVDataRange = memoize(dataKind => createSelector(
             return null;
         }
 
-        const sortedValues = points.filter(point => point.value)
+        let sortedValues = points.filter(point => point.value !== null)
             .map(point => point.value)
             .sort((a, b) => a - b);
         if (sortedValues.length) {

--- a/assets/src/scripts/monitoring-location/components/hydrograph/selectors/iv-data.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/selectors/iv-data.js
@@ -129,6 +129,24 @@ export const getIVDataPoints = memoize(dataKind => createSelector(
     }
 ));
 
+export const getIVDataRange = memoize(dataKind => createSelector(
+    getIVDataPoints(dataKind),
+    points => {
+        if (!points) {
+            return null;
+        }
+
+        const sortedValues = points.filter(point => point.value)
+            .map(point => point.value)
+            .sort((a, b) => a - b);
+        if (sortedValues.length) {
+            return [sortedValues[0], sortedValues[sortedValues.length - 1]];
+        } else {
+            return null;
+        }
+    }
+));
+
 /*
  * Returns a selector function which returns an Array of Objects suitable for describing the
  * IV data in a table.

--- a/assets/src/scripts/monitoring-location/components/hydrograph/selectors/iv-data.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/selectors/iv-data.js
@@ -129,6 +129,11 @@ export const getIVDataPoints = memoize(dataKind => createSelector(
     }
 ));
 
+/*
+ * Returns a selector function which returns a two element Array for the
+ * value range for the IV data.
+ * @return {Function} return an {Array of Number} - [min, max]
+ */
 export const getIVDataRange = memoize(dataKind => createSelector(
     getIVDataPoints(dataKind),
     points => {

--- a/assets/src/scripts/monitoring-location/components/hydrograph/selectors/iv-data.test.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/selectors/iv-data.test.js
@@ -1,6 +1,6 @@
 import config from 'ui/config';
 
-import {getIVDataPoints, getIVTableData, getIVDataSegments, getIVUniqueDataKinds} from './iv-data';
+import {getIVDataPoints, getIVDataRange, getIVTableData, getIVDataSegments, getIVUniqueDataKinds} from './iv-data';
 
 describe('monitoring-location/components/hydrograph/selectors/iv-data', () => {
     config.locationTimeZone = 'America/Chicago';
@@ -100,6 +100,17 @@ describe('monitoring-location/components/hydrograph/selectors/iv-data', () => {
             });
         });
     });
+
+    describe('getIVDataRange', () => {
+        it('Return null if no iv data', () => {
+            expect(getIVDataRange('compare')(TEST_STATE)).toBeNull();
+        });
+
+        it('Return the value range if IV Data', () => {
+            expect(getIVDataRange('primary')(TEST_STATE)).toEqual([24.1, 26.5]);
+        });
+    });
+
 
     describe('getIVTableData', () => {
         it('Expect to return an empty array if no IV data', () => {

--- a/assets/src/scripts/monitoring-location/selectors/hydrograph-data-selector.js
+++ b/assets/src/scripts/monitoring-location/selectors/hydrograph-data-selector.js
@@ -31,59 +31,6 @@ export const getMedianStatisticsData = state => state.hydrographData.medianStati
  * @return {Function}
  */
 export const getGroundwaterLevels = state => state.hydrographData.groundwaterLevels ||  null;
-
-/*
- * Returns a selector which returns an Array [min, max] where min and max represent the value range for the IV data of dataKind
- * @param {String} dataKind - 'primary' or 'compare'
- * @return {Function}
- */
-export const getIVValueRange = memoize(dataKind => createSelector(
-    getIVData(dataKind),
-    ivData => {
-        if (!ivData) {
-            return null;
-        }
-
-        const result = Object.values(ivData.values).reduce((minMaxAccumulator, byMethodID) => {
-            const sortedValues = byMethodID.points
-                .map(point => point.value)
-                .filter(pointValue => pointValue !== null)
-                .sort((a, b) => a - b);
-            if (minMaxAccumulator.length && sortedValues && sortedValues.length) {
-                minMaxAccumulator[0] = Math.min(minMaxAccumulator[0], sortedValues[0]);
-                minMaxAccumulator[1] = Math.max(minMaxAccumulator[1], sortedValues[sortedValues.length - 1]);
-            } else if (sortedValues && sortedValues.length) {
-                minMaxAccumulator = [sortedValues[0], sortedValues[sortedValues.length - 1]];
-            }
-            return minMaxAccumulator;
-        }, []);
-        if (result.length) {
-            return result;
-        } else {
-            return null;
-        }
-    }
-));
-
-/*
- * Returns a selector which returns an Array [min, max] representing the value range of the groundwater
- * levels data
- * @return {Function}
- */
-export const getGroundwaterLevelsValueRange = createSelector(
-    getGroundwaterLevels,
-    gwLevels => {
-        if (!gwLevels) {
-            return null;
-        }
-
-        const values = gwLevels.values.filter(data => data.value !== null).map(data => data.value);
-        if (values.length) {
-            return [Math.min(...values), Math.max(...values)];
-        }
-    }
-);
-
 /*
  * Returns a selector function which returns the parameter that the hydrographData is representing
  * an is an Object containing the parameter code, name, description, and unit

--- a/assets/src/scripts/monitoring-location/selectors/hydrograph-data-selector.test.js
+++ b/assets/src/scripts/monitoring-location/selectors/hydrograph-data-selector.test.js
@@ -1,7 +1,7 @@
 import config from 'ui/config';
 
-import {getTimeRange, getIVData, getMedianStatisticsData, getGroundwaterLevels, getIVValueRange,
-    getGroundwaterLevelsValueRange, getPrimaryParameter, getPrimaryMethods, getPrimaryMedianStatisticsData,
+import {getTimeRange, getIVData, getMedianStatisticsData, getGroundwaterLevels, getPrimaryParameter,
+    getPrimaryMethods, getPrimaryMedianStatisticsData,
     getPrimaryMedianStatisticsValueRange
 } from './hydrograph-data-selector';
 
@@ -147,42 +147,6 @@ describe('monitoring-location/selectors/hydrograph-data-selectors', () => {
                     groundwaterLevels: TEST_GROUNDWATER_LEVELS
                 }
             })).toEqual(TEST_GROUNDWATER_LEVELS);
-        });
-    });
-
-    describe('getIVValueRange', () => {
-        it('Returns null if no iv data', () => {
-            expect(getIVValueRange('primary')({
-                hydrographData: {}
-            })).toBeNull();
-        });
-
-        it('Returns value range of the iv data selected', () => {
-            const testState = {
-                'hydrographData': {
-                    primaryIVData: TEST_PRIMARY_IV_DATA,
-                    compareIVData: TEST_COMPARE_IV_DATA
-                }
-            };
-
-            expect(getIVValueRange('primary')(testState)).toEqual([18.2, 20.2]);
-            expect(getIVValueRange('compare')(testState)).toEqual([12.9, 15.2]);
-        });
-    });
-
-    describe('getGroundwaterLevelsValueRange', () => {
-        it('Returns null if no groundwater levels are defined', () => {
-            expect(getGroundwaterLevelsValueRange({
-                hydrographData: {}
-            })).toBeNull();
-        });
-
-        it('Returns value range of the groundwater data', () => {
-            expect(getGroundwaterLevelsValueRange({
-                hydrographData: {
-                    groundwaterLevels: TEST_GROUNDWATER_LEVELS
-                }
-            })).toEqual([26.2, 27.33]);
         });
     });
 


### PR DESCRIPTION
Before making a pull request
----------------------------

- [X] Make sure all tests run
- [X] Update the changelog appropriately

Title
-----------
Not rendering precipitation correctly on hydrograph

Description
-----------
Needed to determine the value range for IV (and for consistency groundwater levels) by using the selector which processes the data for display so that in the case of precipitation when are using the accumulated values

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the JIRA ticket
- [ ] Assign someone to review unless the change is trivial
