### PR TITLE
show method id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased](https://github.com/usgs/waterdataui/compare/waterdataui-0.46.0...master)
 ### Changed
 - Improved wording on feedback form to better steer feedback to correct destination.
+- Empty sampling method descriptions now show the Method ID instead of a blank space.
 
 ## [0.46.0](https://github.com/usgs/waterdataui/compare/waterdataui-0.45.0...waterdataui-0.46.0)
 ### Changed

--- a/assets/src/scripts/monitoring-location/components/hydrograph/method-picker.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/method-picker.js
@@ -66,9 +66,10 @@ export const drawMethodPicker = function(container, parameterCode, store) {
 
     pickerContainer.append('label')
         .attr('class', 'usa-label sampling-method-selection')
-        .attr('for', 'method-picker');
-    pickerContainer.text('Sampling Methods:')
+        .attr('for', 'method-picker')
+        .text('Sampling Methods:')
         .call(link(store, (container, methods) => {
+            container.select('#no-data-points-note').remove();
             if (methods !== null) {
                 const hasMethodsWithNoPointsInTimeRange = methods.filter(method => method.pointCount === 0).length !== 0;
                 if(hasMethodsWithNoPointsInTimeRange) {

--- a/assets/src/scripts/monitoring-location/components/hydrograph/method-picker.test.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/method-picker.test.js
@@ -141,5 +141,34 @@ describe('monitoring-location/components/hydrograph/method-picker', () => {
 
             expect(div.select('#no-data-points-note').size()).toBe(0);
         });
+
+        it('Expects that if there is not method description, the method id will be used', () => {
+            const parameterCode = '72019';
+            let store = configureStore({
+                ...TEST_STATE,
+                hydrographData: {
+                    primaryIVData: {
+                        ...TEST_STATE,
+                        values: {
+                            '90649': {
+                                ...TEST_PRIMARY_IV_DATA.values['90649']
+                            },
+                            '252055': {
+                                points: [
+                                    {value: 25.6, qualifiers: ['E'], dateTime: 1600618500000},
+                                ],
+                                method: {
+                                    methodDescription: '',
+                                    methodID: '252055'
+                                }
+                            }
+                        }
+                    }
+                }
+            });
+            div.call(drawMethodPicker, parameterCode, store);
+
+            expect(div.selectAll('[value="252055"]')['_groups'][0][0].innerHTML).toContain('252055');
+        });
     });
 });

--- a/assets/src/scripts/monitoring-location/components/hydrograph/method-picker.test.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/method-picker.test.js
@@ -141,34 +141,5 @@ describe('monitoring-location/components/hydrograph/method-picker', () => {
 
             expect(div.select('#no-data-points-note').size()).toBe(0);
         });
-
-        it('Expects that if there is not a method description, the method id will be used', () => {
-            const parameterCode = '72019';
-            let store = configureStore({
-                ...TEST_STATE,
-                hydrographData: {
-                    primaryIVData: {
-                        ...TEST_STATE,
-                        values: {
-                            '90649': {
-                                ...TEST_PRIMARY_IV_DATA.values['90649']
-                            },
-                            '252055': {
-                                points: [
-                                    {value: 25.6, qualifiers: ['E'], dateTime: 1600618500000},
-                                ],
-                                method: {
-                                    methodDescription: '',
-                                    methodID: '252055'
-                                }
-                            }
-                        }
-                    }
-                }
-            });
-            div.call(drawMethodPicker, parameterCode, store);
-
-            expect(div.selectAll('[value="252055"]')['_groups'][0][0].innerHTML).toContain('252055');
-        });
     });
 });

--- a/assets/src/scripts/monitoring-location/components/hydrograph/method-picker.test.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/method-picker.test.js
@@ -142,7 +142,7 @@ describe('monitoring-location/components/hydrograph/method-picker', () => {
             expect(div.select('#no-data-points-note').size()).toBe(0);
         });
 
