### PR TITLE
Wdfn 549 - Method picker appears briefly for parameters that only have a single method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/usgs/waterdataui/compare/waterdataui-0.47.0...master)
+### Fixed
+- The method picker no longer appears briefly when selecting a parameter code with a single method.
 
 ## [0.47.0](https://github.com/usgs/waterdataui/compare/waterdataui-0.46.0...waterdataui-0.47.0) - 2021-05-11
 ### Changed

--- a/assets/src/scripts/monitoring-location/components/hydrograph/method-picker.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/method-picker.js
@@ -4,88 +4,61 @@
 
 import {select} from 'd3-selection';
 
-import{link}  from 'ui/lib/d3-redux';
-
-import {getSelectedIVMethodID} from 'ml/selectors/hydrograph-state-selector';
-
 import {setSelectedIVMethodID} from 'ml/store/hydrograph-state';
 
 import {showDataIndicators} from './data-indicator';
-import {getPreferredIVMethodID, getSortedIVMethods} from './selectors/time-series-data';
 
-/**
- * Changes the list of methods when the parameter changes
- * @param {D3 selection} container- An HTML element to serve as the base for attaching other elements.
- * @param {Object} methods - The complete list of sampling methods available for the selected parameter.
- * @param {Redux store} store - A complex JavaScript object that maps the current state of the application.
- */
-const updateAvailableMethods = function(container, methods, store) {
-    container.selectAll('option').remove();
-    if (!methods || !methods.length) {
-        return;
-    }
-
-    let selectedMethodID = getSelectedIVMethodID(store.getState());
-    const availableMethodIDs = methods.map(data => data.methodID);
-    if (!selectedMethodID || selectedMethodID && !availableMethodIDs.includes(selectedMethodID)) {
-        selectedMethodID = getPreferredIVMethodID(store.getState());
-        store.dispatch(setSelectedIVMethodID(selectedMethodID));
-        showDataIndicators(false, store);
-    }
-
-    methods.forEach((method) => {
-        const hasNoPointsInTimeSpan = method.pointCount === 0;
-        container.append('option')
-            .text(`${method.methodDescription}`)
-            .attr('class', 'method-option sampling-method-selection')
-            .attr('selected', method.methodID === selectedMethodID ? true : null)
-            .attr('value', method.methodID)
-            .attr('disabled', hasNoPointsInTimeSpan ? true : null);
-        });
-};
 
 /**
  * Draw the method picker. It will be set initially to the preferred method id if not already
  * set to a specific, available method id. The picker will be hidden if only one method
  * is available for the IV data.
  * @param {D3 selection} container - An HTML element to serve as the base for attaching other elements.
- * @param {String} parameterCode - The five digit USGS that is unique for each parameter.
+ * @param {Object} parameter - Details about the parameter, including the code and possible methods.
  * @param {Redux store} store - A complex JavaScript object that maps the current state of the application.
  */