-        it('Expects that if there is not method description, the method id will be used', () => {
+        it('Expects that if there is not a method description, the method id will be used', () => {
             const parameterCode = '72019';
             let store = configureStore({
                 ...TEST_STATE,

--- a/assets/src/scripts/monitoring-location/components/hydrograph/selectors/time-series-data.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/selectors/time-series-data.js
@@ -162,13 +162,13 @@ export const getSortedIVMethods = createSelector(
         if (!ivData || !Object.keys(ivData.values).length) {
             return null;
         }
-        const methodsForPrimarySelection = Object.values(ivData.values)
+        return Object.values(ivData.values)
             .map(methodValues => {
                 return {
                     pointCount: methodValues.points.length,
                     lastPoint: methodValues.points.length ? methodValues.points[methodValues.points.length - 1] : null,
                     methodID: methodValues.method.methodID,
-                    methodDescription: methodValues.method.methodDescription === null ? 'No description available for this method' : methodValues.method.methodDescription
+                    methodDescription: methodValues.method.methodDescription ? methodValues.method.methodDescription : methodValues.method.methodID
                 };
             })
             .sort((a, b) => {
@@ -178,6 +178,5 @@ export const getSortedIVMethods = createSelector(
                     return b.pointCount - a.pointCount;
                 }
             });
-        return methodsForPrimarySelection;
     }
 );

--- a/assets/src/scripts/monitoring-location/components/hydrograph/selectors/time-series-data.test.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/selectors/time-series-data.test.js
@@ -3,7 +3,7 @@ import config from 'ui/config';
 import {TEST_PRIMARY_IV_DATA, TEST_MEDIAN_DATA, TEST_GW_LEVELS} from '../mock-hydrograph-state';
 import {
     isVisible, hasVisibleIVData, hasVisibleGroundwaterLevels, hasVisibleMedianStatisticsData, hasAnyVisibleData,
-    getTitle, getDescription, getPrimaryParameterUnitCode, getPreferredIVMethodID
+    getTitle, getDescription, getPrimaryParameterUnitCode, getPreferredIVMethodID, getSortedIVMethods
 }
     from './time-series-data';
 
@@ -425,6 +425,59 @@ describe('monitoring-location/components/hydrograph/selectors/time-series-data m
                     }
                 }
             })).toEqual('69937');
+        });
+    });
+
+    describe('getSortedIVMethods', () => {
+        it('The first object in the array will have the most data points', () => {
+            expect(getSortedIVMethods({
+                hydrographData: {
+                    ...TEST_STATE.hydrographData,
+                    primaryIVData: {
+                        ...TEST_STATE.hydrographData.primaryIVData,
+                        values: {
+                            ...TEST_STATE.hydrographData.primaryIVData.values,
+
+                            '152088': {
+                                points: [
+                                    {value: 25.1},
+                                    {value: 26.1},
+                                    {value: 27.1}
+                                ],
+                                method: {
+                                    methodDescription: '',
+                                    methodID: '152088'
+                                }
+                            }
+                        }
+                    }
+                }
+            })[0]['pointCount']).toBe(3);
+        });
+        it('If there is not a sampling method description, the method id will be used', () => {
+            expect(getSortedIVMethods({
+                hydrographData: {
+                    ...TEST_STATE.hydrographData,
+                    primaryIVData: {
+                        ...TEST_STATE.hydrographData.primaryIVData,
+                        values: {
+                            ...TEST_STATE.hydrographData.primaryIVData.values,
+
+                            '152088': {
+                                points: [
+                                    {value: 25.1},
+                                    {value: 26.1},
+                                    {value: 27.1}
+                                ],
+                                method: {
+                                    methodDescription: '',
+                                    methodID: '152088'
+                                }
+                            }
+                        }
+                    }
+                }
+            })[0]['methodDescription']).toBe('152088');
         });
     });
 });

--- a/assets/src/styles/partials/_parameter-list.scss
+++ b/assets/src/styles/partials/_parameter-list.scss
@@ -50,6 +50,9 @@ $row-border-color: 'black';
       @include u-padding-left(0);
 
       .method-selection-row {
+        .usa-label {
+          margin-top: 0;
+        }
         #ts-method-select-container {
           @include u-padding-top(1);
           @include grid-col(7);


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [x] Update the changelog appropriately

WDFN-546 Methods with No Description Should Show Method ID
-----------
The sampling method names are sketchy at best and sometimes not even there. This defaults the methods descriptions that are not there to their method ID.

It also fixes a small bug where when the time span was changed, the method note was rendered under the method selection element rather than above. 


After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