-export const drawMethodPicker = function(container, parameterCode, store) {
-    const gridRowSamplingMethodSelection = container.append('div')
+export const drawMethodPicker = function(container, sortedIVMethods, store) {
+    container.select('#primary-sampling-method-row').remove();
+
+    if (!sortedIVMethods || sortedIVMethods.methods.length < 2) {
+        return;
+    }
+
+    const hasMethodsWithNoPointsInTimeRange = sortedIVMethods.methods.filter(method => method.pointCount === 0).length !== 0;
+    // Find parameter expansion container
+    const rowContainer = container.select(`#expansion-container-row-${sortedIVMethods.parameterCode}`);
+    const gridRowSamplingMethodSelection = rowContainer.append('div')
         .attr('id', 'primary-sampling-method-row')
-        .attr('class', 'grid-container grid-row-inner sampling-method-selection');
+        .attr('class', 'grid-container grid-row-inner');
     const methodSelectionContainer = gridRowSamplingMethodSelection.append('div')
-        .attr('class', 'grid-row method-selection-row sampling-method-selection');
+        .attr('class', 'grid-row method-selection-row');
     const pickerContainer = methodSelectionContainer.append('div')
-        .attr('id', 'ts-method-select-container')
-        .call(link(store, (container, methods) => {
-            container.attr('hidden', methods && methods.length > 1 ? null : true);
-        }, getSortedIVMethods));
+        .attr('id', 'ts-method-select-container');
 
     pickerContainer.append('label')
-        .attr('class', 'usa-label sampling-method-selection')
+        .attr('class', 'usa-label')
         .attr('for', 'method-picker')
-        .text('Sampling Methods:')
-        .call(link(store, (container, methods) => {
-            container.select('#no-data-points-note').remove();
-            if (methods !== null) {
-                const hasMethodsWithNoPointsInTimeRange = methods.filter(method => method.pointCount === 0).length !== 0;
-                if(hasMethodsWithNoPointsInTimeRange) {
-                    container.append('span')
-                        .attr('id', 'no-data-points-note')
-                        .text(' note - some methods are disabled, because there are no data points for these methods in your selected time span');
-                }
-            }
-        }, getSortedIVMethods));
+        .text('Sampling Methods:');
 
-    pickerContainer.append('select')
-        .attr('class', 'usa-select sampling-method-selection')
-        .attr('id', 'method-picker')
-        .call(link(store, updateAvailableMethods, getSortedIVMethods, store))
-    .on('change', function() {
-            store.dispatch(setSelectedIVMethodID(select(this).property('value')));
-            showDataIndicators(false, store);
-        });
+    if(hasMethodsWithNoPointsInTimeRange) {
+        pickerContainer.append('span')
+            .attr('id', 'no-data-points-note')
+            .text(' note - some methods are disabled, because there are no data points for these methods in your selected time span');
+    }
+
+    const picker = pickerContainer.append('select')
+        .attr('class', 'usa-select ')
+        .attr('id', 'method-picker');
+    sortedIVMethods.methods.forEach((method, index) => {
+        picker.append('option')
+            .text(`${method.methodDescription}`)
+            .attr('class', 'method-option')
+            .attr('selected', index === 0 ? true : null)
+            .attr('value', method.methodID)
+            .attr('disabled', method.pointCount === 0 ? true : null)
+            .on('change', function(event) {
+                event.stopPropagation();
+                store.dispatch(setSelectedIVMethodID(select(this).property('value')));
+            });
+    });
 };

--- a/assets/src/scripts/monitoring-location/components/hydrograph/method-picker.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/method-picker.js
@@ -6,15 +6,15 @@ import {select} from 'd3-selection';
 
 import {setSelectedIVMethodID} from 'ml/store/hydrograph-state';
 
-import {showDataIndicators} from './data-indicator';
 
 
 /**
- * Draw the method picker. It will be set initially to the preferred method id if not already
- * set to a specific, available method id. The picker will be hidden if only one method
- * is available for the IV data.
+ * Draw the method picker. Remove the previous method picker and determine whether a new method
+ * picker is needed before rendering the picker within the expanion constainer for the selected
+ * parameterCode.
  * @param {D3 selection} container - An HTML element to serve as the base for attaching other elements.
- * @param {Object} parameter - Details about the parameter, including the code and possible methods.
+ * @param {Object} sortedIVMethods - An object containing the parameter code and the list of sorted methods to be
+ *      used for rendering.
  * @param {Redux store} store - A complex JavaScript object that maps the current state of the application.
  */
 export const drawMethodPicker = function(container, sortedIVMethods, store) {

--- a/assets/src/scripts/monitoring-location/components/hydrograph/method-picker.test.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/method-picker.test.js
@@ -4,7 +4,8 @@ import * as utils from 'ui/utils';
 
 import {configureStore} from 'ml/store';
 
-import * as dataIndicator from './data-indicator';
+import {getSortedIVMethods} from './selectors/time-series-data';
+
 import {drawMethodPicker} from './method-picker';
 import {TEST_PRIMARY_IV_DATA} from './mock-hydrograph-state';
 
@@ -15,68 +16,31 @@ describe('monitoring-location/components/hydrograph/method-picker', () => {
         const TEST_STATE = {
             hydrographData: {
                 primaryIVData: TEST_PRIMARY_IV_DATA
-            },
-            hydrographState: {
-                selectedIVMethodID: '252055'
             }
         };
         let div;
-        let showDataIndicatorSpy;
         beforeEach(() => {
             div = select('body').append('div');
-            showDataIndicatorSpy = jest.spyOn(dataIndicator, 'showDataIndicators');
+            div.append('div').attr('id', 'expansion-container-row-72019');
         });
 
         afterEach(() => {
             div.remove();
         });
 
-        it('Creates a picker and sets the currentMethodID to the hydrographState\'s selectedIVMethodID', () => {
-            const parameterCode = '72019';
+        it('Creates a picker and sets the currentMethodID to preferred method id', () => {
             let store = configureStore(TEST_STATE);
-            div.call(drawMethodPicker, parameterCode, store);
+            div.call(drawMethodPicker, getSortedIVMethods(store.getState()), store);
 
-            expect(div.select('#ts-method-select-container').attr('hidden')).toBeNull();
-            expect(div.select('select').property('value')).toEqual('252055');
-        });
-
-        it('Creates a picker and if selectedIVMethodID not set set to the preferred method id', () => {
-            const parameterCode = '72019';
-            let store = configureStore({
-                ...TEST_STATE,
-                hydrographState: {
-                    ...TEST_STATE.hydrographState,
-                    selectedIVMethodID: null
-                }
-            });
-            div.call(drawMethodPicker, parameterCode, store);
-
-            expect(div.select('#ts-method-select-container').attr('hidden')).toBeNull();
             expect(div.select('select').property('value')).toEqual('90649');
         });
 
-        it('selecting a different method updates the store and updates the no data available indicator', () => {
-            let store = configureStore(TEST_STATE);
-            const parameterCode = '72019';
-            div.call(drawMethodPicker, parameterCode, store);
-
-            const newOption = div.select('option[value="90649"]');
-            newOption.attr('selected', true);
-
-            div.select('select').dispatch('change');
-
-            expect(store.getState().hydrographState.selectedIVMethodID).toBe('90649');
-            expect(showDataIndicatorSpy.mock.calls).toHaveLength(1);
-            expect(showDataIndicatorSpy.mock.calls[0][0]).toBe(false);
-        });
-
-        it('Expects if the data has only one method then the picker will be hidden', () => {
-            const parameterCode = '72019';
+        it('Expects if the data has only one method then the picker will be not be drawn', () => {
             let store = configureStore({
                 ...TEST_STATE,
                 hydrographData: {
                     primaryIVData: {
-                        ...TEST_STATE,
+                        ...TEST_STATE.hydrographData.primaryIVData,
                         values: {
                             '90649': {
                                 ...TEST_PRIMARY_IV_DATA.values['90649']
@@ -85,39 +49,36 @@ describe('monitoring-location/components/hydrograph/method-picker', () => {
                     }
                 }
             });
-            div.call(drawMethodPicker, parameterCode, store);
+            div.call(drawMethodPicker, getSortedIVMethods(store.getState()), store);
 
-            expect(div.select('#ts-method-select-container').attr('hidden')).toBe('true');
+            expect(div.select('#primary-sampling-method-row').size()).toBe(0);
         });
 
         it('Expects the methods will be in order from most to least points', () => {
-            const parameterCode = '72019';
             let store = configureStore({
                 ...TEST_STATE
             });
-            div.call(drawMethodPicker, parameterCode, store);
+            div.call(drawMethodPicker, getSortedIVMethods(store.getState()), store);
             const allOptionElements = div.selectAll('option');
             expect(allOptionElements['_groups'][0][0].getAttribute('value')).toBe('90649');
             expect(allOptionElements['_groups'][0][1].getAttribute('value')).toBe('252055');
         });
 
         it('Expects that there will be a message if some of the methods have no points', () => {
-            const parameterCode = '72019';
             let store = configureStore({
                 ...TEST_STATE
             });
-            div.call(drawMethodPicker, parameterCode, store);
+            div.call(drawMethodPicker, getSortedIVMethods(store.getState()), store);
 
             expect(div.select('#no-data-points-note')['_groups'][0][0].innerHTML).toContain('some methods are disabled');
         });
 
         it('Expects that there will NOT be a message all of the methods have points', () => {
-            const parameterCode = '72019';
             let store = configureStore({
                 ...TEST_STATE,
                 hydrographData: {
                     primaryIVData: {
-                        ...TEST_STATE,
+                        ...TEST_STATE.hydrographData.primaryIVData,
                         values: {
                             '90649': {
                                 ...TEST_PRIMARY_IV_DATA.values['90649']
@@ -137,7 +98,7 @@ describe('monitoring-location/components/hydrograph/method-picker', () => {
                     }
                 }
             });
-            div.call(drawMethodPicker, parameterCode, store);
+            div.call(drawMethodPicker, getSortedIVMethods(store.getState()), store);
 
             expect(div.select('#no-data-points-note').size()).toBe(0);
         });

--- a/assets/src/scripts/monitoring-location/components/hydrograph/parameters.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/parameters.js
@@ -8,7 +8,7 @@ import {link} from 'ui/lib/d3-redux';
 
 import {getInputsForRetrieval, getSelectedParameterCode} from 'ml/selectors/hydrograph-state-selector';
 
-import {setSelectedParameterCode} from 'ml/store/hydrograph-state';
+import {setSelectedParameterCode, setSelectedIVMethodID} from 'ml/store/hydrograph-state';
 import {retrieveHydrographData} from 'ml/store/hydrograph-data';
 
 import {getAvailableParameters} from './selectors/parameter-data';
@@ -16,7 +16,6 @@ import {getSortedIVMethods} from './selectors/time-series-data';
 
 import {showDataIndicators} from './data-indicator';
 import {drawMethodPicker} from './method-picker';
-import {setSelectedIVMethodID} from "../../store/hydrograph-state";
 
 const ROW_TOGGLE_CLOSED_CLASS = 'fas fa-chevron-down expansion-toggle';
 const ROW_TOGGLE_OPENED_CLASS = 'fas fa-chevron-up expansion-toggle';
@@ -77,29 +76,17 @@ const drawRowExpansionControl = function(container, parameter, type) {
     }
 };
 
-/*
- * Helper function that checks the classes of the element on which the user clicked.
- * This allow any element related to the selection of the sampling methods to be excluded from other user initiated events.
- * @param eventTarget - The classes of the element the user clicked.
- * @returns {boolean} - True, if the click target has specific classes
- */
-const isMethodSelectionClick = function(eventTarget) {
-    if (eventTarget.getAttribute('class')) {
-        return !! eventTarget.getAttribute('class').includes('sampling-method-selection');
-    }
-};
-
-/*
-* Helper function that draws the main containing rows. Note the 'parameter selection' is a nested USWD grid.
-* The grid has one 'container row' for each parameter (this function creates the 'container rows' for each parameter).
-* As a side note - each container row will eventually contain three internal rows.
-* 1) The 'Top Period Of Record Row' (shows only on mobile)
-* 2) The 'Radio Button Row' (radio button and description show on mobile and desktop, toggle and period of record don't show mobile)
-* 3) The 'Expansion Container Row' only shows when row clicked or toggled on. May act as a container for additional rows.
-* @param {Object} container - The target element on which to append the row
-* @param {Object} store - The application Redux state
-* @param {String} siteno - A unique identifier for the monitoring location
-* @param {String} parameter - USGS five digit parameter code
+/**
+ * Helper function that draws the main containing rows. Note the 'parameter selection' is a nested USWD grid.
+ * The grid has one 'container row' for each parameter (this function creates the 'container rows' for each parameter).
+ * As a side note - each container row will eventually contain three internal rows.
+ * 1) The 'Top Period Of Record Row' (shows only on mobile)
+ * 2) The 'Radio Button Row' (radio button and description show on mobile and desktop, toggle and period of record don't show mobile)
+ * 3) The 'Expansion Container Row' only shows when row clicked or toggled on. May act as a container for additional rows.
+ * @param {Object} container - The target element on which to append the row
+ * @param {Object} store - The application Redux state
+ * @param {String} siteno - A unique identifier for the monitoring location
+ * @param {String} parameterCode - USGS five digit parameter code
 */
 const drawContainingRow = function(container, store, siteno, parameterCode) {
     return container.append('div')
@@ -150,11 +137,11 @@ const drawContainingRow = function(container, store, siteno, parameterCode) {
         });
 };
 
-/*
-* Helper function that creates the top row of each parameter selection. This row is hidden except on narrow screens
-* and contains the period of record that appears above the parameter description.
-* @param {Object} container - The target element to append the row
-* @param {D3 selection} parameter - Contains details about the current parameter code
+/**
+ * Helper function that creates the top row of each parameter selection. This row is hidden except on narrow screens
+ * and contains the period of record that appears above the parameter description.
+ * @param {Object} container - The target element to append the row
+ * @param {D3 selection} parameter - Contains details about the current parameter code
 */
 const drawTopPeriodOfRecordRow = function(container, parameter) {
     const gridRowInnerTopPeriodOfRecord = container.append('div')
@@ -168,12 +155,12 @@ const drawTopPeriodOfRecordRow = function(container, parameter) {
     drawRowExpansionControl(topPeriodOfRecordRowExpansionControlDiv, parameter, 'mobile');
 };
 
-/*
-* Helper function that draws the row containing the radio button and parameter description.
-* @param {D3 selection} elem - The target element to append the row
-* @param {Object} parameter - Contains details about the current parameter code
-* @param {Object} store - The application Redux state
-*/
+/**
+ * Helper function that draws the row containing the radio button and parameter description.
+ * @param {D3 selection} container - The target element to append the row
+ * @param {Object} parameter - Contains details about the current parameter code
+ * @param {Object} store - The application Redux state
+ */
 const drawRadioButtonRow = function(container, parameter, store) {
     const gridRowInnerWithRadioButton = container.append('div')
         .attr('class', 'grid-row grid-row-inner');
@@ -209,12 +196,12 @@ const drawRadioButtonRow = function(container, parameter, store) {
     drawRowExpansionControl(radioRowExpansionControlDiv, parameter, 'desktop');
 };
 
-/*
-* Helper function that draws a row containing the controls for the WaterAlert subscription.
-* @param {Object} container- The target element to append the row
-* @param {String} siteno - A unique identifier for the monitoring location
-* @param {D3 selection} parameter - Contains details about the current parameter code
-*/
+/**
+ * Helper function that draws a row containing the controls for the WaterAlert subscription.
+ * @param {Object} container- The target element to append the row
+ * @param {String} siteno - A unique identifier for the monitoring location
+ * @param {D3 selection} parameter - Contains details about the current parameter code
+ */
 const drawWaterAlertRow = function(container, siteno, parameter) {
     // WaterAlert doesn't accept the calculated parameter for Fahrenheit (such as 00010F), so we need to adjust the
     // parameter code back to the Celsius version (such as 00010).
@@ -279,7 +266,7 @@ export const drawSelectionList = function(container, store, siteno) {
         }
     });
 
-    // draw method picker. This can only appear in the selected parameter row because
+    // Draw method picker. This can only appear in the selected parameter row because
     // we only know the methods for the currently selected data. Let the code figure out
     // whether to draw it and where to put it whenever the sorted IV Methods change.
     selectionList.call(link(store, drawMethodPicker, getSortedIVMethods, store));

--- a/assets/src/scripts/monitoring-location/components/hydrograph/selectors/time-series-data.test.js
+++ b/assets/src/scripts/monitoring-location/components/hydrograph/selectors/time-series-data.test.js
@@ -430,14 +430,13 @@ describe('monitoring-location/components/hydrograph/selectors/time-series-data m
 
     describe('getSortedIVMethods', () => {
         it('The first object in the array will have the most data points', () => {
-            expect(getSortedIVMethods({
+            const result = getSortedIVMethods({
                 hydrographData: {
                     ...TEST_STATE.hydrographData,
                     primaryIVData: {
                         ...TEST_STATE.hydrographData.primaryIVData,
                         values: {
                             ...TEST_STATE.hydrographData.primaryIVData.values,
-
                             '152088': {
                                 points: [
                                     {value: 25.1},
@@ -452,17 +451,21 @@ describe('monitoring-location/components/hydrograph/selectors/time-series-data m
                         }
                     }
                 }
-            })[0]['pointCount']).toBe(3);
+            });
+            expect(result.parameterCode).toBe('00030');
+            expect(result.methods.length).toBe(3);
+            expect(result.methods[0].methodID).toBe('152088');
+            expect(result.methods[1].methodID).toBe('252055');
+            expect(result.methods[2].methodID).toBe('69937');
         });
         it('If there is not a sampling method description, the method id will be used', () => {
-            expect(getSortedIVMethods({
+            const result = getSortedIVMethods({
                 hydrographData: {
                     ...TEST_STATE.hydrographData,
                     primaryIVData: {
                         ...TEST_STATE.hydrographData.primaryIVData,
                         values: {
                             ...TEST_STATE.hydrographData.primaryIVData.values,
-
                             '152088': {
                                 points: [
                                     {value: 25.1},
@@ -477,7 +480,10 @@ describe('monitoring-location/components/hydrograph/selectors/time-series-data m
                         }
                     }
                 }
-            })[0]['methodDescription']).toBe('152088');
+            });
+            expect(result.methods[0]['methodDescription']).toBe('152088');
+            expect(result.methods[1]['methodDescription']).toBe('From multiparameter sonde');
+            expect(result.methods[2]['methodDescription']).toBe('From multiparameter sonde, [Discontinued]');
         });
     });
 });


### PR DESCRIPTION
Before making a pull request
----------------------------

- [X] Make sure all tests run
- [X] Update the changelog appropriately

Title
-----------
Wdfn 549 - Method picker appears briefly for parameters that only have a single method

Description
-----------
The drawMethodPicker function is now designed to be called whenever new parameter is selected with a new set of methods. The old one is removed and a new one rendered within the expansion row for the selected parameter code if it has more than one method. The click handler only updates the hydrographState, nothing else needs to be rerendered.

I also simplified the handling of the expansion click by explictly stopping progagation of click events wherever that is appropriate rather.

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the JIRA ticket
- [ ] Assign someone to review unless the change is trivial
